### PR TITLE
Sync README and AGENTS.md with current repo status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 ## 项目状态
 
 - **类型**：个人项目（Skymly 工作区）
-- **远端**：见根 [`AGENTS.md`](../AGENTS.md)「已知远端」；本地 `main`，`origin` 已配置，**尚未推送**；文件夹名 `Observables` = 仓库名
-- **阶段**：**Events.R3**、**RestAPI** 域运行时与双路生成器已实现；`Events.Reactive` 生成器与 **RoutedEvents** 实现待完成；各域 **`.Package` / NuGet** 尚未建立
+- **远端**：https://github.com/Skymly/Observables（私有）；`origin/main` 已与本地 `main` 同步；文件夹名 `Observables` = 仓库名
+- **阶段**：**Events.R3**、**RestAPI** 域运行时与双路生成器已实现（PR #11–#20 已合并）；`Events.Reactive` 生成器与 **RoutedEvents** 实现待完成；各域 **`.Package` / NuGet** 尚未发布
 - **结构约定**：下文「仓库结构」与命名约定为权威
 
 ## 目标

--- a/README.md
+++ b/README.md
@@ -1,34 +1,37 @@
 # Observables
 
-面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件。
+面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件。远端仓库：[github.com/Skymly/Observables](https://github.com/Skymly/Observables)（私有）；`main` 已与 `origin/main` 同步。
 
 ## 运行时与包名
 
-| 包名 | 运行时 |
-|------|--------|
-| `Observables.<Feature>` | [System.Reactive](https://github.com/dotnet/reactive)（`IObservable<T>` 等） |
+| NuGet 包 ID | 运行时 |
+|-------------|--------|
+| `Observables.<Feature>.Reactive` | [System.Reactive](https://github.com/dotnet/reactive)（`IObservable<T>` 等） |
 | `Observables.<Feature>.R3` | [R3](https://github.com/Cysharp/R3) |
 
-每个功能域成对发布，互不混用依赖。
+每个功能域成对发布，互不混用依赖。开发与测试阶段用解决方案内项目（如 `Observables.Events.R3.SourceGenerators`）通过 `ProjectReference` + `OutputItemType="Analyzer"` 引用。
 
-## 包规划
+## 全库与域结构
 
-| 顺序 | System.Reactive | R3 |
-|------|-----------------|-----|
-| — | **Observables.Core**（全库通用运行时） | （同上） |
-| — | **Observables.\<Feature\>.Core**（单域运行时，按需） | （同上） |
-| — | **Observables.SourceGenerators.Shared**（生成器共享 Roslyn 基础设施） | （同上） |
-| 1 | **Observables.Events.Reactive.SourceGenerators** | **Observables.Events.R3.SourceGenerators** |
-| 2 | **Observables.RoutedEvents** | **Observables.RoutedEvents.R3** |
-| 3 | **Observables.RestAPI** | **Observables.RestAPI.R3.SourceGenerators** |（**已实现**：见 `Observables.RestAPI` + 扩展包）
-| 4 | **Observables.SignalR** | **Observables.SignalR.R3** |
-| 5 | **Observables.WebSocket** | **Observables.WebSocket.R3** |
-| 6 | **Observables.Mqtt** | **Observables.Mqtt.R3** |
-| 7 | **Observables.Grpc** | **Observables.Grpc.R3** |
+| 层级 | 说明 |
+|------|------|
+| **`Observables.Core`** | 全库通用运行时（多域复用的 Attribute、枚举、接口等） |
+| **`Observables.SourceGenerators.Shared`** | 全库通用生成器基础设施（诊断、符号扩展等） |
+| **`Observables.<Feature>`** | 域运行时（按需；纯生成域如 Events 可不建） |
+| **`Observables.<Feature>.Reactive`** | System.Reactive 桥接运行时（按需） |
+| **`Observables.<Feature>.R3.SourceGenerators`** / **`.Reactive.SourceGenerators`** | 双路源生成器 |
+| **`Observables.<Feature>.Package`** | 发布时打包，产出上述两个 NuGet 包（尚未发布） |
 
-> 个人项目；远端 GitHub 仓库尚未创建。**Events.R3** 与 **RestAPI** 域已落地；其余域仍为生成器骨架。
+## 域实现状态
 
-## RestAPI（自 Refit.R3）
+| 顺序 | 域 | R3 | System.Reactive |
+|------|-----|-----|-----------------|
+| 1 | **Events**（经典 .NET 事件） | `Events.R3.SourceGenerators`（已实现） | `Events.Reactive.SourceGenerators`（进行中） |
+| 2 | **RoutedEvents**（路由事件） | `RoutedEvents.R3`（骨架） | `Observables.RoutedEvents`（骨架） |
+| 3 | **RestAPI**（自 Refit.R3 迁入） | `RestAPI` + `RestAPI.R3.SourceGenerators` | `RestAPI.Reactive` + `RestAPI.Reactive.SourceGenerators` |
+| 4+ | SignalR、WebSocket、Mqtt、Grpc | 各域 `*.R3` 骨架 | 各域运行时骨架 |
+
+## RestAPI
 
 声明式类型安全 HTTP 客户端：`Observables.RestAPI`（运行时）+ `Observables.RestAPI.R3.SourceGenerators` 或 `Observables.RestAPI.Reactive.SourceGenerators` + 可选 `Observables.RestAPI.Reactive` / `HttpClientFactory`。
 
@@ -39,14 +42,15 @@
 
 ## 与 MVVMAIO / Refit.R3 的关系
 
-- **MVVMAIO**：事件生成计划存档后迁入 Observables（**Events.R3 已完成**）。
+- **MVVMAIO**：事件生成计划存档后迁入 Observables（**Events.R3** 已完成；对照 `MvvmAIO.R3.SourceGenerators`）。
 - **Refit.R3**（`C:\Code\Refit.R3`）：**已迁入 RestAPI 域**，原仓库只读对照。
 
 ## 构建
 
 ```powershell
 cd Observables
-dotnet build
+dotnet build Observables.slnx
+dotnet test Observables.slnx
 ```
 
 代理与贡献者请参阅 [AGENTS.md](./AGENTS.md)。


### PR DESCRIPTION
## Summary
- Update README: remote exists, fix package naming (Observables.Core / per-feature), align Events and RestAPI status with AGENTS.md
- Update AGENTS.md: origin/main synced, PRs #11-#20 merged

Closes #21

## Test plan
- [x] Documentation only; no build changes