### PR TITLE
Add Events and RestAPI Package project skeletons

### DIFF
--- a/Observables.Events.Package/Observables.Events.Package.csproj
+++ b/Observables.Events.Package/Observables.Events.Package.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Description>Packaging placeholder for Observables.Events.R3 and Observables.Events.Reactive NuGet packages (not publishing yet).</Description>
+  </PropertyGroup>
+
+  <!--
+    Future: dual PackageId Observables.Events.R3 / Observables.Events.Reactive
+    with analyzer DLLs + buildTransitive props. See AGENTS.md and MvvmAIO.Markup.Pack.
+  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Events.R3.SourceGenerators\Observables.Events.R3.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Observables.Events.Reactive.SourceGenerators\Observables.Events.Reactive.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.RestAPI.Package/Observables.RestAPI.Package.csproj
+++ b/Observables.RestAPI.Package/Observables.RestAPI.Package.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <Description>Packaging placeholder for Observables.RestAPI.R3 and Observables.RestAPI.Reactive NuGet packages (not publishing yet).</Description>
+  </PropertyGroup>
+
+  <!--
+    Future: dual PackageId Observables.RestAPI.R3 / Observables.RestAPI.Reactive
+    bundling runtime, optional Reactive bridge, and matching analyzers.
+  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
+    <ProjectReference Include="..\Observables.RestAPI.Reactive\Observables.RestAPI.Reactive.csproj" />
+    <ProjectReference Include="..\Observables.RestAPI.R3.SourceGenerators\Observables.RestAPI.R3.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Observables.RestAPI.Reactive.SourceGenerators\Observables.RestAPI.Reactive.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -15,6 +15,7 @@
   </Folder>
 
   <Folder Name="/Events/">
+    <Project Path="Observables.Events.Package/Observables.Events.Package.csproj" />
     <Project Path="Observables.Events.Reactive.SourceGenerators/Observables.Events.Reactive.SourceGenerators.csproj" />
     <Project Path="Observables.Events.Reactive.SourceGenerators.Tests/Observables.Events.Reactive.SourceGenerators.Tests.csproj" />
     <Project Path="Observables.Events.R3.SourceGenerators/Observables.Events.R3.SourceGenerators.csproj" />
@@ -28,6 +29,7 @@
 
   <Folder Name="/RestAPI/">
     <Project Path="Observables.RestAPI.SourceGenerators.Shared/Observables.RestAPI.SourceGenerators.Shared.shproj" Id="a8f3c2e1-9b4d-4f6a-8c7e-2d1b0e9f4a3c" />
+    <Project Path="Observables.RestAPI.Package/Observables.RestAPI.Package.csproj" />
     <Project Path="Observables.RestAPI/Observables.RestAPI.csproj" />
     <Project Path="Observables.RestAPI.Reactive/Observables.RestAPI.Reactive.csproj" />
     <Project Path="Observables.RestAPI.HttpClientFactory/Observables.RestAPI.HttpClientFactory.csproj" />


### PR DESCRIPTION
## Summary
- Add `Observables.Events.Package` and `Observables.RestAPI.Package` skeleton csproj (`IsPackable=false`)
- Register in `Observables.slnx`

Closes #27

## Test plan
- [x] `dotnet build Observables.slnx`
