### PR TITLE
Add package README and NuGet consumer smoke verification

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,6 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
+    "NuGetConsumerFeed": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Local",
+        "Published"
+      ]
+    },
     "Host": {
       "type": "string",
       "enum": [
@@ -28,6 +36,8 @@
         "CiPack",
         "Clean",
         "Compile",
+        "NuGetConsumerSmoke",
+        "NuGetConsumerSmokePublished",
         "Pack",
         "PackVerify",
         "Publish",
@@ -109,6 +119,10 @@
         "Configuration": {
           "type": "string",
           "description": "Build configuration (Debug/Release)"
+        },
+        "ConsumerFeed": {
+          "description": "NuGet consumer smoke feed: Local (artifacts/package) or Published (nuget.org)",
+          "$ref": "#/definitions/NuGetConsumerFeed"
         },
         "GitHubToken": {
           "type": "string",

--- a/Observables.Events/Observables.Events.Package/Observables.Events.R3.csproj
+++ b/Observables.Events/Observables.Events.Package/Observables.Events.R3.csproj
@@ -1,27 +1,29 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\eng\Observables.Package.props" />
-  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>true</IsPackable>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
-    <PackageId>Observables.Events.R3</PackageId>
-    <Description>Roslyn source generators for classic .NET events to R3 Observable.</Description>
-    <PackageTags>observables;events;r3;source-generator;roslyn</PackageTags>
-    <ObservablesPackGeneratorProject>..\Observables.Events.R3.SourceGenerators\Observables.Events.R3.SourceGenerators.csproj</ObservablesPackGeneratorProject>
-    <ObservablesPackGeneratorAssemblyName>Observables.Events.R3.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
-    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Events.R3.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
-    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Events.R3.props</ObservablesPackPackagePropsFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="R3" Version="1.3.0" />
-    <None Include="..\Observables.Events\targets\observables.events.props" Pack="true" PackagePath="buildTransitive\observables.events.props" Visible="false" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <PackageId>Observables.Events.R3</PackageId>
+    <Description>Roslyn source generators for classic .NET events to R3 Observable.</Description>
+    <PackageTags>observables;events;r3;source-generator;roslyn</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.Events.R3.SourceGenerators\Observables.Events.R3.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.Events.R3.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Events.R3.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Events.R3.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="R3" Version="1.3.0" />
+    <None Include="README.Events.R3.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+    <None Include="..\Observables.Events\targets\observables.events.props" Pack="true" PackagePath="buildTransitive\observables.events.props" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Events/Observables.Events.Package/Observables.Events.Reactive.csproj
+++ b/Observables.Events/Observables.Events.Package/Observables.Events.Reactive.csproj
@@ -1,27 +1,29 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\eng\Observables.Package.props" />
-  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>true</IsPackable>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
-    <PackageId>Observables.Events.Reactive</PackageId>
-    <Description>Roslyn source generators for classic .NET events to System.Reactive IObservable.</Description>
-    <PackageTags>observables;events;system.reactive;source-generator;roslyn</PackageTags>
-    <ObservablesPackGeneratorProject>..\Observables.Events.Reactive.SourceGenerators\Observables.Events.Reactive.SourceGenerators.csproj</ObservablesPackGeneratorProject>
-    <ObservablesPackGeneratorAssemblyName>Observables.Events.Reactive.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
-    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Events.Reactive.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
-    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Events.Reactive.props</ObservablesPackPackagePropsFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
-    <None Include="..\Observables.Events\targets\observables.events.props" Pack="true" PackagePath="buildTransitive\observables.events.props" Visible="false" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <PackageId>Observables.Events.Reactive</PackageId>
+    <Description>Roslyn source generators for classic .NET events to System.Reactive IObservable.</Description>
+    <PackageTags>observables;events;system.reactive;source-generator;roslyn</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.Events.Reactive.SourceGenerators\Observables.Events.Reactive.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.Events.Reactive.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Events.Reactive.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Events.Reactive.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <None Include="README.Events.Reactive.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+    <None Include="..\Observables.Events\targets\observables.events.props" Pack="true" PackagePath="buildTransitive\observables.events.props" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Events/Observables.Events.Package/README.Events.R3.pack.md
+++ b/Observables.Events/Observables.Events.Package/README.Events.R3.pack.md
@@ -1,0 +1,33 @@
+# Observables.Events.R3
+
+Roslyn source generators that turn classic .NET events into [R3](https://github.com/Cysharp/R3) `Observable<T>` streams.
+
+## Install
+
+```xml
+<PackageReference Include="Observables.Events.R3" Version="0.1.0-preview1" />
+<PackageReference Include="R3" Version="1.3.0" />
+```
+
+## Usage
+
+```csharp
+using Observables.Events.R3;
+
+public class ClickSource
+{
+    public event Action? Click;
+}
+
+var stream = new ClickSource().Events().Click;
+```
+
+Optional Avalonia/WPF routed events: set `<ObservableRoutedEvents>true</ObservableRoutedEvents>` in your project (see repository docs).
+
+## Diagnostics
+
+`OBS2001`–`OBS2004` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/Observables.Events/Observables.Events.Package/README.Events.Reactive.pack.md
+++ b/Observables.Events/Observables.Events.Package/README.Events.Reactive.pack.md
@@ -1,0 +1,33 @@
+# Observables.Events.Reactive
+
+Roslyn source generators that turn classic .NET events into `System.Reactive` `IObservable<T>` streams.
+
+## Install
+
+```xml
+<PackageReference Include="Observables.Events.Reactive" Version="0.1.0-preview1" />
+<PackageReference Include="System.Reactive" Version="6.0.1" />
+```
+
+## Usage
+
+```csharp
+using Observables.Events.Reactive;
+
+public class ClickSource
+{
+    public event Action? Click;
+}
+
+var stream = new ClickSource().Events().Click;
+```
+
+Optional routed events: `<ObservableRoutedEvents>true</ObservableRoutedEvents>`.
+
+## Diagnostics
+
+`OBS2001`–`OBS2004` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/Observables.RestAPI/Observables.RestAPI.Package/Observables.RestAPI.R3.csproj
+++ b/Observables.RestAPI/Observables.RestAPI.Package/Observables.RestAPI.R3.csproj
@@ -1,28 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\eng\Observables.Package.props" />
-  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
-  <Import Project="..\..\eng\PackReferencedProjects.targets" />
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <DevelopmentDependency>false</DevelopmentDependency>
-    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
-    <PackageId>Observables.RestAPI.R3</PackageId>
-    <Description>Declarative type-safe HTTP client for R3 Observable.</Description>
-    <PackageTags>observables;restapi;r3;http;source-generator</PackageTags>
-    <ObservablesPackGeneratorProject>..\Observables.RestAPI.R3.SourceGenerators\Observables.RestAPI.R3.SourceGenerators.csproj</ObservablesPackGeneratorProject>
-    <ObservablesPackGeneratorAssemblyName>Observables.RestAPI.R3.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
-    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.RestAPI.R3.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
-    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.RestAPI.R3.props</ObservablesPackPackagePropsFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
-    <PackageReference Include="R3" Version="1.3.0" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+  <Import Project="..\..\eng\PackReferencedProjects.targets" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <PackageId>Observables.RestAPI.R3</PackageId>
+    <Description>Declarative type-safe HTTP client for R3 Observable.</Description>
+    <PackageTags>observables;restapi;r3;http;source-generator</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.RestAPI.R3.SourceGenerators\Observables.RestAPI.R3.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.RestAPI.R3.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.RestAPI.R3.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.RestAPI.R3.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
+    <PackageReference Include="R3" Version="1.3.0" />
+    <None Include="README.RestAPI.R3.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.RestAPI/Observables.RestAPI.Package/Observables.RestAPI.Reactive.Pack.csproj
+++ b/Observables.RestAPI/Observables.RestAPI.Package/Observables.RestAPI.Reactive.Pack.csproj
@@ -1,29 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\eng\Observables.Package.props" />
-  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
-  <Import Project="..\..\eng\PackReferencedProjects.targets" />
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <DevelopmentDependency>false</DevelopmentDependency>
-    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
-    <PackageId>Observables.RestAPI.Reactive</PackageId>
-    <Description>Declarative type-safe HTTP client for System.Reactive IObservable.</Description>
-    <PackageTags>observables;restapi;system.reactive;http;source-generator</PackageTags>
-    <ObservablesPackGeneratorProject>..\Observables.RestAPI.Reactive.SourceGenerators\Observables.RestAPI.Reactive.SourceGenerators.csproj</ObservablesPackGeneratorProject>
-    <ObservablesPackGeneratorAssemblyName>Observables.RestAPI.Reactive.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
-    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.RestAPI.Reactive.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
-    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.RestAPI.Reactive.props</ObservablesPackPackagePropsFile>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
-    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI.Reactive\Observables.RestAPI.Reactive.csproj" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+  <Import Project="..\..\eng\PackReferencedProjects.targets" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <PackageId>Observables.RestAPI.Reactive</PackageId>
+    <Description>Declarative type-safe HTTP client for System.Reactive IObservable.</Description>
+    <PackageTags>observables;restapi;system.reactive;http;source-generator</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.RestAPI.Reactive.SourceGenerators\Observables.RestAPI.Reactive.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.RestAPI.Reactive.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.RestAPI.Reactive.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.RestAPI.Reactive.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
+    <ObservablesPackLibProjectReference Include="..\Observables.RestAPI.Reactive\Observables.RestAPI.Reactive.csproj" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <None Include="README.RestAPI.Reactive.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.RestAPI/Observables.RestAPI.Package/README.RestAPI.R3.pack.md
+++ b/Observables.RestAPI/Observables.RestAPI.Package/README.RestAPI.R3.pack.md
@@ -1,0 +1,34 @@
+# Observables.RestAPI.R3
+
+Declarative HTTP client interfaces for [R3](https://github.com/Cysharp/R3) `Observable<T>` (Refit-style attributes, Roslyn-generated implementations).
+
+## Install
+
+```xml
+<PackageReference Include="Observables.RestAPI.R3" Version="0.1.0-preview1" />
+<PackageReference Include="R3" Version="1.3.0" />
+```
+
+## Usage
+
+```csharp
+using Observables.RestAPI;
+using R3;
+
+public interface IUserApi
+{
+    [Get("/users/{id}")]
+    Observable<User> GetUser(int id);
+}
+
+var api = RestService.For<IUserApi>(httpClient);
+User user = await api.GetUser(42).FirstAsync();
+```
+
+## Diagnostics
+
+`OBS3001`–`OBS3005` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/Observables.RestAPI/Observables.RestAPI.Package/README.RestAPI.Reactive.pack.md
+++ b/Observables.RestAPI/Observables.RestAPI.Package/README.RestAPI.Reactive.pack.md
@@ -1,0 +1,34 @@
+# Observables.RestAPI.Reactive
+
+Declarative HTTP client interfaces for `System.Reactive` `IObservable<T>`.
+
+## Install
+
+```xml
+<PackageReference Include="Observables.RestAPI.Reactive" Version="0.1.0-preview1" />
+<PackageReference Include="System.Reactive" Version="6.0.1" />
+```
+
+## Usage
+
+```csharp
+using Observables.RestAPI;
+using System.Reactive.Linq;
+
+public interface IUserApi
+{
+    [Get("/users/{id}")]
+    IObservable<User> GetUser(int id);
+}
+
+var api = RestService.For<IUserApi>(httpClient);
+User user = await api.GetUser(42).FirstAsync().ToTask();
+```
+
+## Diagnostics
+
+`OBS3001`–`OBS3005` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -8,7 +8,6 @@ using Nuke.Common;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
-
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 [UnsetVisualStudioEnvironmentVariables]
@@ -19,6 +18,9 @@ sealed class Build : NukeBuild
 
     [Parameter("Package version override")]
     readonly string? Version = Environment.GetEnvironmentVariable("VERSION");
+
+    [Parameter("NuGet consumer smoke feed: Local (artifacts/package) or Published (nuget.org)")]
+    readonly NuGetConsumerFeed ConsumerFeed = NuGetConsumerFeed.Local;
 
     [Parameter("NuGet API key (required for nuget.org Publish)")]
     readonly string? NuGetApiKey =
@@ -32,6 +34,16 @@ sealed class Build : NukeBuild
     AbsolutePath SolutionFile => Root / "Observables.slnx";
     AbsolutePath TestResultsDirectory => Root / "TestResults";
     AbsolutePath PackageOutputDirectory => Root / "artifacts" / "package";
+    AbsolutePath NuGetSmokeDirectory => Root / "eng" / "nuget-smoke";
+    AbsolutePath NuGetSmokeLocalConfig => NuGetSmokeDirectory / "nuget.config.local";
+
+    static readonly string[] NuGetConsumerProjectRelativePaths =
+    [
+        "eng/nuget-smoke/Events.R3.Consumer/Events.R3.Consumer.csproj",
+        "eng/nuget-smoke/Events.Reactive.Consumer/Events.Reactive.Consumer.csproj",
+        "eng/nuget-smoke/RestAPI.R3.Consumer/RestAPI.R3.Consumer.csproj",
+        "eng/nuget-smoke/RestAPI.Reactive.Consumer/RestAPI.Reactive.Consumer.csproj",
+    ];
 
     /// <summary>
     /// All test projects (slnx does not discover every test project via <c>dotnet test</c>).
@@ -177,6 +189,41 @@ sealed class Build : NukeBuild
                         && e.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
                     Assert.True(hasLib, $"{packageId}: missing runtime assemblies under lib/");
                 }
+
+                Assert.True(
+                    entries.Contains("README.md"),
+                    $"{packageId}: missing package README.md at package root");
+            }
+        });
+
+    Target NuGetConsumerSmoke => _ => _
+        .DependsOn(ConsumerFeed == NuGetConsumerFeed.Local ? Pack : null)
+        .Executes(() =>
+        {
+            string packageVersion = string.IsNullOrWhiteSpace(Version) ? "0.1.0-preview1" : Version;
+            string? previousNuGetConfig = Environment.GetEnvironmentVariable("NUGET_CONFIG");
+
+            if (ConsumerFeed == NuGetConsumerFeed.Local)
+            {
+                Environment.SetEnvironmentVariable("NUGET_CONFIG", NuGetSmokeLocalConfig);
+            }
+
+            try
+            {
+                foreach (string relativePath in NuGetConsumerProjectRelativePaths)
+                {
+                    AbsolutePath projectFile = Root / relativePath;
+                    Assert.FileExists(projectFile, $"Consumer project not found: {projectFile}");
+
+                    DotNetBuild(s => s
+                        .SetProjectFile(projectFile)
+                        .SetConfiguration(Configuration)
+                        .SetProperty("ObservablesConsumerPackageVersion", packageVersion));
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("NUGET_CONFIG", previousNuGetConfig);
             }
         });
 
@@ -210,5 +257,17 @@ sealed class Build : NukeBuild
         .DependsOn(UnitTest);
 
     Target CiPack => _ => _
-        .DependsOn(PackVerify);
+        .DependsOn(PackVerify)
+        .DependsOn(NuGetConsumerSmoke)
+        .OnlyWhenStatic(() => ConsumerFeed == NuGetConsumerFeed.Local);
+
+    Target NuGetConsumerSmokePublished => _ => _
+        .DependsOn(NuGetConsumerSmoke)
+        .OnlyWhenStatic(() => ConsumerFeed == NuGetConsumerFeed.Published);
+}
+
+enum NuGetConsumerFeed
+{
+    Local,
+    Published,
 }

--- a/eng/nuget-smoke/Directory.Build.props
+++ b/eng/nuget-smoke/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ObservablesConsumerPackageVersion Condition="'$(ObservablesConsumerPackageVersion)' == ''">0.1.0-preview1</ObservablesConsumerPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/nuget-smoke/Events.R3.Consumer/Events.R3.Consumer.csproj
+++ b/eng/nuget-smoke/Events.R3.Consumer/Events.R3.Consumer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Observables.NuGetSmoke.Events.R3</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Observables.Events.R3" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+</Project>

--- a/eng/nuget-smoke/Events.R3.Consumer/Program.cs
+++ b/eng/nuget-smoke/Events.R3.Consumer/Program.cs
@@ -1,0 +1,12 @@
+using Observables.Events.R3;
+using R3;
+
+ClickSource source = new();
+using IDisposable sub = source.Events().Click.Subscribe(_ => { });
+
+Console.WriteLine("Observables.Events.R3 consumer smoke OK");
+
+public sealed class ClickSource
+{
+    public event Action? Click;
+}

--- a/eng/nuget-smoke/Events.Reactive.Consumer/Events.Reactive.Consumer.csproj
+++ b/eng/nuget-smoke/Events.Reactive.Consumer/Events.Reactive.Consumer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Observables.NuGetSmoke.Events.Reactive</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Observables.Events.Reactive" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+  </ItemGroup>
+</Project>

--- a/eng/nuget-smoke/Events.Reactive.Consumer/Program.cs
+++ b/eng/nuget-smoke/Events.Reactive.Consumer/Program.cs
@@ -1,0 +1,11 @@
+using Observables.Events.Reactive;
+
+ClickSource source = new();
+using IDisposable sub = source.Events().Click.Subscribe();
+
+Console.WriteLine("Observables.Events.Reactive consumer smoke OK");
+
+public sealed class ClickSource
+{
+    public event Action? Click;
+}

--- a/eng/nuget-smoke/README.md
+++ b/eng/nuget-smoke/README.md
@@ -1,0 +1,19 @@
+# NuGet consumer smoke projects
+
+Minimal console apps that reference **only** published or locally packed Observables packages (no sibling project references).
+
+## Local feed (after pack)
+
+```powershell
+dotnet run --project build/_build.csproj -- --target NuGetConsumerSmoke --configuration Release
+```
+
+Uses `nuget.config.local` pointing at `artifacts/package/`.
+
+## Published feed (nuget.org)
+
+```powershell
+dotnet run --project build/_build.csproj -- --target NuGetConsumerSmokePublished --configuration Release
+```
+
+Uses the default NuGet.org source and `ObservablesConsumerPackageVersion` (default `0.1.0-preview1`).

--- a/eng/nuget-smoke/RestAPI.R3.Consumer/Program.cs
+++ b/eng/nuget-smoke/RestAPI.R3.Consumer/Program.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using Observables.RestAPI;
+using RichardSzalay.MockHttp;
+using R3;
+
+var mockHttp = new MockHttpMessageHandler();
+mockHttp.When(HttpMethod.Get, "https://api.example.com/ping")
+    .Respond(HttpStatusCode.OK, "application/json", """{"ok":true}""");
+
+using HttpClient client = mockHttp.ToHttpClient();
+client.BaseAddress = new Uri("https://api.example.com");
+
+var api = RestService.For<IPingApi>(client);
+using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+PingResponse response = await api.Ping().FirstAsync(cts.Token);
+
+if (!response.Ok)
+{
+    throw new InvalidOperationException("Unexpected ping response.");
+}
+
+Console.WriteLine("Observables.RestAPI.R3 consumer smoke OK");
+
+public interface IPingApi
+{
+    [Get("/ping")]
+    Observable<PingResponse> Ping();
+}
+
+public sealed class PingResponse
+{
+    public bool Ok { get; set; }
+}

--- a/eng/nuget-smoke/RestAPI.R3.Consumer/RestAPI.R3.Consumer.csproj
+++ b/eng/nuget-smoke/RestAPI.R3.Consumer/RestAPI.R3.Consumer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Observables.NuGetSmoke.RestAPI.R3</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Observables.RestAPI.R3" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="R3" Version="1.3.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/eng/nuget-smoke/RestAPI.Reactive.Consumer/Program.cs
+++ b/eng/nuget-smoke/RestAPI.Reactive.Consumer/Program.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Observables.RestAPI;
+using RichardSzalay.MockHttp;
+
+var mockHttp = new MockHttpMessageHandler();
+mockHttp.When(HttpMethod.Get, "https://api.example.com/ping")
+    .Respond(HttpStatusCode.OK, "application/json", """{"ok":true}""");
+
+using HttpClient client = mockHttp.ToHttpClient();
+client.BaseAddress = new Uri("https://api.example.com");
+
+var api = RestService.For<IPingApi>(client);
+PingResponse response = await api.Ping().FirstAsync().ToTask();
+
+if (!response.Ok)
+{
+    throw new InvalidOperationException("Unexpected ping response.");
+}
+
+Console.WriteLine("Observables.RestAPI.Reactive consumer smoke OK");
+
+public interface IPingApi
+{
+    [Get("/ping")]
+    IObservable<PingResponse> Ping();
+}
+
+public sealed class PingResponse
+{
+    public bool Ok { get; set; }
+}

--- a/eng/nuget-smoke/RestAPI.Reactive.Consumer/RestAPI.Reactive.Consumer.csproj
+++ b/eng/nuget-smoke/RestAPI.Reactive.Consumer/RestAPI.Reactive.Consumer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Observables.NuGetSmoke.RestAPI.Reactive</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Observables.RestAPI.Reactive" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/eng/nuget-smoke/nuget.config.local
+++ b/eng/nuget-smoke/nuget.config.local
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="../../artifacts/package" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

- Pack `README.md` into all four NuGet meta-packages (Events/RestAPI × R3/Reactive)
- Extend `PackVerify` to require package README at nupkg root
- Add `eng/nuget-smoke` consumer projects and `NuGetConsumerSmoke` on `CiPack` (local feed after pack)

## Test plan

- [ ] `dotnet run --project build/_build.csproj -- --target CiPack --configuration Release`
- [ ] CI `pack` job green on PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI smoke tests only; no runtime library or auth logic changes.
> 
> **Overview**
> Adds **NuGet gallery READMEs** for all four meta-packages (`Observables.Events` / `Observables.RestAPI` × R3/Reactive): pack-specific markdown is included as root `README.md` via `PackageReadmeFile`, and **`PackVerify` now fails** if any expected `.nupkg` lacks that file.
> 
> Introduces **`eng/nuget-smoke`** — four minimal console apps that reference only NuGet packages (not repo projects) to compile and exercise Events and RestAPI flows. Nuke gains **`NuGetConsumerSmoke`** (optional `Pack` + local `nuget.config.local` → `artifacts/package`) and **`NuGetConsumerSmokePublished`** (nuget.org), with **`ConsumerFeed`** and schema targets; **`CiPack`** runs local consumer smoke after **`PackVerify`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519773d03448cbe17517964e2a4d5d59f09b1d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->