### PR TITLE
Improve Avalonia routed event detection

### DIFF
--- a/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.Discovery.cs
+++ b/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.Discovery.cs
@@ -118,7 +118,9 @@ private static ObservableEventTargetSets CollectObservableEventTargets(
     // Cache Avalonia detection to avoid repeated metadata lookups
     var avaloniaRoutedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
     var avaloniaRoutedEventTypeNonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
-    var useAvalonia = avaloniaRoutedEventType is not null || avaloniaRoutedEventTypeNonGeneric is not null;
+    var useAvalonia = avaloniaRoutedEventType is not null
+        || avaloniaRoutedEventTypeNonGeneric is not null
+        || string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal);
 
     foreach (var candidate in candidates)
     {

--- a/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.RoutedDetection.cs
+++ b/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.RoutedDetection.cs
@@ -57,8 +57,9 @@ private static bool TryGetAvaloniaRoutedClrEventField(
     routedEventField = null!;
     eventArgsType = null!;
 
-    var routedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
-    if (routedEventType is null)
+    var routedEventGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
+    var routedEventNonGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
+    if (routedEventGenericType is null && routedEventNonGenericType is null)
     {
         return false;
     }
@@ -76,18 +77,56 @@ private static bool TryGetAvaloniaRoutedClrEventField(
             if (member is not IFieldSymbol field
                 || !field.IsStatic
                 || field.IsImplicitlyDeclared
-                || field.Type is not INamedTypeSymbol fieldType
-                || !SymbolEqualityComparer.Default.Equals(fieldType.OriginalDefinition, routedEventType)
-                || fieldType.TypeArguments.Length != 1
-                || fieldType.TypeArguments[0] is not INamedTypeSymbol argsType)
+                || field.Type is not INamedTypeSymbol fieldType)
             {
                 continue;
             }
 
-            routedEventField = field;
-            eventArgsType = argsType;
-            return true;
+            var normalizedFieldType = fieldType.WithNullableAnnotation(NullableAnnotation.None);
+
+            if (routedEventGenericType is not null
+                && SymbolEqualityComparer.Default.Equals(normalizedFieldType.OriginalDefinition, routedEventGenericType)
+                && fieldType.TypeArguments.Length == 1
+                && fieldType.TypeArguments[0] is INamedTypeSymbol genericArgsType)
+            {
+                routedEventField = field;
+                eventArgsType = genericArgsType;
+                return true;
+            }
+
+            if (routedEventNonGenericType is not null
+                && SymbolEqualityComparer.Default.Equals(normalizedFieldType, routedEventNonGenericType)
+                && TryGetAvaloniaRoutedEventArgsType(evt, compilation, out INamedTypeSymbol nonGenericArgsType))
+            {
+                routedEventField = field;
+                eventArgsType = nonGenericArgsType;
+                return true;
+            }
         }
+    }
+
+    return false;
+}
+
+private static bool TryGetAvaloniaRoutedEventArgsType(
+    IEventSymbol evt,
+    Compilation compilation,
+    out INamedTypeSymbol eventArgsType)
+{
+    eventArgsType = null!;
+
+    var routedEventArgs = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEventArgs");
+    if (evt.Type is INamedTypeSymbol { TypeArguments.Length: 1 } handlerType
+        && handlerType.TypeArguments[0] is INamedTypeSymbol argsFromHandler)
+    {
+        eventArgsType = argsFromHandler;
+        return true;
+    }
+
+    if (routedEventArgs is not null)
+    {
+        eventArgsType = routedEventArgs;
+        return true;
     }
 
     return false;

--- a/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.cs
+++ b/Observables.Events/Observables.Events.R3.SourceGenerators/ObservableEventsGenerator.cs
@@ -145,6 +145,11 @@ public sealed partial class ObservableEventsGenerator : IIncrementalGenerator
 
     private static bool IsGeneratorTestRoutedGeneration(Compilation compilation, ImmutableArray<SyntaxNode> candidates)
     {
+        if (string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal))
+        {
+            return true;
+        }
+
         if (!string.Equals(compilation.AssemblyName, "GeneratorTests", System.StringComparison.Ordinal))
         {
             return false;

--- a/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.Discovery.cs
+++ b/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.Discovery.cs
@@ -118,7 +118,9 @@ private static ObservableEventTargetSets CollectObservableEventTargets(
     // Cache Avalonia detection to avoid repeated metadata lookups
     var avaloniaRoutedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
     var avaloniaRoutedEventTypeNonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
-    var useAvalonia = avaloniaRoutedEventType is not null || avaloniaRoutedEventTypeNonGeneric is not null;
+    var useAvalonia = avaloniaRoutedEventType is not null
+        || avaloniaRoutedEventTypeNonGeneric is not null
+        || string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal);
 
     foreach (var candidate in candidates)
     {

--- a/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.RoutedDetection.cs
+++ b/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.RoutedDetection.cs
@@ -57,8 +57,9 @@ private static bool TryGetAvaloniaRoutedClrEventField(
     routedEventField = null!;
     eventArgsType = null!;
 
-    var routedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
-    if (routedEventType is null)
+    var routedEventGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
+    var routedEventNonGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
+    if (routedEventGenericType is null && routedEventNonGenericType is null)
     {
         return false;
     }
@@ -76,18 +77,56 @@ private static bool TryGetAvaloniaRoutedClrEventField(
             if (member is not IFieldSymbol field
                 || !field.IsStatic
                 || field.IsImplicitlyDeclared
-                || field.Type is not INamedTypeSymbol fieldType
-                || !SymbolEqualityComparer.Default.Equals(fieldType.OriginalDefinition, routedEventType)
-                || fieldType.TypeArguments.Length != 1
-                || fieldType.TypeArguments[0] is not INamedTypeSymbol argsType)
+                || field.Type is not INamedTypeSymbol fieldType)
             {
                 continue;
             }
 
-            routedEventField = field;
-            eventArgsType = argsType;
-            return true;
+            var normalizedFieldType = fieldType.WithNullableAnnotation(NullableAnnotation.None);
+
+            if (routedEventGenericType is not null
+                && SymbolEqualityComparer.Default.Equals(normalizedFieldType.OriginalDefinition, routedEventGenericType)
+                && fieldType.TypeArguments.Length == 1
+                && fieldType.TypeArguments[0] is INamedTypeSymbol genericArgsType)
+            {
+                routedEventField = field;
+                eventArgsType = genericArgsType;
+                return true;
+            }
+
+            if (routedEventNonGenericType is not null
+                && SymbolEqualityComparer.Default.Equals(normalizedFieldType, routedEventNonGenericType)
+                && TryGetAvaloniaRoutedEventArgsType(evt, compilation, out INamedTypeSymbol nonGenericArgsType))
+            {
+                routedEventField = field;
+                eventArgsType = nonGenericArgsType;
+                return true;
+            }
         }
+    }
+
+    return false;
+}
+
+private static bool TryGetAvaloniaRoutedEventArgsType(
+    IEventSymbol evt,
+    Compilation compilation,
+    out INamedTypeSymbol eventArgsType)
+{
+    eventArgsType = null!;
+
+    var routedEventArgs = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEventArgs");
+    if (evt.Type is INamedTypeSymbol { TypeArguments.Length: 1 } handlerType
+        && handlerType.TypeArguments[0] is INamedTypeSymbol argsFromHandler)
+    {
+        eventArgsType = argsFromHandler;
+        return true;
+    }
+
+    if (routedEventArgs is not null)
+    {
+        eventArgsType = routedEventArgs;
+        return true;
     }
 
     return false;

--- a/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.cs
+++ b/Observables.Events/Observables.Events.Reactive.SourceGenerators/ObservableEventsGenerator.cs
@@ -140,6 +140,11 @@ public sealed partial class ObservableEventsGenerator : IIncrementalGenerator
 
     private static bool IsGeneratorTestRoutedGeneration(Compilation compilation, ImmutableArray<SyntaxNode> candidates)
     {
+        if (string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal))
+        {
+            return true;
+        }
+
         if (!string.Equals(compilation.AssemblyName, "GeneratorTests", System.StringComparison.Ordinal))
         {
             return false;


### PR DESCRIPTION
## Summary

- Support Avalonia **non-generic** `RoutedEvent` static fields (e.g. `Button.ClickEvent`)
- Enable routed bootstrap generation for `Observables.Samples.Events.Routed` consumer assembly

## Test plan

- [ ] `dotnet test Observables.Events/Observables.Events.R3.SourceGenerators.Tests -c Release`
- [ ] `dotnet test Observables.Events/Observables.Events.Reactive.SourceGenerators.Tests -c Release`
- [ ] Build `Observables.Samples.Events.Routed` with `-p:UseLocalObservables=true` (after Samples PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time source generator logic only; no runtime auth or data paths, with parallel changes in R3 and Reactive generators.
> 
> **Overview**
> Extends **Avalonia routed-event** support in the R3 and Reactive **ObservableEvents** source generators so CLR events backed by **non-generic** `RoutedEvent` static fields (e.g. `Button.ClickEvent`) are recognized, not only `RoutedEvent<T>`.
> 
> `TryGetAvaloniaRoutedClrEventField` now matches both generic and non-generic field types (with nullable normalization) and resolves event-args types via a new `TryGetAvaloniaRoutedEventArgsType` (handler delegate type argument, else `RoutedEventArgs`). Discovery treats Avalonia as enabled when that metadata exists **or** when compiling assembly **`Observables.Samples.Events.Routed`**, and routed bootstrap generation is forced on for that sample assembly (same pattern as existing `GeneratorTests` routing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66a1e4ab0fe3546be86ba6db3eb3d2ee99af7980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->