### PR TITLE
Harden RestAPI tests and fix diagnostic messages

### DIFF
--- a/Observables.RestAPI/Observables.RestAPI.Reactive.Tests/SystemReactiveRuntimeTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.Reactive.Tests/SystemReactiveRuntimeTests.cs
@@ -25,6 +25,20 @@ public sealed class SystemReactiveRuntimeTests
         Assert.Equal("Lin", user.Name);
     }
 
+    [Fact]
+    public async Task IObservableGet_throws_ApiException_on_404()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "https://api.example.com/users/404")
+            .Respond(HttpStatusCode.NotFound);
+
+        var client = mockHttp.ToHttpClient();
+        client.BaseAddress = new Uri("https://api.example.com");
+
+        var api = RestService.For<IIoUserApi>(client);
+        await Assert.ThrowsAsync<ApiException>(() => api.GetUser(404).FirstAsync().ToTask());
+    }
+
     public interface IIoUserApi
     {
         [Get("/users/{id}")]

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -9,7 +9,7 @@ internal static class DiagnosticDescriptors
         new(
             "OBS3001",
             "Observables.RestAPI types must have HTTP method attributes",
-            "Method {0}.{1} either has no Observables.RestAPI HTTP method attribute or you've used something other than a string literal for the 'path' argument",
+            "Method {0}.{1} has no Observables.RestAPI HTTP method attribute or uses a non-literal path argument",
             "Observables.RestAPI",
             DiagnosticSeverity.Warning,
             true
@@ -29,7 +29,7 @@ internal static class DiagnosticDescriptors
         new(
             "OBS3003",
             "Unsupported return type",
-            "Return type '{0}' is not supported by Observables.RestAPI.",
+            "Return type '{0}' is not supported by Observables.RestAPI",
             "Observables.RestAPI",
             DiagnosticSeverity.Error,
             true
@@ -39,7 +39,7 @@ internal static class DiagnosticDescriptors
         new(
             "OBS3004",
             "Path template mismatch",
-            "Path template for method '{0}' does not match its parameters.",
+            "Path template for method '{0}' does not match its parameters",
             "Observables.RestAPI",
             DiagnosticSeverity.Error,
             true
@@ -49,7 +49,7 @@ internal static class DiagnosticDescriptors
         new(
             "OBS3005",
             "SystemReactive package required for IObservable",
-            "Return type '{0}' requires PackageReference to Observables.RestAPI.Reactive.",
+            "Return type '{0}' requires PackageReference to Observables.RestAPI.Reactive",
             "Observables.RestAPI",
             DiagnosticSeverity.Error,
             true

--- a/Observables.RestAPI/Observables.RestAPI.Tests/RuntimeTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.Tests/RuntimeTests.cs
@@ -47,6 +47,20 @@ public sealed class RuntimeTests
         Assert.Equal(7, received.Id);
     }
 
+    [Fact]
+    public async Task TaskGet_throws_ApiException_on_404()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "https://api.example.com/users/404")
+            .Respond(HttpStatusCode.NotFound);
+
+        var client = mockHttp.ToHttpClient();
+        client.BaseAddress = new Uri("https://api.example.com");
+
+        var api = RestService.For<IUserApi>(client);
+        await Assert.ThrowsAsync<ApiException>(() => api.GetUser(404));
+    }
+
     public interface IUserApi
     {
         [Get("/users/{id}")]


### PR DESCRIPTION
## Summary

- Add **404 / ApiException** coverage for R3 `Observable` and Reactive `IObservable` GET
- Fix RestAPI generator diagnostic message formatting (RS1032)

## Test plan

- [ ] `dotnet test Observables.RestAPI/Observables.RestAPI.Tests -c Release`
- [ ] `dotnet test Observables.RestAPI/Observables.RestAPI.Reactive.Tests -c Release`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions plus cosmetic analyzer message text; no runtime or generator behavior changes.
> 
> **Overview**
> Adds runtime tests that a **404** from the mock HTTP client surfaces as **`ApiException`** for **`Task<User>`** GETs (R3 tests) and **`IObservable<User>`** GETs (Reactive tests), alongside existing success-path coverage.
> 
> Tightens RestAPI source generator **diagnostic message** text in `DiagnosticDescriptors` (clearer wording, consistent punctuation) to satisfy **RS1032** formatting rules—no generator logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5271a2a6d7ff4b8a10804eb1da951b25161aadc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->