### PR TITLE
Update AGENTS for post-preview1 status and SignalR roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；`origin/main` 已与本地 `main` 同步；文件夹名 `Observables` = 仓库名
-- **阶段**：**Events**、**RestAPI** 已实现；**NuGet 预览包** `0.1.0-preview1`（4 包）已配置，推送须维护者批准
+- **阶段**：**Events**、**RestAPI** 已实现；**NuGet 预览包** `0.1.0-preview1`（4 包）已发布；Nuke `PackVerify` + 包 README + `eng/nuget-smoke` 消费者校验已就绪
+- **下一 Feature**：**SignalR**（设计 Issue [#44](https://github.com/Skymly/Observables/issues/44)）；实现按独立 Issue/PR 链推进
 - **结构约定**：下文「仓库结构」与命名约定为权威
 
 ## 目标


### PR DESCRIPTION
## Summary

- Document packaging hardening (README, nuget-smoke)

- Mark SignalR as next feature (Issue #44)

## Test plan

- [ ] Docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md; no runtime, packaging, or CI behavior is modified.
> 
> **Overview**
> Updates **`AGENTS.md`** project status so agents and contributors see the repo **after** `0.1.0-preview1`, not the pre-publish state.
> 
> The **阶段** bullet now states the four preview packages are **published**, and calls out packaging guardrails already in the repo (**Nuke `PackVerify`**, package READMEs, **`eng/nuget-smoke`** consumer checks) instead of “push needs maintainer approval.”
> 
> A new **下一 Feature** bullet names **SignalR** as the roadmap focus, links design Issue **#44**, and notes implementation should follow separate issues/PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aece253533a208fa209de9eb676aee097c237f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->