### PR TITLE
Add SignalR hub E2E tests and fix multi-arg invokes

### DIFF
--- a/Observables.SignalR/Observables.SignalR.Reactive.Tests/Contracts/IE2EHub.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive.Tests/Contracts/IE2EHub.cs
@@ -1,0 +1,20 @@
+using Observables.SignalR;
+using System.Reactive;
+
+namespace Observables.SignalR.Reactive.Tests.Contracts;
+
+[Hub]
+public interface IE2EHub
+{
+    [HubInvoke]
+    IObservable<int> Add(int a, int b);
+
+    [HubSend]
+    IObservable<Unit> EchoSend(string text);
+
+    [HubStream]
+    IObservable<int> Counter(int max);
+
+    [HubOn("Notify")]
+    IObservable<string> Notify { get; }
+}

--- a/Observables.SignalR/Observables.SignalR.Reactive.Tests/HubConnectionReactiveE2ETests.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive.Tests/HubConnectionReactiveE2ETests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Observables.SignalR;
+using Observables.SignalR.Reactive.Tests.Contracts;
+using Observables.SignalR.Tests.Infrastructure;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Observables.SignalR.Reactive.Tests;
+
+[Collection(nameof(SignalRTestServerCollection))]
+public sealed class HubConnectionReactiveE2ETests(SignalRTestServerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task HubInvoke_Add_returns_sum()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        var sum = await hub.Add(2, 3).Timeout(DefaultTimeout).FirstAsync().ToTask();
+
+        Assert.Equal(5, sum);
+    }
+
+    [Fact]
+    public async Task HubSend_EchoSend_completes()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        await hub.EchoSend("ping").Timeout(DefaultTimeout).FirstAsync().ToTask();
+    }
+
+    [Fact]
+    public async Task HubStream_Counter_emits_sequence()
+    {
+        await using var connection = await ConnectStreamingAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        var values = await hub.Counter(3).Take(3).ToList().ToTask();
+
+        Assert.Equal([0, 1, 2], values);
+    }
+
+    [Fact]
+    public async Task HubOn_Notify_receives_server_push()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var receive = hub.Notify.Timeout(DefaultTimeout).FirstAsync().ToTask();
+        await connection.InvokeAsync("PushNotify", "hello", cts.Token).ConfigureAwait(false);
+        var message = await receive;
+
+        Assert.Equal("hello", message);
+    }
+
+    async Task<HubConnection> ConnectAsync() => await StartAsync(fixture.Server.CreateConnection());
+
+    async Task<HubConnection> ConnectStreamingAsync() =>
+        await StartAsync(fixture.Server.CreateStreamingConnection());
+
+    static async Task<HubConnection> StartAsync(HubConnection connection)
+    {
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        await connection.StartAsync(cts.Token);
+        return connection;
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj
+++ b/Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <RootNamespace>Observables.SignalR.Reactive.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.SignalR.Reactive\Observables.SignalR.Reactive.csproj" />
+    <ProjectReference Include="..\Observables.SignalR.Reactive.SourceGenerators\Observables.SignalR.Reactive.SourceGenerators.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Observables.SignalR.Tests\Infrastructure\E2ETestHub.cs" Link="Infrastructure\E2ETestHub.cs" />
+    <Compile Include="..\Observables.SignalR.Tests\Infrastructure\SignalRTestServer.cs" Link="Infrastructure\SignalRTestServer.cs" />
+    <Compile Include="..\Observables.SignalR.Tests\Infrastructure\SignalRTestServerFixture.cs" Link="Infrastructure\SignalRTestServerFixture.cs" />
+    <Compile Include="..\Observables.SignalR.Tests\Infrastructure\HubConnectionAsyncDisposableExtensions.cs" Link="Infrastructure\HubConnectionAsyncDisposableExtensions.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
@@ -23,7 +23,7 @@ public static class SystemReactiveSignalRAdapter
         Observable.FromAsync(ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            return connection.InvokeAsync<T>(methodName, args, linked.Token);
+            return HubConnectionArgs.InvokeAsync<T>(connection, methodName, args, linked.Token);
         });
 
     public static IObservable<System.Reactive.Unit> FromSend(
@@ -40,7 +40,7 @@ public static class SystemReactiveSignalRAdapter
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await connection.SendAsync(methodName, args, linked.Token).ConfigureAwait(false);
+            await HubConnectionArgs.SendAsync(connection, methodName, args, linked.Token).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
@@ -71,8 +71,8 @@ public static class SystemReactiveSignalRAdapter
     {
         try
         {
-            await foreach (var item in connection
-                               .StreamAsync<T>(methodName, args, cancellationToken)
+            await foreach (var item in HubConnectionArgs
+                               .StreamAsync<T>(connection, methodName, args, cancellationToken)
                                .ConfigureAwait(false))
             {
                 observer.OnNext(item);

--- a/Observables.SignalR/Observables.SignalR.Tests/Contracts/IE2EHub.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Contracts/IE2EHub.cs
@@ -1,0 +1,20 @@
+using Observables.SignalR;
+using R3;
+
+namespace Observables.SignalR.Tests.Contracts;
+
+[Hub]
+public interface IE2EHub
+{
+    [HubInvoke]
+    Observable<int> Add(int a, int b);
+
+    [HubSend]
+    Observable<Unit> EchoSend(string text);
+
+    [HubStream]
+    Observable<int> Counter(int max);
+
+    [HubOn("Notify")]
+    Observable<string> Notify { get; }
+}

--- a/Observables.SignalR/Observables.SignalR.Tests/HubConnectionR3E2ETests.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/HubConnectionR3E2ETests.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Observables.SignalR;
+using Observables.SignalR.Tests.Contracts;
+using Observables.SignalR.Tests.Infrastructure;
+using R3;
+
+namespace Observables.SignalR.Tests;
+
+[Collection(nameof(SignalRTestServerCollection))]
+public sealed class HubConnectionR3E2ETests(SignalRTestServerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task HubInvoke_Add_returns_sum()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var sum = await hub.Add(2, 3).FirstAsync(cts.Token);
+
+        Assert.Equal(5, sum);
+    }
+
+    [Fact]
+    public async Task HubInvoke_Add_direct_invoke_matches_generated_proxy()
+    {
+        await using var connection = await ConnectAsync();
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var direct = await connection.InvokeAsync<int>("Add", 2, 3, cts.Token);
+        var viaProxy = await HubService.For<IE2EHub>(connection).Add(2, 3).FirstAsync(cts.Token);
+
+        Assert.Equal(5, direct);
+        Assert.Equal(direct, viaProxy);
+    }
+
+    [Fact]
+    public async Task HubSend_EchoSend_completes()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        await hub.EchoSend("ping").FirstAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task HubStream_Counter_emits_sequence()
+    {
+        await using var connection = await ConnectStreamingAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var values = new List<int>();
+        await foreach (var value in hub.Counter(3).ToAsyncEnumerable(cts.Token))
+        {
+            values.Add(value);
+        }
+
+        Assert.Equal([0, 1, 2], values);
+    }
+
+    [Fact]
+    public async Task HubOn_Notify_receives_server_push()
+    {
+        await using var connection = await ConnectAsync();
+        var hub = HubService.For<IE2EHub>(connection);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var receive = hub.Notify.FirstAsync(cts.Token);
+        await connection.InvokeAsync("PushNotify", "hello", cts.Token);
+        var message = await receive;
+
+        Assert.Equal("hello", message);
+    }
+
+    async Task<HubConnection> ConnectAsync() => await StartAsync(fixture.Server.CreateConnection());
+
+    async Task<HubConnection> ConnectStreamingAsync() =>
+        await StartAsync(fixture.Server.CreateStreamingConnection());
+
+    static async Task<HubConnection> StartAsync(HubConnection connection)
+    {
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        await connection.StartAsync(cts.Token);
+        return connection;
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/E2ETestHub.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/E2ETestHub.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace Observables.SignalR.Tests.Infrastructure;
+
+/// <summary>In-process SignalR hub backing <see cref="Contracts.IE2EHub"/> client contract.</summary>
+public sealed class E2ETestHub : Hub
+{
+    public Task<int> Add(int a, int b) => Task.FromResult(a + b);
+
+    public Task EchoSend(string text) => Task.CompletedTask;
+
+    public async IAsyncEnumerable<int> Counter(int max)
+    {
+        for (var i = 0; i < max; i++)
+        {
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+    public async Task PushNotify(string message) =>
+        await Clients.Caller.SendAsync("Notify", message).ConfigureAwait(false);
+}

--- a/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/HubConnectionAsyncDisposableExtensions.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/HubConnectionAsyncDisposableExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Observables.SignalR.Tests.Infrastructure;
+
+public static class HubConnectionAsyncDisposableExtensions
+{
+    public static async ValueTask DisposeAsync(this HubConnection connection)
+    {
+        if (connection.State == HubConnectionState.Disconnected)
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            return;
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            await connection.StopAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await connection.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/SignalRTestServer.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/SignalRTestServer.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Observables.SignalR.Tests.Infrastructure;
+
+/// <summary>Hosts <see cref="E2ETestHub"/> in-memory via <see cref="TestServer"/>.</summary>
+public sealed class SignalRTestServer : IAsyncDisposable
+{
+    readonly IHost host;
+    readonly TestServer testServer;
+
+    SignalRTestServer(IHost host, TestServer testServer)
+    {
+        this.host = host;
+        this.testServer = testServer;
+        HubUri = new Uri(testServer.BaseAddress, "hub");
+    }
+
+    public Uri HubUri { get; }
+
+    public static async Task<SignalRTestServer> StartAsync(CancellationToken cancellationToken = default)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                    services.AddSignalR(options => options.EnableDetailedErrors = true));
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints => endpoints.MapHub<E2ETestHub>("/hub"));
+                });
+            })
+            .Build();
+
+        await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        return new SignalRTestServer(host, host.GetTestServer());
+    }
+
+    public HubConnection CreateConnection() =>
+        new HubConnectionBuilder()
+            .WithUrl(HubUri, options =>
+            {
+                options.Transports = HttpTransportType.LongPolling;
+                options.HttpMessageHandlerFactory = _ => testServer.CreateHandler();
+            })
+            .Build();
+
+    public HubConnection CreateStreamingConnection()
+    {
+        var webSocketClient = testServer.CreateWebSocketClient();
+        return new HubConnectionBuilder()
+            .WithUrl(HubUri, options =>
+            {
+                options.Transports = HttpTransportType.WebSockets;
+                options.HttpMessageHandlerFactory = _ => testServer.CreateHandler();
+                options.WebSocketFactory = async (context, cancellationToken) =>
+                    await webSocketClient.ConnectAsync(context.Uri, cancellationToken).ConfigureAwait(false);
+            })
+            .Build();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await host.StopAsync().ConfigureAwait(false);
+        host.Dispose();
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/SignalRTestServerFixture.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/SignalRTestServerFixture.cs
@@ -1,0 +1,13 @@
+namespace Observables.SignalR.Tests.Infrastructure;
+
+public sealed class SignalRTestServerFixture : IAsyncLifetime, IAsyncDisposable
+{
+    public SignalRTestServer Server { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync() => Server = await SignalRTestServer.StartAsync();
+
+    public async ValueTask DisposeAsync() => await Server.DisposeAsync().ConfigureAwait(false);
+}
+
+[CollectionDefinition(nameof(SignalRTestServerCollection), DisableParallelization = true)]
+public sealed class SignalRTestServerCollection : ICollectionFixture<SignalRTestServerFixture>;

--- a/Observables.SignalR/Observables.SignalR.Tests/Observables.SignalR.Tests.csproj
+++ b/Observables.SignalR/Observables.SignalR.Tests/Observables.SignalR.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <RootNamespace>Observables.SignalR.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.SignalR\Observables.SignalR.csproj" />
+    <ProjectReference Include="..\Observables.SignalR.R3.SourceGenerators\Observables.SignalR.R3.SourceGenerators.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.SignalR/Observables.SignalR/HubConnectionArgs.cs
+++ b/Observables.SignalR/Observables.SignalR/HubConnectionArgs.cs
@@ -1,0 +1,184 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Observables.SignalR;
+
+/// <summary>Invokes hub methods using per-argument overloads so args bind correctly on the server.</summary>
+public static class HubConnectionArgs
+{
+    public static Task<T> InvokeAsync<T>(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        CancellationToken cancellationToken) =>
+        args.Length switch
+        {
+            0 => connection.InvokeAsync<T>(methodName, cancellationToken),
+            1 => connection.InvokeAsync<T>(methodName, args[0], cancellationToken),
+            2 => connection.InvokeAsync<T>(methodName, args[0], args[1], cancellationToken),
+            3 => connection.InvokeAsync<T>(methodName, args[0], args[1], args[2], cancellationToken),
+            4 => connection.InvokeAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                cancellationToken),
+            5 => connection.InvokeAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                cancellationToken),
+            6 => connection.InvokeAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                cancellationToken),
+            7 => connection.InvokeAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                cancellationToken),
+            8 => connection.InvokeAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                args[7],
+                cancellationToken),
+            _ => connection.InvokeAsync<T>(methodName, args, cancellationToken),
+        };
+
+    public static Task SendAsync(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        CancellationToken cancellationToken) =>
+        args.Length switch
+        {
+            0 => connection.SendAsync(methodName, cancellationToken),
+            1 => connection.SendAsync(methodName, args[0], cancellationToken),
+            2 => connection.SendAsync(methodName, args[0], args[1], cancellationToken),
+            3 => connection.SendAsync(methodName, args[0], args[1], args[2], cancellationToken),
+            4 => connection.SendAsync(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                cancellationToken),
+            5 => connection.SendAsync(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                cancellationToken),
+            6 => connection.SendAsync(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                cancellationToken),
+            7 => connection.SendAsync(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                cancellationToken),
+            8 => connection.SendAsync(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                args[7],
+                cancellationToken),
+            _ => connection.SendAsync(methodName, args, cancellationToken),
+        };
+
+    public static IAsyncEnumerable<T> StreamAsync<T>(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        CancellationToken cancellationToken) =>
+        args.Length switch
+        {
+            0 => connection.StreamAsync<T>(methodName, cancellationToken),
+            1 => connection.StreamAsync<T>(methodName, args[0], cancellationToken),
+            2 => connection.StreamAsync<T>(methodName, args[0], args[1], cancellationToken),
+            3 => connection.StreamAsync<T>(methodName, args[0], args[1], args[2], cancellationToken),
+            4 => connection.StreamAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                cancellationToken),
+            5 => connection.StreamAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                cancellationToken),
+            6 => connection.StreamAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                cancellationToken),
+            7 => connection.StreamAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                cancellationToken),
+            8 => connection.StreamAsync<T>(
+                methodName,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                args[7],
+                cancellationToken),
+            _ => connection.StreamAsync<T>(methodName, args, cancellationToken),
+        };
+}

--- a/Observables.SignalR/Observables.SignalR/SignalRObservable.cs
+++ b/Observables.SignalR/Observables.SignalR/SignalRObservable.cs
@@ -20,8 +20,8 @@ public static class SignalRObservable
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            return await connection
-                .InvokeAsync<T>(methodName, args, linked.Token)
+            return await HubConnectionArgs
+                .InvokeAsync<T>(connection, methodName, args, linked.Token)
                 .ConfigureAwait(false);
         });
 
@@ -39,7 +39,7 @@ public static class SignalRObservable
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await connection.SendAsync(methodName, args, linked.Token).ConfigureAwait(false);
+            await HubConnectionArgs.SendAsync(connection, methodName, args, linked.Token).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -57,8 +57,8 @@ public static class SignalRObservable
         Observable.Create<T>(async (observer, ct) =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await foreach (var item in connection
-                               .StreamAsync<T>(methodName, args, linked.Token)
+            await foreach (var item in HubConnectionArgs
+                               .StreamAsync<T>(connection, methodName, args, linked.Token)
                                .ConfigureAwait(false))
             {
                 observer.OnNext(item);

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -92,6 +92,10 @@
 
       <Project Path="Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators.Tests/Observables.SignalR.Reactive.SourceGenerators.Tests.csproj" />
 
+      <Project Path="Observables.SignalR/Observables.SignalR.Tests/Observables.SignalR.Tests.csproj" />
+
+      <Project Path="Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj" />
+
     </Folder>
 
   </Folder>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -60,6 +60,8 @@ sealed class Build : NukeBuild
         "Observables.RestAPI/Observables.RestAPI.HttpClientFactory.Tests/Observables.RestAPI.HttpClientFactory.Tests.csproj",
         "Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/Observables.SignalR.R3.SourceGenerators.Tests.csproj",
         "Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators.Tests/Observables.SignalR.Reactive.SourceGenerators.Tests.csproj",
+        "Observables.SignalR/Observables.SignalR.Tests/Observables.SignalR.Tests.csproj",
+        "Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj",
     ];
 
     static readonly string[] PackProjectRelativePaths =

--- a/docs/design/signalr.md
+++ b/docs/design/signalr.md
@@ -198,7 +198,8 @@ R3 包不引用 System.Reactive，反之亦然（约定）。
 | `Observables.SignalR.Package` | **已发布** | `Observables.SignalR.R3` / `.Reactive` 两包 |
 | `Observables.SignalR.R3.SourceGenerators.Tests` | **已发布** | 生成器单测 |
 | `Observables.SignalR.Reactive.SourceGenerators.Tests` | **已发布** | Verify 快照 + 生成器单测 |
-| `Observables.SignalR.Tests` | 未建 | 可选运行时桥接 E2E（非 preview3 范围） |
+| `Observables.SignalR.Tests` | **已发布** | TestServer + 真实 Hub E2E（Invoke/Send/Stream/On，R3） |
+| `Observables.SignalR.Reactive.Tests` | **已发布** | 同上（System.Reactive） |
 
 配套：
 


### PR DESCRIPTION
## Summary

- Add in-process TestServer E2E projects for R3 (Observables.SignalR.Tests) and Reactive (Observables.SignalR.Reactive.Tests), exercising generated hub proxies for Invoke, Send, Stream (WebSocket), and On callbacks.
- Fix runtime hub invocation when generators pass object?[] by routing through HubConnectionArgs per-argument overloads on HubConnection (Invoke/Send/Stream).
- Wire new test projects into Observables.slnx, Nuke Test, and docs/design/signalr.md.

## Test plan

- [x] dotnet test Observables.SignalR/Observables.SignalR.Tests/Observables.SignalR.Tests.csproj
- [x] dotnet test Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj
- [x] dotnet test Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/Observables.SignalR.R3.SourceGenerators.Tests.csproj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared runtime hub invoke/send/stream paths used by all generated proxies; behavior fix is targeted but affects production client calls.
> 
> **Overview**
> Adds **in-process SignalR E2E coverage** for generated hub proxies: shared **TestServer** infrastructure (`E2ETestHub`, long-polling vs WebSocket clients) and separate test projects for **R3** and **System.Reactive**, exercising **Invoke**, **Send**, **Stream**, and **On** (server push).
> 
> Fixes **multi-argument hub calls** when generated code passes `object?[]` by introducing **`HubConnectionArgs`**, which dispatches to `HubConnection`’s per-argument overloads (0–8 args) instead of a single `args` array—wired through **`SignalRObservable`** and **`SystemReactiveSignalRAdapter`**.
> 
> Registers the new test projects in **`Observables.slnx`**, **`build/Program.cs`**, and **`docs/design/signalr.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c82bbe96da1a61575e9de1a173078c2d4eee2d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->