### PR TITLE
Add in-process MQTT broker E2E tests

### DIFF
--- a/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Contracts/IE2EHub.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Contracts/IE2EHub.cs
@@ -1,0 +1,14 @@
+using Observables.Mqtt;
+using System.Reactive;
+
+namespace Observables.Mqtt.Reactive.Tests.Contracts;
+
+[Mqtt]
+public interface IE2EHub
+{
+    [MqttSubscribe("e2e/ping")]
+    IObservable<string> Ping { get; }
+
+    [MqttPublish("e2e/ping")]
+    IObservable<Unit> PublishPing();
+}

--- a/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/MqttClientReactiveE2ETests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/MqttClientReactiveE2ETests.cs
@@ -1,0 +1,43 @@
+using MQTTnet;
+using MQTTnet.Client;
+using Observables.Mqtt;
+using Observables.Mqtt.Reactive.Tests.Contracts;
+using Observables.Mqtt.Tests.Infrastructure;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Observables.Mqtt.Reactive.Tests;
+
+[Collection(nameof(MqttTestBrokerCollection))]
+public sealed class MqttClientReactiveE2ETests(MqttTestBrokerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task MqttSubscribe_Ping_receives_broker_message()
+    {
+        await using var session = await fixture.Broker.ConnectAsync();
+        var hub = MqttService.For<IE2EHub>(session.Client);
+
+        var receive = hub.Ping.Timeout(DefaultTimeout).FirstAsync().ToTask();
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic("e2e/ping")
+            .WithPayload("hello"u8.ToArray())
+            .Build();
+        await session.Client.PublishAsync(message);
+
+        Assert.Equal("hello", await receive);
+    }
+
+    [Fact]
+    public async Task MqttPublish_PublishPing_reaches_subscriber()
+    {
+        await using var session = await fixture.Broker.ConnectAsync();
+        var hub = MqttService.For<IE2EHub>(session.Client);
+
+        var receive = hub.Ping.Timeout(DefaultTimeout).FirstAsync().ToTask();
+        await hub.PublishPing().Timeout(DefaultTimeout).FirstAsync().ToTask();
+
+        Assert.Equal(string.Empty, await receive);
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <RootNamespace>Observables.Mqtt.Reactive.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Mqtt.Reactive\Observables.Mqtt.Reactive.csproj" />
+    <ProjectReference Include="..\Observables.Mqtt.Reactive.SourceGenerators\Observables.Mqtt.Reactive.SourceGenerators.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Observables.Mqtt.Tests\Infrastructure\MqttTestBroker.cs" Link="Infrastructure\MqttTestBroker.cs" />
+    <Compile Include="..\Observables.Mqtt.Tests\Infrastructure\MqttTestBrokerFixture.cs" Link="Infrastructure\MqttTestBrokerFixture.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
@@ -74,7 +74,10 @@ public static class SystemReactiveMqttAdapter
 
                         try
                         {
-                            observer.OnNext(DeserializePayload<T>(e.ApplicationMessage.PayloadSegment.ToArray()));
+                            var payload = e.ApplicationMessage.PayloadSegment.Count == 0
+                                ? Array.Empty<byte>()
+                                : e.ApplicationMessage.PayloadSegment.ToArray();
+                            observer.OnNext(DeserializePayload<T>(payload));
                         }
                         catch (Exception ex)
                         {

--- a/Observables.Mqtt/Observables.Mqtt.Tests/Contracts/IE2EHub.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/Contracts/IE2EHub.cs
@@ -1,0 +1,14 @@
+using Observables.Mqtt;
+using R3;
+
+namespace Observables.Mqtt.Tests.Contracts;
+
+[Mqtt]
+public interface IE2EHub
+{
+    [MqttSubscribe("e2e/ping")]
+    Observable<string> Ping { get; }
+
+    [MqttPublish("e2e/ping")]
+    Observable<Unit> PublishPing();
+}

--- a/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBroker.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBroker.cs
@@ -1,0 +1,80 @@
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Server;
+
+namespace Observables.Mqtt.Tests.Infrastructure;
+
+/// <summary>In-process MQTT broker for E2E tests.</summary>
+public sealed class MqttTestBroker : IAsyncDisposable
+{
+    readonly MqttServer server;
+    readonly MqttFactory factory;
+
+    MqttTestBroker(MqttServer server, MqttFactory factory, int port)
+    {
+        this.server = server;
+        this.factory = factory;
+        Port = port;
+    }
+
+    public int Port { get; }
+
+    public static async Task<MqttTestBroker> StartAsync(CancellationToken cancellationToken = default)
+    {
+        var factory = new MqttFactory();
+        var port = Random.Shared.Next(50_000, 60_000);
+        var options = factory
+            .CreateServerOptionsBuilder()
+            .WithDefaultEndpoint()
+            .WithDefaultEndpointPort(port)
+            .Build();
+        var server = factory.CreateMqttServer(options);
+
+        await server.StartAsync().ConfigureAwait(false);
+        return new MqttTestBroker(server, factory, port);
+    }
+
+    public async Task<MqttClientSession> ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        var client = factory.CreateMqttClient();
+        var result = await client
+            .ConnectAsync(
+                new MqttClientOptionsBuilder()
+                    .WithTcpServer("127.0.0.1", Port)
+                    .WithClientId(Guid.NewGuid().ToString("N"))
+                    .Build(),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.ResultCode != MqttClientConnectResultCode.Success)
+        {
+            throw new InvalidOperationException($"MQTT connect failed: {result.ResultCode}");
+        }
+
+        return new MqttClientSession(client);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await server.StopAsync().ConfigureAwait(false);
+        server.Dispose();
+    }
+
+    public sealed class MqttClientSession(IMqttClient client) : IAsyncDisposable
+    {
+        public IMqttClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Client.IsConnected)
+            {
+                await Client.DisconnectAsync().ConfigureAwait(false);
+            }
+
+            if (Client is IAsyncDisposable disposable)
+            {
+                await disposable.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBrokerFixture.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBrokerFixture.cs
@@ -1,0 +1,13 @@
+namespace Observables.Mqtt.Tests.Infrastructure;
+
+public sealed class MqttTestBrokerFixture : IAsyncLifetime, IAsyncDisposable
+{
+    public MqttTestBroker Broker { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync() => Broker = await MqttTestBroker.StartAsync();
+
+    public async ValueTask DisposeAsync() => await Broker.DisposeAsync().ConfigureAwait(false);
+}
+
+[CollectionDefinition(nameof(MqttTestBrokerCollection))]
+public sealed class MqttTestBrokerCollection : ICollectionFixture<MqttTestBrokerFixture>;

--- a/Observables.Mqtt/Observables.Mqtt.Tests/MqttClientR3E2ETests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/MqttClientR3E2ETests.cs
@@ -1,0 +1,44 @@
+using MQTTnet;
+using MQTTnet.Client;
+using Observables.Mqtt;
+using Observables.Mqtt.Tests.Contracts;
+using Observables.Mqtt.Tests.Infrastructure;
+using R3;
+
+namespace Observables.Mqtt.Tests;
+
+[Collection(nameof(MqttTestBrokerCollection))]
+public sealed class MqttClientR3E2ETests(MqttTestBrokerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task MqttSubscribe_Ping_receives_broker_message()
+    {
+        await using var session = await fixture.Broker.ConnectAsync();
+        var hub = MqttService.For<IE2EHub>(session.Client);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var receive = hub.Ping.FirstAsync(cts.Token);
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic("e2e/ping")
+            .WithPayload("hello"u8.ToArray())
+            .Build();
+        await session.Client.PublishAsync(message, cts.Token);
+
+        Assert.Equal("hello", await receive);
+    }
+
+    [Fact]
+    public async Task MqttPublish_PublishPing_reaches_subscriber()
+    {
+        await using var session = await fixture.Broker.ConnectAsync();
+        var hub = MqttService.For<IE2EHub>(session.Client);
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var receive = hub.Ping.FirstAsync(cts.Token);
+        await hub.PublishPing().FirstAsync(cts.Token);
+
+        Assert.Equal(string.Empty, await receive);
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <RootNamespace>Observables.Mqtt.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Mqtt\Observables.Mqtt.csproj" />
+    <ProjectReference Include="..\Observables.Mqtt.R3.SourceGenerators\Observables.Mqtt.R3.SourceGenerators.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
@@ -59,7 +59,9 @@ public static class MqttObservable
 
                 try
                 {
-                    var payload = e.ApplicationMessage.PayloadSegment.ToArray();
+                    var payload = e.ApplicationMessage.PayloadSegment.Count == 0
+                        ? Array.Empty<byte>()
+                        : e.ApplicationMessage.PayloadSegment.ToArray();
                     observer.OnNext(DeserializePayload<T>(payload));
                 }
                 catch (Exception ex)

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -128,6 +128,10 @@
 
       <Project Path="Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators.Tests/Observables.Mqtt.Reactive.SourceGenerators.Tests.csproj" />
 
+      <Project Path="Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj" />
+
+      <Project Path="Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj" />
+
     </Folder>
 
   </Folder>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -66,6 +66,8 @@ sealed class Build : NukeBuild
         "Observables.SignalR/Observables.SignalR.Reactive.Tests/Observables.SignalR.Reactive.Tests.csproj",
         "Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators.Tests/Observables.Mqtt.R3.SourceGenerators.Tests.csproj",
         "Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators.Tests/Observables.Mqtt.Reactive.SourceGenerators.Tests.csproj",
+        "Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj",
+        "Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj",
     ];
 
     static readonly string[] PackProjectRelativePaths =


### PR DESCRIPTION
## Summary

- Add in-process MQTTnet broker E2E tests for R3 and Reactive generated `MqttService` proxies.
- Fix empty MQTT application message payloads in subscribe bridges.

Closes #53

## Test plan

- [x] `dotnet test Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj`
- [x] `dotnet test Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure plus a small, targeted fix in MQTT subscribe deserialization; no auth or production API surface changes.
> 
> **Overview**
> Adds **in-process MQTTnet E2E coverage** for generated `MqttService` hubs on both **R3** and **System.Reactive**, using a shared `MqttTestBroker` fixture (random localhost port, xUnit collection) and new test projects wired into the solution and build test list.
> 
> Subscribe/publish paths are exercised end-to-end (`e2e/ping` with payload and empty publish round-trip). **Subscribe bridges** in `MqttObservable` and `SystemReactiveMqttAdapter` now treat zero-length `PayloadSegment` as `Array.Empty<byte>()` before deserialization so empty MQTT messages deserialize correctly (e.g. empty `string`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e3d3deaaaf0b863ce67f62bb3cc78b62f3bfd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->