### PR TITLE
Add pluggable MQTT payload serializers (IMqttPayloadSerializer)

### DIFF
--- a/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
@@ -1,25 +1,16 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
-#if NETSTANDARD2_0
-#else
-using System.Text.Json;
-#endif
 
 namespace Observables.Mqtt.Reactive;
 
 /// <summary>Bridges MQTT client APIs to <see cref="IObservable{T}"/>.</summary>
 public static class SystemReactiveMqttAdapter
 {
-#if NETSTANDARD2_0
-#else
-    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-#endif
 
     public static IObservable<System.Reactive.Unit> FromPublish(
         IMqttClient client,
@@ -73,7 +64,7 @@ public static class SystemReactiveMqttAdapter
                             var payload = e.ApplicationMessage.PayloadSegment.Count == 0
                                 ? Array.Empty<byte>()
                                 : e.ApplicationMessage.PayloadSegment.ToArray();
-                            observer.OnNext(DeserializePayload<T>(payload));
+                            observer.OnNext(MqttPayloadSerializers.Deserialize<T>(payload));
                         }
                         catch (Exception ex)
                         {
@@ -98,33 +89,6 @@ public static class SystemReactiveMqttAdapter
                 }
             }
         });
-
-    static T DeserializePayload<T>(byte[] payload)
-    {
-        if (typeof(T) == typeof(byte[]))
-        {
-            return (T)(object)payload;
-        }
-
-        if (typeof(T) == typeof(string))
-        {
-            return (T)(object)Encoding.UTF8.GetString(payload);
-        }
-
-#if NETSTANDARD2_0
-        throw new NotSupportedException(
-            "Deserializing MQTT payloads to types other than byte[] or string requires net8.0 or later.");
-#else
-        var json = Encoding.UTF8.GetString(payload);
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        if (value is null)
-        {
-            throw new InvalidOperationException("MQTT payload deserialized to null.");
-        }
-
-        return value;
-#endif
-    }
 
     static bool TopicMatches(string filter, string? topic)
     {

--- a/Observables.Mqtt/Observables.Mqtt.Tests/MqttPayloadSerializerTests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/MqttPayloadSerializerTests.cs
@@ -1,0 +1,188 @@
+using System.Text;
+
+namespace Observables.Mqtt.Tests;
+
+public sealed class MqttPayloadSerializerTests
+{
+    [Fact]
+    public void Primitive_deserializes_string_and_byte_array()
+    {
+        var serializer = PrimitiveMqttPayloadSerializer.Instance;
+
+        Assert.Equal("ping", serializer.Deserialize(typeof(string), "ping"u8.ToArray()));
+        Assert.Equal(new byte[] { 1, 2 }, serializer.Deserialize(typeof(byte[]), new byte[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void Primitive_serializes_string_and_byte_array()
+    {
+        var serializer = PrimitiveMqttPayloadSerializer.Instance;
+
+        Assert.Equal("ping"u8.ToArray(), serializer.Serialize(typeof(string), "ping"));
+        Assert.Equal(new byte[] { 3 }, serializer.Serialize(typeof(byte[]), new byte[] { 3 }));
+    }
+
+    [Fact]
+    public void Primitive_throws_for_unsupported_types()
+    {
+        var serializer = PrimitiveMqttPayloadSerializer.Instance;
+
+        Assert.Throws<NotSupportedException>(() => serializer.Deserialize(typeof(int), "1"u8.ToArray()));
+        Assert.Throws<NotSupportedException>(() => serializer.Serialize(typeof(int), 1));
+    }
+
+    [Fact]
+    public void Interface_overloads_deserialize_and_serialize_generically()
+    {
+        IMqttPayloadSerializer serializer = PrimitiveMqttPayloadSerializer.Instance;
+
+        Assert.Equal("ping", serializer.Deserialize<string>("ping"u8.ToArray()));
+        Assert.Equal("ping", serializer.Deserialize<string>((ReadOnlySpan<byte>)"ping"u8.ToArray()));
+        Assert.Equal("ping"u8.ToArray(), serializer.Serialize("ping"));
+        Assert.Equal(new byte[] { 4 }, serializer.Deserialize<byte[]>(new byte[] { 4 }));
+    }
+
+    [Fact]
+    public void Serializers_expose_non_generic_overloads()
+    {
+        Assert.Equal("ping", MqttPayloadSerializers.Deserialize(typeof(string), "ping"u8.ToArray()));
+        Assert.Equal("ping"u8.ToArray(), MqttPayloadSerializers.Serialize(typeof(string), "ping"));
+        Assert.Equal("ping", MqttPayloadSerializers.Deserialize<string>("ping"u8.ToArray()));
+        Assert.Equal("ping"u8.ToArray(), MqttPayloadSerializers.Serialize<string>("ping"));
+    }
+
+    [Fact]
+    public void Default_serializer_roundtrips_json_payloads()
+    {
+        var serializer = DefaultMqttPayloadSerializer.Instance;
+        var payload = serializer.Serialize(typeof(TemperatureReading), new TemperatureReading { DeviceId = "a", Celsius = 21.5 });
+        var reading = (TemperatureReading)serializer.Deserialize(typeof(TemperatureReading), payload);
+
+        Assert.Equal("a", reading.DeviceId);
+        Assert.Equal(21.5, reading.Celsius);
+    }
+
+    [Fact]
+    public void Register_non_generic_serializer_for_type()
+    {
+        var previous = MqttPayloadSerializers.Current;
+        try
+        {
+            MqttPayloadSerializers.Current = PrimitiveMqttPayloadSerializer.Instance;
+            MqttPayloadSerializers.Register<int>(new Int32Serializer());
+
+            Assert.Equal(7, MqttPayloadSerializers.Deserialize<int>("7"u8.ToArray()));
+            Assert.Equal("7"u8.ToArray(), MqttPayloadSerializers.Serialize(7));
+        }
+        finally
+        {
+            MqttPayloadSerializers.Unregister<int>();
+            MqttPayloadSerializers.Current = previous;
+        }
+    }
+
+    [Fact]
+    public void Current_can_be_replaced_with_custom_serializer()
+    {
+        var previous = MqttPayloadSerializers.Current;
+        try
+        {
+            MqttPayloadSerializers.Current = new PrefixSerializer();
+            Assert.Equal("hello", MqttPayloadSerializers.Deserialize<string>("prefix:hello"u8.ToArray()));
+        }
+        finally
+        {
+            MqttPayloadSerializers.Current = previous;
+        }
+    }
+
+    [Fact]
+    public void Register_generic_serializer_takes_precedence_over_current()
+    {
+        var previous = MqttPayloadSerializers.Current;
+        try
+        {
+            MqttPayloadSerializers.Current = PrimitiveMqttPayloadSerializer.Instance;
+            MqttPayloadSerializers.Register<int>(
+                static payload => int.Parse(System.Text.Encoding.UTF8.GetString(payload)),
+                static value => System.Text.Encoding.UTF8.GetBytes(value.ToString()));
+
+            Assert.Equal(42, MqttPayloadSerializers.Deserialize<int>("42"u8.ToArray()));
+            Assert.Equal("99"u8.ToArray(), MqttPayloadSerializers.Serialize(99));
+        }
+        finally
+        {
+            MqttPayloadSerializers.Unregister<int>();
+            MqttPayloadSerializers.Current = previous;
+        }
+    }
+
+    [Fact]
+    public void Unregister_removes_typed_serializer()
+    {
+        var previous = MqttPayloadSerializers.Current;
+        try
+        {
+            MqttPayloadSerializers.Current = PrimitiveMqttPayloadSerializer.Instance;
+            MqttPayloadSerializers.Register<string>(
+                static _ => "typed",
+                static _ => "typed"u8.ToArray());
+
+            Assert.Equal("typed", MqttPayloadSerializers.Deserialize<string>(Array.Empty<byte>()));
+            Assert.True(MqttPayloadSerializers.Unregister<string>());
+            Assert.Equal(string.Empty, MqttPayloadSerializers.Deserialize<string>(Array.Empty<byte>()));
+        }
+        finally
+        {
+            MqttPayloadSerializers.Unregister<string>();
+            MqttPayloadSerializers.Current = previous;
+        }
+    }
+
+    sealed class PrefixSerializer : IMqttPayloadSerializer
+    {
+        public object Deserialize(Type payloadType, ReadOnlySpan<byte> payload)
+        {
+            if (payloadType != typeof(string))
+            {
+                throw new NotSupportedException();
+            }
+
+            var text = Encoding.UTF8.GetString(payload);
+            return text.StartsWith("prefix:", StringComparison.Ordinal) ? text["prefix:".Length..] : text;
+        }
+
+        public byte[] Serialize(Type payloadType, object? value) =>
+            Encoding.UTF8.GetBytes("prefix:" + (value as string ?? string.Empty));
+    }
+
+    sealed class Int32Serializer : IMqttPayloadSerializer
+    {
+        public object Deserialize(Type payloadType, ReadOnlySpan<byte> payload)
+        {
+            if (payloadType != typeof(int))
+            {
+                throw new NotSupportedException();
+            }
+
+            return int.Parse(Encoding.UTF8.GetString(payload));
+        }
+
+        public byte[] Serialize(Type payloadType, object? value)
+        {
+            if (payloadType != typeof(int))
+            {
+                throw new NotSupportedException();
+            }
+
+            return Encoding.UTF8.GetBytes(((int)value!).ToString());
+        }
+    }
+
+    sealed class TemperatureReading
+    {
+        public string DeviceId { get; init; } = string.Empty;
+
+        public double Celsius { get; init; }
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt/DefaultMqttPayloadSerializer.cs
+++ b/Observables.Mqtt/Observables.Mqtt/DefaultMqttPayloadSerializer.cs
@@ -1,0 +1,44 @@
+namespace Observables.Mqtt;
+
+/// <summary>
+/// Default serializer: raw <see cref="byte"/>[] / UTF-8 <see cref="string"/> via
+/// <see cref="PrimitiveMqttPayloadSerializer"/>; JSON for other types on net8.0+.
+/// </summary>
+public sealed class DefaultMqttPayloadSerializer : IMqttPayloadSerializer
+{
+    public static DefaultMqttPayloadSerializer Instance { get; } = new();
+
+    DefaultMqttPayloadSerializer()
+    {
+    }
+
+    public object Deserialize(Type payloadType, ReadOnlySpan<byte> payload)
+    {
+        if (payloadType == typeof(byte[]) || payloadType == typeof(string))
+        {
+            return PrimitiveMqttPayloadSerializer.Instance.Deserialize(payloadType, payload);
+        }
+
+#if NETSTANDARD2_0
+        throw new NotSupportedException(
+            "Deserializing MQTT payloads to types other than byte[] or string requires net8.0 or later.");
+#else
+        return JsonMqttPayloadSerializer.Instance.Deserialize(payloadType, payload);
+#endif
+    }
+
+    public byte[] Serialize(Type payloadType, object? value)
+    {
+        if (payloadType == typeof(byte[]) || payloadType == typeof(string))
+        {
+            return PrimitiveMqttPayloadSerializer.Instance.Serialize(payloadType, value);
+        }
+
+#if NETSTANDARD2_0
+        throw new NotSupportedException(
+            "Serializing MQTT payloads for types other than byte[] or string requires net8.0 or later.");
+#else
+        return JsonMqttPayloadSerializer.Instance.Serialize(payloadType, value);
+#endif
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt/DelegateMqttPayloadSerializer.cs
+++ b/Observables.Mqtt/Observables.Mqtt/DelegateMqttPayloadSerializer.cs
@@ -1,0 +1,9 @@
+namespace Observables.Mqtt;
+
+internal sealed class DelegateMqttPayloadSerializer<T>(Func<byte[], T> deserialize, Func<T, byte[]> serialize)
+    : IMqttPayloadSerializer<T>
+{
+    public T Deserialize(ReadOnlySpan<byte> payload) => deserialize(payload.ToArray());
+
+    public byte[] Serialize(T value) => serialize(value);
+}

--- a/Observables.Mqtt/Observables.Mqtt/IMqttPayloadSerializer.cs
+++ b/Observables.Mqtt/Observables.Mqtt/IMqttPayloadSerializer.cs
@@ -1,0 +1,17 @@
+namespace Observables.Mqtt;
+
+/// <summary>Converts MQTT application message payloads to and from CLR values.</summary>
+/// <remarks>
+/// The default implementation supports <see cref="byte"/>[] and <see cref="string"/> only.
+/// Register a custom IMqttPayloadSerializer via <see cref="MqttPayloadSerializers.Current"/>,
+/// or a typed IMqttPayloadSerializer{T} via <see cref="MqttPayloadSerializers.Register{T}(IMqttPayloadSerializer{T})"/>.
+/// Convenience overloads: <see cref="MqttPayloadSerializerExtensions"/>.
+/// </remarks>
+public interface IMqttPayloadSerializer
+{
+    /// <summary>Deserializes a payload to <paramref name="payloadType"/>.</summary>
+    object Deserialize(Type payloadType, ReadOnlySpan<byte> payload);
+
+    /// <summary>Serializes <paramref name="value"/> to a wire payload.</summary>
+    byte[] Serialize(Type payloadType, object? value);
+}

--- a/Observables.Mqtt/Observables.Mqtt/IMqttPayloadSerializerOfT.cs
+++ b/Observables.Mqtt/Observables.Mqtt/IMqttPayloadSerializerOfT.cs
@@ -1,0 +1,11 @@
+namespace Observables.Mqtt;
+
+/// <summary>Typed MQTT payload serializer for a single CLR type.</summary>
+public interface IMqttPayloadSerializer<T>
+{
+    /// <summary>Deserializes a payload to <typeparamref name="T"/>.</summary>
+    T Deserialize(ReadOnlySpan<byte> payload);
+
+    /// <summary>Serializes <paramref name="value"/> to a wire payload.</summary>
+    byte[] Serialize(T value);
+}

--- a/Observables.Mqtt/Observables.Mqtt/JsonMqttPayloadSerializer.cs
+++ b/Observables.Mqtt/Observables.Mqtt/JsonMqttPayloadSerializer.cs
@@ -1,0 +1,43 @@
+#if !NETSTANDARD2_0
+using System.Text;
+using System.Text.Json;
+
+namespace Observables.Mqtt;
+
+/// <summary>UTF-8 JSON serializer for complex MQTT payloads (net8.0+).</summary>
+public sealed class JsonMqttPayloadSerializer : IMqttPayloadSerializer
+{
+    public static JsonMqttPayloadSerializer Instance { get; } = new();
+
+    public static JsonSerializerOptions DefaultOptions { get; } = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    JsonMqttPayloadSerializer()
+    {
+    }
+
+    public object Deserialize(Type payloadType, ReadOnlySpan<byte> payload)
+    {
+        var json = Encoding.UTF8.GetString(payload);
+        var value = JsonSerializer.Deserialize(json, payloadType, DefaultOptions);
+        if (value is null)
+        {
+            throw new InvalidOperationException("MQTT payload deserialized to null.");
+        }
+
+        return value;
+    }
+
+    public byte[] Serialize(Type payloadType, object? value)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value, payloadType, DefaultOptions));
+    }
+}
+#endif

--- a/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
@@ -1,22 +1,13 @@
-using System.Text;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
 using R3;
-#if NETSTANDARD2_0
-#else
-using System.Text.Json;
-#endif
 
 namespace Observables.Mqtt;
 
 /// <summary>Bridges MQTT client APIs to R3 <see cref="Observable{T}"/>.</summary>
 public static class MqttObservable
 {
-#if NETSTANDARD2_0
-#else
-    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-#endif
 
     public static Observable<Unit> FromPublish(
         IMqttClient client,
@@ -56,7 +47,7 @@ public static class MqttObservable
                     var payload = e.ApplicationMessage.PayloadSegment.Count == 0
                         ? Array.Empty<byte>()
                         : e.ApplicationMessage.PayloadSegment.ToArray();
-                    observer.OnNext(DeserializePayload<T>(payload));
+                    observer.OnNext(MqttPayload.Deserialize<T>(payload));
                 }
                 catch (Exception ex)
                 {
@@ -82,33 +73,6 @@ public static class MqttObservable
                 client.ApplicationMessageReceivedAsync -= Handler;
             }
         });
-
-    internal static T DeserializePayload<T>(byte[] payload)
-    {
-        if (typeof(T) == typeof(byte[]))
-        {
-            return (T)(object)payload;
-        }
-
-        if (typeof(T) == typeof(string))
-        {
-            return (T)(object)Encoding.UTF8.GetString(payload);
-        }
-
-#if NETSTANDARD2_0
-        throw new NotSupportedException(
-            "Deserializing MQTT payloads to types other than byte[] or string requires net8.0 or later.");
-#else
-        var json = Encoding.UTF8.GetString(payload);
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        if (value is null)
-        {
-            throw new InvalidOperationException("MQTT payload deserialized to null.");
-        }
-
-        return value;
-#endif
-    }
 
     static bool TopicMatches(string filter, string? topic)
     {

--- a/Observables.Mqtt/Observables.Mqtt/MqttPayload.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttPayload.cs
@@ -1,0 +1,7 @@
+namespace Observables.Mqtt;
+
+/// <summary>Payload conversion helpers shared by R3 and Reactive MQTT bridges.</summary>
+internal static class MqttPayload
+{
+    internal static T Deserialize<T>(byte[] payload) => MqttPayloadSerializers.Deserialize<T>(payload);
+}

--- a/Observables.Mqtt/Observables.Mqtt/MqttPayloadSerializerExtensions.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttPayloadSerializerExtensions.cs
@@ -1,0 +1,25 @@
+namespace Observables.Mqtt;
+
+/// <summary>Convenience overloads for <see cref="IMqttPayloadSerializer"/> and <see cref="IMqttPayloadSerializer{T}"/>.</summary>
+public static class MqttPayloadSerializerExtensions
+{
+    /// <summary>Deserializes a payload buffer to <paramref name="payloadType"/>.</summary>
+    public static object Deserialize(this IMqttPayloadSerializer serializer, Type payloadType, byte[] payload) =>
+        serializer.Deserialize(payloadType, (ReadOnlySpan<byte>)payload);
+
+    /// <summary>Deserializes a payload to <typeparamref name="T"/>.</summary>
+    public static T Deserialize<T>(this IMqttPayloadSerializer serializer, ReadOnlySpan<byte> payload) =>
+        (T)serializer.Deserialize(typeof(T), payload);
+
+    /// <summary>Deserializes a payload buffer to <typeparamref name="T"/>.</summary>
+    public static T Deserialize<T>(this IMqttPayloadSerializer serializer, byte[] payload) =>
+        serializer.Deserialize<T>((ReadOnlySpan<byte>)payload);
+
+    /// <summary>Serializes <paramref name="value"/> to a wire payload.</summary>
+    public static byte[] Serialize<T>(this IMqttPayloadSerializer serializer, T value) =>
+        serializer.Serialize(typeof(T), value);
+
+    /// <summary>Deserializes a payload buffer to <typeparamref name="T"/>.</summary>
+    public static T Deserialize<T>(this IMqttPayloadSerializer<T> serializer, byte[] payload) =>
+        serializer.Deserialize((ReadOnlySpan<byte>)payload);
+}

--- a/Observables.Mqtt/Observables.Mqtt/MqttPayloadSerializers.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttPayloadSerializers.cs
@@ -1,0 +1,79 @@
+namespace Observables.Mqtt;
+
+/// <summary>Global MQTT payload serializer used by <see cref="MqttObservable"/> and generated proxies.</summary>
+public static class MqttPayloadSerializers
+{
+    static IMqttPayloadSerializer s_current = DefaultMqttPayloadSerializer.Instance;
+    static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, object> s_typed = new();
+
+    /// <summary>Fallback serializer when no typed registration exists for <typeparamref name="T"/>.</summary>
+    public static IMqttPayloadSerializer Current
+    {
+        get => s_current;
+        set => s_current = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Registers a typed serializer. Takes precedence over <see cref="Current"/> for that <typeparamref name="T"/>.</summary>
+    public static void Register<T>(IMqttPayloadSerializer<T> serializer) =>
+        s_typed[typeof(T)] = serializer ?? throw new ArgumentNullException(nameof(serializer));
+
+    /// <summary>Registers <typeparamref name="T"/> using a non-generic <see cref="IMqttPayloadSerializer"/>.</summary>
+    public static void Register<T>(IMqttPayloadSerializer serializer) =>
+        Register(new NonGenericMqttPayloadSerializerAdapter<T>(
+            serializer ?? throw new ArgumentNullException(nameof(serializer))));
+
+    /// <summary>Registers a typed serializer from delegates (<paramref name="deserialize"/> receives a copied payload buffer).</summary>
+    public static void Register<T>(Func<byte[], T> deserialize, Func<T, byte[]> serialize) =>
+        Register(new DelegateMqttPayloadSerializer<T>(deserialize, serialize));
+
+    /// <summary>Removes a typed registration, if present.</summary>
+    public static bool Unregister<T>() => s_typed.TryRemove(typeof(T), out _);
+
+    /// <summary>Deserializes a payload using <see cref="Current"/>.</summary>
+    public static object Deserialize(Type payloadType, ReadOnlySpan<byte> payload) =>
+        Current.Deserialize(payloadType, payload);
+
+    /// <summary>Deserializes a payload buffer using <see cref="Current"/>.</summary>
+    public static object Deserialize(Type payloadType, byte[] payload) =>
+        Current.Deserialize(payloadType, payload);
+
+    public static T Deserialize<T>(ReadOnlySpan<byte> payload)
+    {
+        if (TryGetTypedSerializer<T>(out var typed))
+        {
+            return typed.Deserialize(payload);
+        }
+
+        return Current.Deserialize<T>(payload);
+    }
+
+    /// <summary>Deserializes a payload buffer to <typeparamref name="T"/>.</summary>
+    public static T Deserialize<T>(byte[] payload) =>
+        Deserialize<T>((ReadOnlySpan<byte>)payload);
+
+    /// <summary>Serializes <paramref name="value"/> using <see cref="Current"/>.</summary>
+    public static byte[] Serialize(Type payloadType, object? value) =>
+        Current.Serialize(payloadType, value);
+
+    public static byte[] Serialize<T>(T value)
+    {
+        if (TryGetTypedSerializer<T>(out var typed))
+        {
+            return typed.Serialize(value!);
+        }
+
+        return Current.Serialize<T>(value);
+    }
+
+    static bool TryGetTypedSerializer<T>(out IMqttPayloadSerializer<T> serializer)
+    {
+        if (s_typed.TryGetValue(typeof(T), out var instance) && instance is IMqttPayloadSerializer<T> typed)
+        {
+            serializer = typed;
+            return true;
+        }
+
+        serializer = null!;
+        return false;
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt/NonGenericMqttPayloadSerializerAdapter.cs
+++ b/Observables.Mqtt/Observables.Mqtt/NonGenericMqttPayloadSerializerAdapter.cs
@@ -1,0 +1,10 @@
+namespace Observables.Mqtt;
+
+internal sealed class NonGenericMqttPayloadSerializerAdapter<T>(IMqttPayloadSerializer serializer)
+    : IMqttPayloadSerializer<T>
+{
+    public T Deserialize(ReadOnlySpan<byte> payload) =>
+        (T)serializer.Deserialize(typeof(T), payload);
+
+    public byte[] Serialize(T value) => serializer.Serialize(typeof(T), value);
+}

--- a/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
+++ b/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
@@ -17,6 +17,9 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <!-- Source-only polyfills for span/text APIs missing on netstandard2.0 (see eng/NetStandard20.props). -->
+  <Import Project="..\..\eng\NetStandard20.props" Condition="Exists('..\..\eng\NetStandard20.props')" />
+
   <ItemGroup>
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="R3" Version="1.3.0" />

--- a/Observables.Mqtt/Observables.Mqtt/PrimitiveMqttPayloadSerializer.cs
+++ b/Observables.Mqtt/Observables.Mqtt/PrimitiveMqttPayloadSerializer.cs
@@ -1,0 +1,53 @@
+using System.Text;
+
+namespace Observables.Mqtt;
+
+/// <summary>Built-in serializer for raw <see cref="byte"/>[] and UTF-8 <see cref="string"/> payloads.</summary>
+public sealed class PrimitiveMqttPayloadSerializer : IMqttPayloadSerializer
+{
+    public static PrimitiveMqttPayloadSerializer Instance { get; } = new();
+
+    PrimitiveMqttPayloadSerializer()
+    {
+    }
+
+    public object Deserialize(Type payloadType, ReadOnlySpan<byte> payload)
+    {
+        if (payloadType == typeof(byte[]))
+        {
+            return payload.ToArray();
+        }
+
+        if (payloadType == typeof(string))
+        {
+            return Encoding.UTF8.GetString(payload);
+        }
+
+        throw CreateUnsupportedException(payloadType, deserialize: true);
+    }
+
+    public byte[] Serialize(Type payloadType, object? value)
+    {
+        if (payloadType == typeof(byte[]))
+        {
+            return value is byte[] bytes ? bytes : Array.Empty<byte>();
+        }
+
+        if (payloadType == typeof(string))
+        {
+            return Encoding.UTF8.GetBytes(value as string ?? string.Empty);
+        }
+
+        throw CreateUnsupportedException(payloadType, deserialize: false);
+    }
+
+    static NotSupportedException CreateUnsupportedException(Type payloadType, bool deserialize)
+    {
+        var direction = deserialize ? "Deserialize" : "Serialize";
+        return new NotSupportedException(
+            $"{direction} for MQTT payload type '{payloadType.FullName}' is not supported by the built-in serializer. "
+            + "Register IMqttPayloadSerializer<T> via MqttPayloadSerializers.Register<T>, "
+            + "or assign a custom IMqttPayloadSerializer to MqttPayloadSerializers.Current "
+            + "(for example one that wraps System.Text.Json, Newtonsoft.Json, or Protobuf).");
+    }
+}

--- a/docs/design/mqtt.md
+++ b/docs/design/mqtt.md
@@ -63,7 +63,7 @@ ISensorHub hub = MqttService.For<ISensorHub>(client);
 - **入口对齐 SignalR / RestAPI**：`MqttService.For<T>(IMqttClient)` + `RegisterGeneratedFactory`（模块初始化器，无反射，AOT 友好）。
 - **订阅**为**属性**（无参）；**发布**为**方法**（参数用于 topic 模板占位符）。订阅 topic **不支持** `{param}` 占位符（OBS5006）。
 - **Topic 模板**：`{param}` 段与方法参数名绑定；`+` / `#` 通配符保留在模板字面量中。
-- **载荷**：首版以 UTF-8 字符串 / 空 payload 为主；JSON 反序列化见运行时 `MqttObservable`（带 trim/AOT 警告）。
+- **载荷**：`MqttPayloadSerializers`（默认 `DefaultMqttPayloadSerializer`：`string`/`byte[]` 原始 UTF-8，net8+ 其余类型走 STJ JSON）。可 `Register<T>` 或替换 `Current`（`IMqttPayloadSerializer` / `IMqttPayloadSerializer<T>`）；netstandard2.0 仅原始类型。
 
 ### 3.2 扩展模型（可选，次优先级）
 

--- a/eng/NetStandard20.props
+++ b/eng/NetStandard20.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- Source-only polyfills for APIs missing on netstandard2.0 (e.g. Encoding.GetString(ReadOnlySpan<byte>)). -->
+  <!-- Scoped to runtime projects that do not reference Observables.SourceGenerators.Shared (Polyfill would duplicate). -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Polyfill" Version="10.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Add `IMqttPayloadSerializer` / `IMqttPayloadSerializer<T>` and `MqttPayloadSerializers` registry with typed `Register<T>` overloads
- Default serializer: primitives + STJ JSON on net8+ (`DefaultMqttPayloadSerializer` / `JsonMqttPayloadSerializer`)
- Wire `MqttObservable` and `SystemReactiveMqttAdapter` through the registry
- Add `eng/NetStandard20.props` Polyfill for netstandard2.0; unit tests and design doc update

## Test plan

- [x] `dotnet test` Observables.Mqtt.Tests (12 tests) and Mqtt.Reactive.Tests (2 E2E)
- [x] `dotnet build` Observables.Mqtt (netstandard2.0 / net8 / net9)
- [ ] CI build-test + pack

Closes #57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Subscribe deserialization behavior is now global and mutable via `Current`/`Register`; default STJ JSON should match prior inline logic, but custom serializers or registration order can change wire compatibility for all MQTT streams in the process.
> 
> **Overview**
> Introduces a **pluggable MQTT payload serialization** layer so subscribe/publish bridges no longer embed ad hoc UTF-8/JSON logic.
> 
> **`MqttPayloadSerializers`** is the global entry point: default **`DefaultMqttPayloadSerializer`** (primitives via **`PrimitiveMqttPayloadSerializer`**, other types via **`JsonMqttPayloadSerializer`** on net8+), with **`Current`** replacement and per-type **`Register<T>`** / **`Unregister<T>`** (typed registrations win over the fallback). **`MqttObservable`** and **`SystemReactiveMqttAdapter`** now deserialize through this registry instead of local **`DeserializePayload`** helpers.
> 
> Adds unit tests for primitives, JSON round-trip, registry precedence, and **`eng/NetStandard20.props`** (Polyfill on netstandard2.0) so span-based APIs compile; design doc **`docs/design/mqtt.md`** documents the new payload model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995eda4f56714ce460610a4d04d5a44781c02493. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->