### PR TITLE
Add ObservableReturnTypeParser for R3/Reactive return-type diagnostics

### DIFF
--- a/Observables.Shared/Observables.SourceGenerators.Shared/Diagnostics/ObservableReturnTypeParser.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/Diagnostics/ObservableReturnTypeParser.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.SourceGenerators.Shared.Diagnostics;
+
+/// <summary>Shared Observable / IObservable return-type validation for interface-proxy generators.</summary>
+public static class ObservableReturnTypeParser
+{
+    static readonly SymbolDisplayFormat DisplayFormat =
+        SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
+    /// <summary>
+    /// Validates return type against the active generator backend (R3 vs System.Reactive).
+    /// </summary>
+    /// <param name="isR3Generator">True when compiling the R3 source generator (SIGNALR_R3, MQTT_R3, etc.).</param>
+    /// <param name="reactiveAdapterMetadataName">
+    /// Fully qualified metadata name of the Reactive bridge type, e.g.
+    /// <c>Observables.SignalR.Reactive.SystemReactiveSignalRAdapter</c>.
+    /// </param>
+    public static bool TryParse(
+        ITypeSymbol returnType,
+        Compilation compilation,
+        bool isR3Generator,
+        string reactiveAdapterMetadataName,
+        INamedTypeSymbol? expectedObservableType,
+        INamedTypeSymbol? unitType,
+        bool requiresUnitPayload,
+        DiagnosticDescriptor unsupportedReturnType,
+        DiagnosticDescriptor systemReactiveNotReferenced,
+        Location? location,
+        List<Diagnostic> diagnostics,
+        out string resultTypeDisplay,
+        out string returnTypeDisplay)
+    {
+        resultTypeDisplay = string.Empty;
+        returnTypeDisplay = returnType.ToDisplayString(DisplayFormat);
+        location ??= Location.None;
+
+        if (returnType is not INamedTypeSymbol named || !named.IsGenericType)
+        {
+            diagnostics.Add(Diagnostic.Create(unsupportedReturnType, location, returnTypeDisplay));
+            return false;
+        }
+
+        var def = named.OriginalDefinition;
+        var metadata = def.MetadataName;
+        var ns = def.ContainingNamespace?.ToDisplayString();
+
+        if (metadata == "IObservable`1" && ns == "System")
+        {
+            if (isR3Generator)
+            {
+                diagnostics.Add(
+                    Diagnostic.Create(systemReactiveNotReferenced, location, returnTypeDisplay));
+                return false;
+            }
+
+            if (compilation.GetTypeByMetadataName(reactiveAdapterMetadataName) is null)
+            {
+                diagnostics.Add(
+                    Diagnostic.Create(systemReactiveNotReferenced, location, returnTypeDisplay));
+                return false;
+            }
+        }
+        else if (metadata == "Observable`1" && ns == "R3")
+        {
+            if (!isR3Generator)
+            {
+                diagnostics.Add(Diagnostic.Create(unsupportedReturnType, location, returnTypeDisplay));
+                return false;
+            }
+        }
+        else if (expectedObservableType is null
+                 || !SymbolEqualityComparer.Default.Equals(def, expectedObservableType))
+        {
+            diagnostics.Add(Diagnostic.Create(unsupportedReturnType, location, returnTypeDisplay));
+            return false;
+        }
+
+        if (named.TypeArguments.Length != 1)
+        {
+            diagnostics.Add(Diagnostic.Create(unsupportedReturnType, location, returnTypeDisplay));
+            return false;
+        }
+
+        resultTypeDisplay = named.TypeArguments[0].ToDisplayString(DisplayFormat);
+
+        if (requiresUnitPayload)
+        {
+            if (unitType is null
+                || !SymbolEqualityComparer.Default.Equals(named.TypeArguments[0], unitType))
+            {
+                diagnostics.Add(Diagnostic.Create(unsupportedReturnType, location, returnTypeDisplay));
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ObservableReturnTypeParser` in `Observables.SourceGenerators.Shared` for shared R3 vs Reactive return-type validation
- Enables SignalR/Mqtt/WebSocket parsers to emit OBS4/5/6xx5 instead of generic unsupported-return errors

## Test plan

- [x] `dotnet build` Observables.SourceGenerators.Shared
- [ ] Follow-up domain PRs (SignalR #61, Mqtt #62, WebSocket #63) consume this helper

Closes #59

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New shared compile-time helper only; no runtime or consumer wiring in this PR.
> 
> **Overview**
> Introduces **`ObservableReturnTypeParser`** in `Observables.SourceGenerators.Shared` so SignalR/Mqtt/WebSocket interface-proxy generators can share one place to validate method return types for **R3 vs System.Reactive**.
> 
> **`TryParse`** checks that returns are a single generic observable type, optionally enforces a **unit** payload, and routes failures to caller-supplied descriptors: **`IObservable<T>`** on an R3 build or without the reactive adapter type → `systemReactiveNotReferenced`; **`R3.Observable<T>`** on a non-R3 build or other mismatches → `unsupportedReturnType`. On success it fills **`resultTypeDisplay`** and **`returnTypeDisplay`** for codegen. Domain generators are expected to wire this in follow-up PRs so users get OBS4/5/6xx5-style diagnostics instead of generic unsupported-return errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713bdcae2c121d6feabbfaaafac3d8c18e964862. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->