### PR TITLE
Wire RestAPI OBS3004 path validation and OBS3005 on R3

### DIFF
--- a/Observables.RestAPI/Observables.RestAPI.GeneratorTests/CoreGeneratorTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.GeneratorTests/CoreGeneratorTests.cs
@@ -46,4 +46,25 @@ public class CoreGeneratorTests
 
         return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
+
+    [Fact]
+    public Task GetUser_path_parameter_mismatch_reports_OBS3004()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            public interface IUserApi
+            {
+                [Get("/users/{id}")]
+                Observable<User> GetUser(int id, int page);
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        Assert.Contains("OBS3004", GeneratorTestHarness.ToSnapshot(output), StringComparison.Ordinal);
+        return Task.CompletedTask;
+    }
 }

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
@@ -347,13 +347,13 @@ namespace {RestApiInternalNamespace}
 
         // Handle Refit Methods
         var refitMethodsArray = refitMethods
-            .Select(m => ParseMethod(m, true, wellKnownTypes, diagnostics))
+            .Select(m => ParseMethod(m, true, httpMethodBaseAttributeSymbol, wellKnownTypes, diagnostics))
             .ToImmutableEquatableArray();
 
         // Only include refit methods discovered on base interfaces here.
         // Do NOT duplicate the current interface's refit methods.
         var derivedRefitMethodsArray = derivedRefitMethods
-            .Select(m => ParseMethod(m, false, wellKnownTypes, diagnostics))
+            .Select(m => ParseMethod(m, false, httpMethodBaseAttributeSymbol, wellKnownTypes, diagnostics))
             .ToImmutableEquatableArray();
 
         // Handle non-refit Methods that aren't static or properties or have a method body
@@ -496,6 +496,79 @@ namespace {RestApiInternalNamespace}
             == true;
     }
 
+    static void ValidatePathTemplate(
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol httpMethodBaseAttributeSymbol,
+        List<Diagnostic> diagnostics)
+    {
+        AttributeData? httpAttr = null;
+        foreach (var attribute in methodSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.InheritsFromOrEquals(httpMethodBaseAttributeSymbol) == true)
+            {
+                httpAttr = attribute;
+                break;
+            }
+        }
+
+        if (httpAttr?.ConstructorArguments is not { Length: 1 } args
+            || args[0].Value is not string path)
+        {
+            return;
+        }
+
+        var placeholders = ExtractPathPlaceholders(path);
+        var paramNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var parameter in methodSymbol.Parameters)
+        {
+            if (!IsCancellationTokenParameter(parameter))
+            {
+                paramNames.Add(parameter.Name);
+            }
+        }
+
+        if (!placeholders.SetEquals(paramNames))
+        {
+            diagnostics.Add(
+                Diagnostic.Create(
+                    DiagnosticDescriptors.PathParameterMismatch,
+                    methodSymbol.Locations.FirstOrDefault(),
+                    methodSymbol.Name));
+        }
+    }
+
+    static HashSet<string> ExtractPathPlaceholders(string path)
+    {
+        var placeholders = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < path.Length; i++)
+        {
+            if (path[i] != '{')
+            {
+                continue;
+            }
+
+            var close = path.IndexOf('}', i + 1);
+            if (close < 0)
+            {
+                break;
+            }
+
+            var name = path.Substring(i + 1, close - i - 1);
+            if (!string.IsNullOrEmpty(name))
+            {
+                placeholders.Add(name);
+            }
+
+            i = close;
+        }
+
+        return placeholders;
+    }
+
+    static bool IsCancellationTokenParameter(IParameterSymbol parameter) =>
+        parameter.Type.Name == "CancellationToken"
+        && parameter.Type.ContainingNamespace?.ToDisplayString() == "System.Threading";
+
     private static ImmutableEquatableArray<TypeConstraint> GenerateConstraints(
         ImmutableArray<ITypeParameterSymbol> typeParameters,
         bool isOverrideOrExplicitImplementation
@@ -592,6 +665,7 @@ namespace {RestApiInternalNamespace}
     private static MethodModel ParseMethod(
         IMethodSymbol methodSymbol,
         bool isImplicitInterface,
+        INamedTypeSymbol httpMethodBaseAttributeSymbol,
         WellKnownTypes wellKnownTypes,
         List<Diagnostic> diagnostics
     )
@@ -633,6 +707,8 @@ namespace {RestApiInternalNamespace}
             wellKnownTypes,
             diagnostics
         );
+
+        ValidatePathTemplate(methodSymbol, httpMethodBaseAttributeSymbol, diagnostics);
 
         var parameters = methodSymbol.Parameters.Select(ParseParameter).ToImmutableEquatableArray();
 
@@ -689,7 +765,7 @@ namespace {RestApiInternalNamespace}
             {
                 diagnostics.Add(
                     Diagnostic.Create(
-                        DiagnosticDescriptors.UnsupportedReturnType,
+                        DiagnosticDescriptors.SystemReactiveNotReferenced,
                         methodSymbol.Locations.FirstOrDefault(),
                         returnType.ToDisplayString()
                     )


### PR DESCRIPTION
## Summary

- Validate HTTP path `{placeholder}` names against method parameters (OBS3004)
- R3 generator emits OBS3005 when interface uses `IObservable<T>`

## Test plan

- [x] `GetUser_path_parameter_mismatch_reports_OBS3004` generator test
- [ ] CI build-test + pack

Closes #60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time generator diagnostics only; no runtime API or auth changes.
> 
> **Overview**
> The RestAPI source generator now **validates HTTP route paths** on attributed methods: `{placeholder}` segments must match the method’s parameters exactly (excluding `CancellationToken`), or it reports **OBS3004**.
> 
> For the **R3** generator flavor, **`IObservable<T>`** on an interface now emits **OBS3005** (`SystemReactiveNotReferenced`) instead of the generic unsupported-return diagnostic, steering users toward the Reactive package.
> 
> A generator test asserts **OBS3004** when the path has `{id}` but the method has extra parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c733b285b27551a88c67039d2b0e423b9eb8a6bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->