### PR TITLE
Link-compile ObservableReturnTypeParser for interface-proxy generators

### DIFF
--- a/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/Observables.Mqtt.R3.SourceGenerators.csproj
+++ b/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/Observables.Mqtt.R3.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.R3.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for MQTT topic proxies → R3 Observable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="R3" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/Observables.Mqtt.Reactive.SourceGenerators.csproj
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/Observables.Mqtt.Reactive.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for MQTT topic proxies → System.Reactive IObservable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="System.Reactive" Version="6.0.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/Observables.SignalR.R3.SourceGenerators.csproj
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/Observables.SignalR.R3.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.R3.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for SignalR hub proxies → R3 Observable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="R3" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/Observables.SignalR.Reactive.SourceGenerators.csproj
+++ b/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/Observables.SignalR.Reactive.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for SignalR hub proxies → System.Reactive IObservable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="System.Reactive" Version="6.0.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Observables.SourceGenerators.InterfaceProxy.props
+++ b/Observables.SourceGenerators.InterfaceProxy.props
@@ -1,0 +1,19 @@
+<Project>
+
+  <!--
+    Interface-proxy generators (SignalR, Mqtt, WebSocket) compile ObservableReturnTypeParser
+    from source so ProjectReference OutputItemType="Analyzer" consumers do not need a separate
+    Observables.SourceGenerators.Shared.dll on the Roslyn analyzer load path.
+    Events / RestAPI generators keep a ProjectReference to Observables.SourceGenerators.Shared.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1573</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared\Observables.SourceGenerators.Shared\Diagnostics\ObservableReturnTypeParser.cs">
+      <Link>Shared\Diagnostics\ObservableReturnTypeParser.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/Observables.WebSocket.R3.SourceGenerators.csproj
+++ b/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/Observables.WebSocket.R3.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.R3.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for WebSocket proxies → R3 Observable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="R3" Version="1.3.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/Observables.WebSocket.Reactive.SourceGenerators.csproj
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/Observables.WebSocket.Reactive.SourceGenerators.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\Observables.SourceGenerators.props" />
+  <Import Project="..\..\Observables.SourceGenerators.InterfaceProxy.props" />
 
   <PropertyGroup>
     <Description>Source generator for WebSocket proxies → System.Reactive IObservable.</Description>
@@ -8,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\Observables.SourceGenerators.Shared.csproj" />
     <PackageReference Include="System.Reactive" Version="6.0.1" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Add `Observables.SourceGenerators.InterfaceProxy.props` to link-compile `ObservableReturnTypeParser.cs` into SignalR, Mqtt, and WebSocket R3/Reactive source generators.
- Remove `ProjectReference` to `Observables.SourceGenerators.Shared` from those six generator projects so `OutputItemType="Analyzer"` test projects no longer hit CS8785 (missing Shared.dll on the Roslyn analyzer load path).
- Events and RestAPI generators are unchanged; NuGet packing via `PackRoslynAnalyzer.targets` still ships Shared.dll alongside generator assemblies.

## Test plan

- [x] `dotnet test Observables.SignalR/Observables.SignalR.Tests` — 5 E2E tests pass (net8.0 + net9.0)
- [x] `dotnet test Observables.SignalR/Observables.SignalR.Reactive.Tests` — 4 E2E tests pass
- [x] `dotnet test Observables.Mqtt/Observables.Mqtt.Tests` — 12 E2E tests pass
- [x] `dotnet test Observables.WebSocket/Observables.WebSocket.Tests` — 4 E2E tests pass
- [x] SignalR / Mqtt / WebSocket R3 generator tests pass
- [ ] CI green after merge

Closes #69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MSBuild-only change to six generator projects; Events/RestAPI and NuGet packing are untouched, with E2E tests reported passing.
> 
> **Overview**
> Fixes **CS8785** for interface-proxy source generators when tests reference them as analyzers (`OutputItemType="Analyzer"`) by **inlining** shared parsing logic instead of loading a separate **`Observables.SourceGenerators.Shared.dll`** on Roslyn’s analyzer path.
> 
> Adds **`Observables.SourceGenerators.InterfaceProxy.props`**, which **link-compiles** `ObservableReturnTypeParser.cs` into the six **SignalR**, **Mqtt**, and **WebSocket** R3/Reactive generator projects. Those projects **drop** the **`ProjectReference`** to **`Observables.SourceGenerators.Shared`**. **Events** and **RestAPI** generators are **unchanged** and still reference Shared; NuGet packing via **`PackRoslynAnalyzer.targets`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e831092e02618a45d3ac547ca88a81ffadd064. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->