### PR TITLE
Add Observables.CodeFixes for runtime and Reactive package diagnostics

### DIFF
--- a/Observables.Shared/Observables.CodeFixes.Tests/CsprojPackageReferenceEditorTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/CsprojPackageReferenceEditorTests.cs
@@ -1,0 +1,65 @@
+namespace Observables.CodeFixes.Tests;
+
+public sealed class CsprojPackageReferenceEditorTests
+{
+    const string SampleCsproj = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+          <ItemGroup>
+            <PackageReference Include="Observables.RestAPI.R3" Version="0.1.0-preview4" />
+          </ItemGroup>
+        </Project>
+        """;
+
+    [Fact]
+    public void AddPackageReferenceIfMissing_appends_to_existing_item_group()
+    {
+        var updated = CsprojPackageReferenceEditor.AddPackageReferenceIfMissing(
+            SampleCsproj,
+            "Observables.RestAPI",
+            version: "0.1.0-preview4");
+
+        Assert.Contains("<PackageReference Include=\"Observables.RestAPI\" Version=\"0.1.0-preview4\" />", updated);
+        Assert.Equal(2, updated.Split("<PackageReference", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void AddPackageReferenceIfMissing_is_idempotent()
+    {
+        var once = CsprojPackageReferenceEditor.AddPackageReferenceIfMissing(
+            SampleCsproj,
+            "Observables.RestAPI.Reactive",
+            version: null);
+        var twice = CsprojPackageReferenceEditor.AddPackageReferenceIfMissing(
+            once,
+            "Observables.RestAPI.Reactive",
+            version: null);
+
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void ReplacePackageReference_swaps_r3_for_reactive()
+    {
+        var updated = CsprojPackageReferenceEditor.ReplacePackageReference(
+            SampleCsproj,
+            "Observables.RestAPI.R3",
+            "Observables.RestAPI.Reactive",
+            version: "0.1.0-preview4");
+
+        Assert.DoesNotContain("Observables.RestAPI.R3", updated);
+        Assert.Contains("<PackageReference Include=\"Observables.RestAPI.Reactive\" Version=\"0.1.0-preview4\" />", updated);
+    }
+
+    [Fact]
+    public void TryGetPackageVersion_reads_version_attribute()
+    {
+        var version = CsprojPackageReferenceEditor.TryGetPackageVersion(
+            SampleCsproj,
+            "Observables.RestAPI.R3");
+
+        Assert.Equal("0.1.0-preview4", version);
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj
+++ b/Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Observables.CodeFixes.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.CodeFixes\Observables.CodeFixes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Shared/Observables.CodeFixes.Tests/ObservablesPackageReferenceMappingsTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/ObservablesPackageReferenceMappingsTests.cs
@@ -1,0 +1,20 @@
+namespace Observables.CodeFixes.Tests;
+
+public sealed class ObservablesPackageReferenceMappingsTests
+{
+    [Fact]
+    public void RuntimePackageByDiagnosticId_covers_core_not_referenced_diagnostics()
+    {
+        Assert.Equal(
+            ["OBS3002", "OBS4002", "OBS5002", "OBS6002"],
+            ObservablesPackageReferenceMappings.RuntimePackageByDiagnosticId.Keys.OrderBy(id => id, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void ReactivePackageByDiagnosticId_covers_reactive_package_diagnostics()
+    {
+        Assert.Equal(
+            ["OBS3005", "OBS4005", "OBS5005", "OBS6005"],
+            ObservablesPackageReferenceMappings.ReactivePackageByDiagnosticId.Keys.OrderBy(id => id, StringComparer.Ordinal));
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/AddRuntimePackageReferenceCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/AddRuntimePackageReferenceCodeFixProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddRuntimePackageReferenceCodeFixProvider)), Shared]
+public sealed class AddRuntimePackageReferenceCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesPackageReferenceMappings.RuntimePackageByDiagnosticId.Keys.ToImmutableArray();
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (diagnostic is null)
+            return Task.CompletedTask;
+
+        if (!ObservablesPackageReferenceMappings.TryGetRuntimePackage(
+                diagnostic.Id,
+                out var packageId))
+            return Task.CompletedTask;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: $"Add package reference to '{packageId}'",
+                createChangedSolution: cancellationToken =>
+                    AddPackageReferenceAsync(context.Document.Project, packageId, version: null, cancellationToken),
+                equivalenceKey: $"{nameof(AddRuntimePackageReferenceCodeFixProvider)}:{packageId}"),
+            diagnostic);
+
+        return Task.CompletedTask;
+    }
+
+    internal static Task<Solution> AddPackageReferenceAsync(
+        Project project,
+        string packageId,
+        string? version,
+        CancellationToken cancellationToken)
+    {
+        return ProjectFileWriter.ApplyProjectFileTransformAsync(
+            project.Solution,
+            project,
+            content =>
+            {
+                var inferredVersion = version
+                    ?? InferVersionFromSiblingPackages(content, packageId);
+                return CsprojPackageReferenceEditor.AddPackageReferenceIfMissing(
+                    content,
+                    packageId,
+                    inferredVersion);
+            },
+            cancellationToken);
+    }
+
+    internal static string? InferVersionFromSiblingPackages(string csprojContent, string runtimePackageId)
+    {
+        foreach (var pair in ObservablesPackageReferenceMappings.R3PackageByReactivePackageId)
+        {
+            if (!pair.Value.StartsWith(runtimePackageId + ".", StringComparison.Ordinal))
+                continue;
+
+            var version = CsprojPackageReferenceEditor.TryGetPackageVersion(csprojContent, pair.Value);
+            if (version is not null)
+                return version;
+        }
+
+        foreach (var reactivePackage in ObservablesPackageReferenceMappings.ReactivePackageByDiagnosticId.Values)
+        {
+            if (!reactivePackage.StartsWith(runtimePackageId + ".", StringComparison.Ordinal))
+                continue;
+
+            var version = CsprojPackageReferenceEditor.TryGetPackageVersion(csprojContent, reactivePackage);
+            if (version is not null)
+                return version;
+        }
+
+        return null;
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/CsprojPackageReferenceEditor.cs
+++ b/Observables.Shared/Observables.CodeFixes/CsprojPackageReferenceEditor.cs
@@ -1,0 +1,105 @@
+using System.Text.RegularExpressions;
+
+namespace Observables.CodeFixes;
+
+internal static class CsprojPackageReferenceEditor
+{
+    static readonly Regex PackageReferencePattern = new(
+        "<PackageReference\\s+Include\\s*=\\s*\"(?<id>[^\"]+)\"(?:\\s+Version\\s*=\\s*\"(?<version>[^\"]+)\")?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static bool ContainsPackageReference(string csprojContent, string packageId)
+    {
+        foreach (Match match in PackageReferencePattern.Matches(csprojContent))
+        {
+            if (string.Equals(match.Groups["id"].Value, packageId, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    public static string? TryGetPackageVersion(string csprojContent, string packageId)
+    {
+        foreach (Match match in PackageReferencePattern.Matches(csprojContent))
+        {
+            if (!string.Equals(match.Groups["id"].Value, packageId, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var version = match.Groups["version"].Value;
+            return string.IsNullOrEmpty(version) ? null : version;
+        }
+
+        return null;
+    }
+
+    public static string AddPackageReferenceIfMissing(string csprojContent, string packageId, string? version)
+    {
+        if (ContainsPackageReference(csprojContent, packageId))
+            return csprojContent;
+
+        var packageLine = version is null
+            ? $"    <PackageReference Include=\"{packageId}\" />"
+            : $"    <PackageReference Include=\"{packageId}\" Version=\"{version}\" />";
+
+        var lastPackageReference = csprojContent.LastIndexOf("<PackageReference", StringComparison.OrdinalIgnoreCase);
+        if (lastPackageReference >= 0)
+        {
+            var itemGroupEnd = csprojContent.IndexOf("</ItemGroup>", lastPackageReference, StringComparison.OrdinalIgnoreCase);
+            if (itemGroupEnd >= 0)
+                return csprojContent.Insert(itemGroupEnd, "\n" + packageLine);
+        }
+
+        var projectEnd = csprojContent.LastIndexOf("</Project>", StringComparison.OrdinalIgnoreCase);
+        if (projectEnd < 0)
+            throw new InvalidOperationException("The project file does not contain a </Project> element.");
+
+        var block = "\n  <ItemGroup>\n" + packageLine + "\n  </ItemGroup>\n";
+        return csprojContent.Insert(projectEnd, block);
+    }
+
+    public static string ReplacePackageReference(string csprojContent, string oldPackageId, string newPackageId, string? version)
+    {
+        if (ContainsPackageReference(csprojContent, newPackageId))
+            return RemovePackageReference(csprojContent, oldPackageId);
+
+        var updated = Regex.Replace(
+            csprojContent,
+            $"(<PackageReference\\s+Include\\s*=\\s*\"){Regex.Escape(oldPackageId)}(\")",
+            match => $"{match.Groups[1].Value}{newPackageId}{match.Groups[2].Value}",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        if (!string.Equals(updated, csprojContent, StringComparison.Ordinal))
+        {
+            if (version is not null)
+                updated = SetPackageVersion(updated, newPackageId, version);
+
+            return updated;
+        }
+
+        return AddPackageReferenceIfMissing(RemovePackageReference(csprojContent, oldPackageId), newPackageId, version);
+    }
+
+    public static string RemovePackageReference(string csprojContent, string packageId)
+    {
+        return Regex.Replace(
+            csprojContent,
+            "\\s*<PackageReference\\s+Include\\s*=\\s*\"" + Regex.Escape(packageId) +
+            "\"(?:\\s+Version\\s*=\\s*\"[^\"]+\")?\\s*/>\\s*",
+            "\n",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    static string SetPackageVersion(string csprojContent, string packageId, string version)
+    {
+        var pattern =
+            "(<PackageReference\\s+Include\\s*=\\s*\"" + Regex.Escape(packageId) +
+            "\")(?:\\s+Version\\s*=\\s*\"[^\"]+\")?(\\s*/>)";
+
+        return Regex.Replace(
+            csprojContent,
+            pattern,
+            $"$1 Version=\"{version}\"$2",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj
+++ b/Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Observables.CodeFixes</RootNamespace>
+    <Description>Roslyn code fixes for Observables source-generator diagnostics.</Description>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RS2001;RS2002;RS1035</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Observables.CodeFixes.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Shared/Observables.CodeFixes/ObservablesPackageReferenceMappings.cs
+++ b/Observables.Shared/Observables.CodeFixes/ObservablesPackageReferenceMappings.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+
+namespace Observables.CodeFixes;
+
+internal static class ObservablesPackageReferenceMappings
+{
+    internal static readonly ImmutableDictionary<string, string> RuntimePackageByDiagnosticId =
+        new Dictionary<string, string>
+        {
+            ["OBS3002"] = "Observables.RestAPI",
+            ["OBS4002"] = "Observables.SignalR",
+            ["OBS5002"] = "Observables.Mqtt",
+            ["OBS6002"] = "Observables.WebSocket",
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    internal static readonly ImmutableDictionary<string, string> ReactivePackageByDiagnosticId =
+        new Dictionary<string, string>
+        {
+            ["OBS3005"] = "Observables.RestAPI.Reactive",
+            ["OBS4005"] = "Observables.SignalR.Reactive",
+            ["OBS5005"] = "Observables.Mqtt.Reactive",
+            ["OBS6005"] = "Observables.WebSocket.Reactive",
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    internal static readonly ImmutableDictionary<string, string> R3PackageByReactivePackageId =
+        new Dictionary<string, string>
+        {
+            ["Observables.RestAPI.Reactive"] = "Observables.RestAPI.R3",
+            ["Observables.SignalR.Reactive"] = "Observables.SignalR.R3",
+            ["Observables.Mqtt.Reactive"] = "Observables.Mqtt.R3",
+            ["Observables.WebSocket.Reactive"] = "Observables.WebSocket.R3",
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    internal static bool TryGetRuntimePackage(string diagnosticId, out string packageId) =>
+        RuntimePackageByDiagnosticId.TryGetValue(diagnosticId, out packageId!);
+
+    internal static bool TryGetReactivePackage(string diagnosticId, out string packageId) =>
+        ReactivePackageByDiagnosticId.TryGetValue(diagnosticId, out packageId!);
+}

--- a/Observables.Shared/Observables.CodeFixes/ProjectFileWriter.cs
+++ b/Observables.Shared/Observables.CodeFixes/ProjectFileWriter.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.CodeFixes;
+
+internal static class ProjectFileWriter
+{
+    public static Task<Solution> ApplyProjectFileTransformAsync(
+        Solution solution,
+        Project project,
+        Func<string, string> transform,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (project.FilePath is not { Length: > 0 } path)
+            return Task.FromResult(solution);
+
+        var original = File.ReadAllText(path);
+        var updated = transform(original);
+        if (string.Equals(original, updated, StringComparison.Ordinal))
+            return Task.FromResult(solution);
+
+        File.WriteAllText(path, updated);
+        return Task.FromResult(solution);
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/SwitchToReactivePackageCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/SwitchToReactivePackageCodeFixProvider.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SwitchToReactivePackageCodeFixProvider)), Shared]
+public sealed class SwitchToReactivePackageCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesPackageReferenceMappings.ReactivePackageByDiagnosticId.Keys.ToImmutableArray();
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (diagnostic is null)
+            return Task.CompletedTask;
+
+        if (!ObservablesPackageReferenceMappings.TryGetReactivePackage(
+                diagnostic.Id,
+                out var reactivePackageId))
+            return Task.CompletedTask;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: $"Add package reference to '{reactivePackageId}'",
+                createChangedSolution: cancellationToken =>
+                    AddReactivePackageAsync(context.Document.Project, reactivePackageId, cancellationToken),
+                equivalenceKey: $"{nameof(SwitchToReactivePackageCodeFixProvider)}:Add:{reactivePackageId}"),
+            diagnostic);
+
+        if (ObservablesPackageReferenceMappings.R3PackageByReactivePackageId.TryGetValue(
+                reactivePackageId,
+                out var r3PackageId))
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Switch to '{reactivePackageId}' package",
+                    createChangedSolution: cancellationToken =>
+                        SwitchToReactivePackageAsync(
+                            context.Document.Project,
+                            r3PackageId,
+                            reactivePackageId,
+                            cancellationToken),
+                    equivalenceKey: $"{nameof(SwitchToReactivePackageCodeFixProvider)}:Switch:{reactivePackageId}"),
+                diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal static Task<Solution> AddReactivePackageAsync(
+        Project project,
+        string reactivePackageId,
+        CancellationToken cancellationToken)
+    {
+        return ProjectFileWriter.ApplyProjectFileTransformAsync(
+            project.Solution,
+            project,
+            content =>
+            {
+                var version = InferReactivePackageVersion(content, reactivePackageId);
+                return CsprojPackageReferenceEditor.AddPackageReferenceIfMissing(
+                    content,
+                    reactivePackageId,
+                    version);
+            },
+            cancellationToken);
+    }
+
+    internal static Task<Solution> SwitchToReactivePackageAsync(
+        Project project,
+        string r3PackageId,
+        string reactivePackageId,
+        CancellationToken cancellationToken)
+    {
+        return ProjectFileWriter.ApplyProjectFileTransformAsync(
+            project.Solution,
+            project,
+            content =>
+            {
+                var version = CsprojPackageReferenceEditor.TryGetPackageVersion(content, r3PackageId)
+                    ?? InferReactivePackageVersion(content, reactivePackageId);
+                return CsprojPackageReferenceEditor.ReplacePackageReference(
+                    content,
+                    r3PackageId,
+                    reactivePackageId,
+                    version);
+            },
+            cancellationToken);
+    }
+
+    internal static string? InferReactivePackageVersion(string csprojContent, string reactivePackageId)
+    {
+        if (ObservablesPackageReferenceMappings.R3PackageByReactivePackageId.TryGetValue(
+                reactivePackageId,
+                out var r3PackageId))
+        {
+            var version = CsprojPackageReferenceEditor.TryGetPackageVersion(csprojContent, r3PackageId);
+            if (version is not null)
+                return version;
+        }
+
+        return CsprojPackageReferenceEditor.TryGetPackageVersion(csprojContent, reactivePackageId);
+    }
+}

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -24,6 +24,10 @@
 
     <Project Path="Observables.Shared/Observables.SourceGenerators.Shared/Observables.SourceGenerators.Shared.csproj" />
 
+    <Project Path="Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj" />
+
+    <Project Path="Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj" />
+
   </Folder>
 
   <Folder Name="/Events/">

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -206,6 +206,16 @@ sealed class Build : NukeBuild
                     && e.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
                 Assert.True(hasAnalyzer, $"{packageId}: missing analyzer DLL under analyzers/dotnet/roslyn4.12/cs/");
 
+                if (packageId.StartsWith("Observables.RestAPI.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.SignalR.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.Mqtt.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.WebSocket.", StringComparison.Ordinal))
+                {
+                    Assert.True(
+                        entries.Contains("analyzers/dotnet/roslyn4.12/cs/Observables.CodeFixes.dll"),
+                        $"{packageId}: missing Observables.CodeFixes.dll under analyzers/dotnet/roslyn4.12/cs/");
+                }
+
                 if (packageId.StartsWith("Observables.Events.", StringComparison.Ordinal))
                 {
                     Assert.True(

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -16,6 +16,8 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ObservablesAnalyzerRoslynFolder>analyzers/dotnet/roslyn4.12/cs</ObservablesAnalyzerRoslynFolder>
     <ObservablesSharedGeneratorProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.SourceGenerators.Shared/Observables.SourceGenerators.Shared.csproj</ObservablesSharedGeneratorProject>
+    <ObservablesCodeFixesProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj</ObservablesCodeFixesProject>
+    <ObservablesCodeFixesOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/bin/$(Configuration)/netstandard2.0/'))</ObservablesCodeFixesOutputDir>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 

--- a/eng/PackRoslynAnalyzer.targets
+++ b/eng/PackRoslynAnalyzer.targets
@@ -13,11 +13,14 @@
   <PropertyGroup>
     <ObservablesPackSharedGeneratorProject Condition="'$(ObservablesPackSharedGeneratorProject)' == ''">$(ObservablesSharedGeneratorProject)</ObservablesPackSharedGeneratorProject>
     <ObservablesPackSharedOutputDir Condition="'$(ObservablesPackSharedOutputDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.SourceGenerators.Shared/bin/$(Configuration)/netstandard2.0/'))</ObservablesPackSharedOutputDir>
+    <ObservablesPackCodeFixesProject Condition="'$(ObservablesPackCodeFixesProject)' == ''">$(ObservablesCodeFixesProject)</ObservablesPackCodeFixesProject>
+    <ObservablesPackCodeFixesOutputDir Condition="'$(ObservablesPackCodeFixesOutputDir)' == ''">$(ObservablesCodeFixesOutputDir)</ObservablesPackCodeFixesOutputDir>
   </PropertyGroup>
 
   <Target Name="ObservablesPackBuildAnalyzerInputs" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="$(ObservablesPackGeneratorProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" />
     <MSBuild Projects="$(ObservablesPackSharedGeneratorProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" />
+    <MSBuild Projects="$(ObservablesPackCodeFixesProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" Condition="'$(ObservablesPackCodeFixesProject)' != ''" />
   </Target>
 
   <Target Name="ObservablesPackIncludeAnalyzers"
@@ -26,14 +29,18 @@
     <PropertyGroup>
       <_ObservablesPackGeneratorDll>$(ObservablesPackGeneratorOutputDir)$(ObservablesPackGeneratorAssemblyName)</_ObservablesPackGeneratorDll>
       <_ObservablesPackSharedDll>$(ObservablesPackSharedOutputDir)Observables.SourceGenerators.Shared.dll</_ObservablesPackSharedDll>
+      <_ObservablesPackCodeFixesDll>$(ObservablesPackCodeFixesOutputDir)Observables.CodeFixes.dll</_ObservablesPackCodeFixesDll>
     </PropertyGroup>
     <Error Condition="!Exists('$(_ObservablesPackGeneratorDll)')"
            Text="Observables pack: missing generator assembly '$(_ObservablesPackGeneratorDll)'." />
     <Error Condition="!Exists('$(_ObservablesPackSharedDll)')"
            Text="Observables pack: missing shared assembly '$(_ObservablesPackSharedDll)'." />
+    <Error Condition="'$(ObservablesPackCodeFixesProject)' != '' and !Exists('$(_ObservablesPackCodeFixesDll)')"
+           Text="Observables pack: missing code fix assembly '$(_ObservablesPackCodeFixesDll)'." />
     <ItemGroup>
       <None Include="$(_ObservablesPackGeneratorDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" />
       <None Include="$(_ObservablesPackSharedDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" />
+      <None Include="$(_ObservablesPackCodeFixesDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" Condition="'$(ObservablesPackCodeFixesProject)' != '' and Exists('$(_ObservablesPackCodeFixesDll)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="build/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="buildTransitive/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

- Add shared `Observables.CodeFixes` Roslyn assembly with code fixes for interface-proxy package diagnostics.
- **OBS3002 / 4002 / 5002 / 6002** → add the domain runtime NuGet package to the project file.
- **OBS3005 / 4005 / 5005 / 6005** → add the Reactive package, or switch from the R3 meta-package when present.
- Pack `Observables.CodeFixes.dll` alongside generator assemblies; `PackVerify` now requires it for RestAPI, SignalR, Mqtt, and WebSocket packages.

## Test plan

- [x] `dotnet test Observables.Shared/Observables.CodeFixes.Tests`
- [x] Nuke `PackVerify` (full solution unit tests + pack + nupkg checks)
- [ ] CI green after merge

Closes #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Code fixes rewrite project files on disk with regex-based XML editing, which can mis-handle unusual csproj layouts; impact is limited to developer tooling and mitigated by unit tests and pack verification.
> 
> **Overview**
> Introduces **`Observables.CodeFixes`**, a shared Roslyn assembly that offers light-bulb fixes for interface-proxy **missing package** diagnostics. **OBS3002 / 4002 / 5002 / 6002** add the domain runtime package; **OBS3005 / 4005 / 5005 / 6005** add the Reactive package or **switch from the R3 meta-package** when it is already referenced, with versions inferred from sibling R3/Reactive references when possible.
> 
> Fixes edit the **`.csproj` on disk** via regex-based helpers (`CsprojPackageReferenceEditor`, `ProjectFileWriter`) rather than Roslyn document edits. **`PackRoslynAnalyzer.targets`** now builds and packs `Observables.CodeFixes.dll` next to generator assemblies, and **PackVerify** asserts that DLL is present for RestAPI, SignalR, Mqtt, and WebSocket packages. Unit tests cover csproj editing and diagnostic-to-package mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef22c66dafd89f6f2cffeda84007f44388137fcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->