### PR TITLE
Add Phase 2 attribute and member shape code fixes

### DIFF
--- a/Observables.Shared/Observables.CodeFixes.Tests/CodeFixSyntaxHelperTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/CodeFixSyntaxHelperTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Observables.CodeFixes.Tests;
+
+public sealed class CodeFixSyntaxHelperTests
+{
+    [Fact]
+    public void ConvertMethodToProperty_preserves_attributes_and_return_type()
+    {
+        const string source =
+            """
+            public interface IHub
+            {
+                [HubOn("ReceiveMessage")]
+                Observable<string> ReceiveMessage();
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>().Single();
+        var property = CodeFixSyntaxHelper.ConvertMethodToProperty(method);
+
+        var text = property.ToFullString();
+        Assert.Contains("HubOn", text, StringComparison.Ordinal);
+        Assert.Contains("get;", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("();", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SuggestRestApiPath_uses_parameter_placeholders()
+    {
+        const string source =
+            """
+            public interface IApi
+            {
+                Observable<User> GetUser(int id, int page);
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>().Single();
+        var path = CodeFixSyntaxHelper.SuggestRestApiPath(method);
+
+        Assert.Equal("/{id}/{page}", path);
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj
+++ b/Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Observables.CodeFixes\Observables.CodeFixes.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
 </Project>

--- a/Observables.Shared/Observables.CodeFixes.Tests/PathTemplateSyncTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/PathTemplateSyncTests.cs
@@ -1,0 +1,32 @@
+namespace Observables.CodeFixes.Tests;
+
+public sealed class PathTemplateSyncTests
+{
+    [Fact]
+    public void SyncPathWithParameters_appends_missing_placeholder()
+    {
+        var synced = PathTemplateSync.SyncPathWithParameters(
+            "/users/{id}",
+            ["id", "page"]);
+
+        Assert.Equal("/users/{id}/{page}", synced);
+    }
+
+    [Fact]
+    public void SyncPathWithParameters_removes_extra_placeholder()
+    {
+        var synced = PathTemplateSync.SyncPathWithParameters(
+            "/users/{id}/{page}",
+            ["id"]);
+
+        Assert.Equal("/users/{id}", synced);
+    }
+
+    [Fact]
+    public void SyncPathWithParameters_is_idempotent_when_already_synced()
+    {
+        const string path = "/users/{id}/{page}";
+        var synced = PathTemplateSync.SyncPathWithParameters(path, ["id", "page"]);
+        Assert.Equal(path, synced);
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/AddBoundaryAttributeCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/AddBoundaryAttributeCodeFixProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddBoundaryAttributeCodeFixProvider)), Shared]
+public sealed class AddBoundaryAttributeCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesMemberDiagnosticIds.MissingBoundaryAttribute;
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (diagnostic is null
+            || !ObservablesMemberDiagnosticIds.TryGetDomain(diagnostic.Id, out var domain)
+            || diagnostic.Location is not { IsInSource: true } location)
+        {
+            return;
+        }
+
+        var document = context.Document;
+        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var member = CodeFixSyntaxHelper.FindMemberDeclaration(root, location);
+        if (member is null || CodeFixSyntaxHelper.FindBoundaryAttribute(member) is not null)
+        {
+            return;
+        }
+
+        var attributeSource = member switch
+        {
+            MethodDeclarationSyntax method =>
+                BoundaryAttributeDefaults.MethodAttribute(domain, method.Identifier.Text),
+            PropertyDeclarationSyntax property =>
+                BoundaryAttributeDefaults.PropertyAttribute(domain, property.Identifier.Text),
+            _ => null,
+        };
+
+        if (attributeSource is null)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: $"Add {attributeSource} attribute",
+                createChangedSolution: cancellationToken =>
+                    ApplyAsync(document, member, attributeSource, cancellationToken),
+                equivalenceKey: $"{nameof(AddBoundaryAttributeCodeFixProvider)}:{diagnostic.Id}"),
+            diagnostic);
+    }
+
+    static async Task<Solution> ApplyAsync(
+        Document document,
+        MemberDeclarationSyntax member,
+        string attributeSource,
+        CancellationToken cancellationToken)
+    {
+        var attributeList = CodeFixSyntaxHelper.CreateAttributeList(attributeSource);
+        var solution = await CodeFixSyntaxHelper.TryApplyDocumentEditAsync(
+            document,
+            (editor, _) =>
+            {
+                var updated = member.WithAttributeLists(member.AttributeLists.Add(attributeList));
+                editor.ReplaceNode(member, updated);
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return solution ?? document.Project.Solution;
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/AddHttpMethodAttributeCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/AddHttpMethodAttributeCodeFixProvider.cs
@@ -1,0 +1,70 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AddHttpMethodAttributeCodeFixProvider)), Shared]
+public sealed class AddHttpMethodAttributeCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesMemberDiagnosticIds.MissingHttpMethod;
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault(d => d.Id == "OBS3001");
+        if (diagnostic?.Location is not { IsInSource: true } location)
+        {
+            return;
+        }
+
+        var document = context.Document;
+        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var method = CodeFixSyntaxHelper.FindEnclosingMethod(root, location);
+        if (method is null || CodeFixSyntaxHelper.HasHttpMethodAttribute(method))
+        {
+            return;
+        }
+
+        var path = CodeFixSyntaxHelper.SuggestRestApiPath(method);
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: $"Add [Get(\"{path}\")] attribute",
+                createChangedSolution: cancellationToken =>
+                    ApplyAsync(document, method, path, cancellationToken),
+                equivalenceKey: nameof(AddHttpMethodAttributeCodeFixProvider)),
+            diagnostic);
+    }
+
+    static async Task<Solution> ApplyAsync(
+        Document document,
+        MethodDeclarationSyntax method,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        var attributeList = CodeFixSyntaxHelper.CreateAttributeList($"[Get(\"{path}\")]");
+        var solution = await CodeFixSyntaxHelper.TryApplyDocumentEditAsync(
+            document,
+            (editor, _) =>
+            {
+                var updated = method.WithAttributeLists(method.AttributeLists.Add(attributeList));
+                editor.ReplaceNode(method, updated);
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return solution ?? document.Project.Solution;
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
+++ b/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
@@ -1,0 +1,30 @@
+namespace Observables.CodeFixes;
+
+internal static class BoundaryAttributeDefaults
+{
+    internal static string MethodAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
+        domain switch
+        {
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubInvoke(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttPublish(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketSend(\"{memberName}\")]",
+            _ => throw new ArgumentOutOfRangeException(nameof(domain)),
+        };
+
+    internal static string PropertyAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
+        domain switch
+        {
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubOn(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttSubscribe(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketReceive(\"{memberName}\")]",
+            _ => throw new ArgumentOutOfRangeException(nameof(domain)),
+        };
+
+    internal static bool RequiresProperty(string attributeName) =>
+        attributeName is "HubOnAttribute" or "MqttSubscribeAttribute" or "WebSocketReceiveAttribute";
+
+    internal static bool RequiresMethod(string attributeName) =>
+        attributeName is "HubInvokeAttribute" or "HubSendAttribute" or "HubStreamAttribute"
+            or "MqttPublishAttribute"
+            or "WebSocketSendAttribute" or "WebSocketConnectAttribute" or "WebSocketCloseAttribute";
+}

--- a/Observables.Shared/Observables.CodeFixes/CodeFixSyntaxHelper.cs
+++ b/Observables.Shared/Observables.CodeFixes/CodeFixSyntaxHelper.cs
@@ -1,0 +1,126 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Observables.CodeFixes;
+
+internal static class CodeFixSyntaxHelper
+{
+    internal static async Task<Solution?> TryApplyDocumentEditAsync(
+        Document document,
+        Func<DocumentEditor, CancellationToken, Task> editAsync,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        await editAsync(editor, cancellationToken).ConfigureAwait(false);
+        return editor.GetChangedDocument().Project.Solution;
+    }
+
+    internal static MemberDeclarationSyntax? FindMemberDeclaration(SyntaxNode root, Location location)
+    {
+        var node = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+        return node.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+    }
+
+    internal static MethodDeclarationSyntax? FindEnclosingMethod(SyntaxNode root, Location location) =>
+        FindMemberDeclaration(root, location) as MethodDeclarationSyntax;
+
+    internal static PropertyDeclarationSyntax? FindEnclosingProperty(SyntaxNode root, Location location) =>
+        FindMemberDeclaration(root, location) as PropertyDeclarationSyntax;
+
+    internal static bool IsCancellationTokenParameter(ParameterSyntax parameter) =>
+        parameter.Type?.ToString() is "CancellationToken" or "System.Threading.CancellationToken";
+
+    internal static IReadOnlyList<string> GetNonCancellationParameterNames(MethodDeclarationSyntax method) =>
+        method.ParameterList.Parameters
+            .Where(p => !IsCancellationTokenParameter(p))
+            .Select(p => p.Identifier.Text)
+            .ToArray();
+
+    internal static AttributeSyntax? FindHttpMethodAttributeWithLiteralPath(MethodDeclarationSyntax method)
+    {
+        foreach (var attribute in method.AttributeLists.SelectMany(list => list.Attributes))
+        {
+            if (attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression is not LiteralExpressionSyntax
+                || !attribute.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                continue;
+            }
+
+            if (IsHttpMethodAttributeName(attribute.Name.ToString()))
+            {
+                return attribute;
+            }
+        }
+
+        return null;
+    }
+
+    internal static bool HasHttpMethodAttribute(MethodDeclarationSyntax method) =>
+        method.AttributeLists.SelectMany(list => list.Attributes)
+            .Any(attribute => IsHttpMethodAttributeName(attribute.Name.ToString()));
+
+    internal static AttributeSyntax? FindBoundaryAttribute(MemberDeclarationSyntax member)
+    {
+        foreach (var attribute in member.AttributeLists.SelectMany(list => list.Attributes))
+        {
+            var name = NormalizeAttributeName(attribute.Name.ToString());
+            if (BoundaryAttributeDefaults.RequiresProperty(name)
+                || BoundaryAttributeDefaults.RequiresMethod(name))
+            {
+                return attribute;
+            }
+        }
+
+        return null;
+    }
+
+    internal static bool IsHttpMethodAttributeName(string name) =>
+        name is "Get" or "Post" or "Put" or "Delete" or "Patch" or "Head" or "Options"
+            or "GetAttribute" or "PostAttribute" or "PutAttribute" or "DeleteAttribute"
+            or "PatchAttribute" or "HeadAttribute" or "OptionsAttribute";
+
+    internal static string NormalizeAttributeName(string name) =>
+        name.EndsWith("Attribute", StringComparison.Ordinal) ? name : name + "Attribute";
+
+    internal static string SuggestRestApiPath(MethodDeclarationSyntax method)
+    {
+        var parameters = GetNonCancellationParameterNames(method);
+        if (parameters.Count == 0)
+        {
+            return "/" + method.Identifier.Text.ToLowerInvariant();
+        }
+
+        return "/" + string.Join("/", parameters.Select(p => "{" + p + "}"));
+    }
+
+    internal static AttributeListSyntax CreateAttributeList(string attributeSource)
+    {
+        var member = ParseMemberDeclaration(attributeSource + " void M();") as MethodDeclarationSyntax
+            ?? throw new InvalidOperationException("Unable to parse attribute list.");
+        return member.AttributeLists[0];
+    }
+
+    internal static MethodDeclarationSyntax ConvertPropertyToMethod(PropertyDeclarationSyntax property) =>
+        MethodDeclaration(property.Type!, property.Identifier)
+            .WithAttributeLists(property.AttributeLists)
+            .WithModifiers(property.Modifiers)
+            .WithParameterList(ParameterList())
+            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+            .WithLeadingTrivia(property.GetLeadingTrivia())
+            .WithTrailingTrivia(property.GetTrailingTrivia());
+
+    internal static PropertyDeclarationSyntax ConvertMethodToProperty(MethodDeclarationSyntax method) =>
+        PropertyDeclaration(method.ReturnType!, method.Identifier)
+            .WithAttributeLists(method.AttributeLists)
+            .WithModifiers(method.Modifiers)
+            .WithAccessorList(
+                AccessorList(
+                    SingletonList(
+                        AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)))))
+            .WithLeadingTrivia(method.GetLeadingTrivia())
+            .WithTrailingTrivia(method.GetTrailingTrivia());
+}

--- a/Observables.Shared/Observables.CodeFixes/FixMemberShapeCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/FixMemberShapeCodeFixProvider.cs
@@ -1,0 +1,101 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FixMemberShapeCodeFixProvider)), Shared]
+public sealed class FixMemberShapeCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesMemberDiagnosticIds.MemberShapeMismatch;
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault();
+        if (diagnostic?.Location is not { IsInSource: true } location)
+        {
+            return;
+        }
+
+        var document = context.Document;
+        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var member = CodeFixSyntaxHelper.FindMemberDeclaration(root, location);
+        var boundaryAttribute = member is null ? null : CodeFixSyntaxHelper.FindBoundaryAttribute(member);
+        if (member is null || boundaryAttribute is null)
+        {
+            return;
+        }
+
+        var attributeName = CodeFixSyntaxHelper.NormalizeAttributeName(boundaryAttribute.Name.ToString());
+        switch (member)
+        {
+            case MethodDeclarationSyntax method when BoundaryAttributeDefaults.RequiresProperty(attributeName):
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: "Convert method to property",
+                        createChangedSolution: cancellationToken =>
+                            ApplyMethodToPropertyAsync(document, method, cancellationToken),
+                        equivalenceKey: $"{nameof(FixMemberShapeCodeFixProvider)}:MethodToProperty"),
+                    diagnostic);
+                break;
+
+            case PropertyDeclarationSyntax property when BoundaryAttributeDefaults.RequiresMethod(attributeName):
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: "Convert property to method",
+                        createChangedSolution: cancellationToken =>
+                            ApplyPropertyToMethodAsync(document, property, cancellationToken),
+                        equivalenceKey: $"{nameof(FixMemberShapeCodeFixProvider)}:PropertyToMethod"),
+                    diagnostic);
+                break;
+        }
+    }
+
+    static async Task<Solution> ApplyMethodToPropertyAsync(
+        Document document,
+        MethodDeclarationSyntax method,
+        CancellationToken cancellationToken)
+    {
+        var property = CodeFixSyntaxHelper.ConvertMethodToProperty(method);
+        var solution = await CodeFixSyntaxHelper.TryApplyDocumentEditAsync(
+            document,
+            (editor, _) =>
+            {
+                editor.ReplaceNode(method, property);
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return solution ?? document.Project.Solution;
+    }
+
+    static async Task<Solution> ApplyPropertyToMethodAsync(
+        Document document,
+        PropertyDeclarationSyntax property,
+        CancellationToken cancellationToken)
+    {
+        var method = CodeFixSyntaxHelper.ConvertPropertyToMethod(property);
+        var solution = await CodeFixSyntaxHelper.TryApplyDocumentEditAsync(
+            document,
+            (editor, _) =>
+            {
+                editor.ReplaceNode(property, method);
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return solution ?? document.Project.Solution;
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
+++ b/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace Observables.CodeFixes;
+
+internal static class ObservablesMemberDiagnosticIds
+{
+    internal static readonly ImmutableArray<string> MissingHttpMethod = ["OBS3001"];
+
+    internal static readonly ImmutableArray<string> PathParameterMismatch = ["OBS3004"];
+
+    internal static readonly ImmutableArray<string> MissingBoundaryAttribute =
+        ["OBS4001", "OBS5001", "OBS6001"];
+
+    internal static readonly ImmutableArray<string> MemberShapeMismatch =
+        ["OBS4004", "OBS5004", "OBS6004"];
+
+    internal enum InterfaceProxyDomain
+    {
+        SignalR,
+        Mqtt,
+        WebSocket,
+    }
+
+    internal static bool TryGetDomain(string diagnosticId, out InterfaceProxyDomain domain)
+    {
+        domain = diagnosticId switch
+        {
+            "OBS4001" or "OBS4004" => InterfaceProxyDomain.SignalR,
+            "OBS5001" or "OBS5004" => InterfaceProxyDomain.Mqtt,
+            "OBS6001" or "OBS6004" => InterfaceProxyDomain.WebSocket,
+            _ => default,
+        };
+
+        return diagnosticId is "OBS4001" or "OBS4004" or "OBS5001" or "OBS5004" or "OBS6001" or "OBS6004";
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/PathTemplateSync.cs
+++ b/Observables.Shared/Observables.CodeFixes/PathTemplateSync.cs
@@ -1,0 +1,92 @@
+namespace Observables.CodeFixes;
+
+internal static class PathTemplateSync
+{
+    internal static string SyncPathWithParameters(string path, IReadOnlyCollection<string> parameterNames)
+    {
+        var placeholders = ExtractPathPlaceholders(path);
+        var desired = new HashSet<string>(parameterNames, StringComparer.Ordinal);
+
+        foreach (var extra in placeholders.Where(p => !desired.Contains(p)).ToArray())
+        {
+            path = RemovePlaceholder(path, extra);
+            placeholders.Remove(extra);
+        }
+
+        foreach (var missing in desired.Where(p => !placeholders.Contains(p)))
+        {
+            path = AppendPlaceholder(path, missing);
+            placeholders.Add(missing);
+        }
+
+        return path;
+    }
+
+    internal static HashSet<string> ExtractPathPlaceholders(string path)
+    {
+        var placeholders = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < path.Length; i++)
+        {
+            if (path[i] != '{')
+            {
+                continue;
+            }
+
+            var end = path.IndexOf('}', i + 1);
+            if (end < 0)
+            {
+                break;
+            }
+
+            var name = path.Substring(i + 1, end - i - 1);
+            if (name.Length > 0)
+            {
+                placeholders.Add(name);
+            }
+
+            i = end;
+        }
+
+        return placeholders;
+    }
+
+    static string RemovePlaceholder(string path, string placeholder)
+    {
+        var token = "{" + placeholder + "}";
+        var index = path.IndexOf(token, StringComparison.Ordinal);
+        if (index < 0)
+        {
+            return path;
+        }
+
+        var before = path.Substring(0, index);
+        var after = path.Substring(index + token.Length);
+
+        if (before.EndsWith("/", StringComparison.Ordinal))
+        {
+            before = before.Substring(0, before.Length - 1);
+        }
+
+        if (after.StartsWith("/", StringComparison.Ordinal))
+        {
+            after = after.Substring(1);
+        }
+
+        return before + after;
+    }
+
+    static string AppendPlaceholder(string path, string placeholder)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return "{" + placeholder + "}";
+        }
+
+        if (!path.EndsWith("/", StringComparison.Ordinal))
+        {
+            path += '/';
+        }
+
+        return path + "{" + placeholder + "}";
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/SyncPathTemplateWithParametersCodeFixProvider.cs
+++ b/Observables.Shared/Observables.CodeFixes/SyncPathTemplateWithParametersCodeFixProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Observables.CodeFixes;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SyncPathTemplateWithParametersCodeFixProvider)), Shared]
+public sealed class SyncPathTemplateWithParametersCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        ObservablesMemberDiagnosticIds.PathParameterMismatch;
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.FirstOrDefault(d => d.Id == "OBS3004");
+        if (diagnostic?.Location is not { IsInSource: true } location)
+        {
+            return;
+        }
+
+        var document = context.Document;
+        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var method = CodeFixSyntaxHelper.FindEnclosingMethod(root, location);
+        var httpAttribute = method is null ? null : CodeFixSyntaxHelper.FindHttpMethodAttributeWithLiteralPath(method);
+        if (method is null || httpAttribute?.ArgumentList?.Arguments.FirstOrDefault()?.Expression is not LiteralExpressionSyntax literal)
+        {
+            return;
+        }
+
+        var currentPath = literal.Token.ValueText;
+        var parameterNames = CodeFixSyntaxHelper.GetNonCancellationParameterNames(method);
+        var syncedPath = PathTemplateSync.SyncPathWithParameters(currentPath, parameterNames);
+        if (string.Equals(currentPath, syncedPath, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: $"Sync path template to '{syncedPath}'",
+                createChangedSolution: cancellationToken =>
+                    ApplyAsync(document, method, httpAttribute, literal, syncedPath, cancellationToken),
+                equivalenceKey: nameof(SyncPathTemplateWithParametersCodeFixProvider)),
+            diagnostic);
+    }
+
+    static async Task<Solution> ApplyAsync(
+        Document document,
+        MethodDeclarationSyntax method,
+        AttributeSyntax httpAttribute,
+        LiteralExpressionSyntax literal,
+        string syncedPath,
+        CancellationToken cancellationToken)
+    {
+        var newLiteral = SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression,
+            SyntaxFactory.Literal(syncedPath));
+        var newAttribute = httpAttribute.ReplaceNode(literal, newLiteral);
+        var newMethod = method.ReplaceNode(httpAttribute, newAttribute);
+
+        var solution = await CodeFixSyntaxHelper.TryApplyDocumentEditAsync(
+            document,
+            (editor, _) =>
+            {
+                editor.ReplaceNode(method, newMethod);
+                return Task.CompletedTask;
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return solution ?? document.Project.Solution;
+    }
+}


### PR DESCRIPTION
## Summary

- Add four Roslyn code fix providers for Phase 2 diagnostics in `Observables.CodeFixes`.
- **OBS3001**: add `[Get("{path}")]` using parameter placeholders when a RestAPI method lacks an HTTP attribute.
- **OBS3004**: sync the HTTP path template placeholders with non-`CancellationToken` parameters.
- **OBS4001 / OBS5001 / OBS6001**: add default boundary attributes (`HubInvoke` / `MqttPublish` / `WebSocketSend` for methods; `HubOn` / `MqttSubscribe` / `WebSocketReceive` for properties).
- **OBS4004 / OBS5004 / OBS6004**: convert methods/properties to match subscribe/on/receive vs invoke/publish/send boundaries.

## Test plan

- [x] `dotnet test Observables.Shared/Observables.CodeFixes.Tests` (11 tests)
- [x] Nuke `PackVerify`
- [ ] CI green after merge

Closes #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes rewrite interface member signatures and HTTP route templates; wrong heuristics (always `[Get]`, default boundary names) could misconfigure generated proxies but changes are localized to analyzer-driven quick fixes.
> 
> **Overview**
> Adds **Phase 2** Roslyn code fixes in `Observables.CodeFixes` for Rest API and SignalR/Mqtt/WebSocket interface diagnostics, with shared helpers and unit tests.
> 
> **Rest API:** **OBS3001** offers `[Get("{path}")]` where `path` is inferred from method parameters (excluding `CancellationToken`). **OBS3004** rewrites the HTTP attribute path string so `{placeholder}` segments match those parameters via `PathTemplateSync`.
> 
> **Boundary proxies:** **OBS4001 / OBS5001 / OBS6001** insert domain-default attributes (`HubInvoke`/`HubOn`, `MqttPublish`/`MqttSubscribe`, `WebSocketSend`/`WebSocketReceive`) from member name and method vs property. **OBS4004 / OBS5004 / OBS6004** convert method ↔ property when the existing boundary attribute expects the other shape, preserving attributes and types.
> 
> Supporting pieces include `ObservablesMemberDiagnosticIds`, `CodeFixSyntaxHelper`, `BoundaryAttributeDefaults`, batch **Fix All** on each provider, and tests for path sync and syntax conversion (tests project references `Microsoft.CodeAnalysis.CSharp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7325bbc227031acc089808fa9db89be4cc7cb5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->