### PR TITLE
Add Phase 3 standalone analyzers and completion providers

### DIFF
--- a/Observables.Shared/Observables.Analyzers.Tests/AnalyzerTestHarness.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/AnalyzerTestHarness.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Observables.Analyzers.Tests;
+
+internal static class AnalyzerTestHarness
+{
+    internal static ImmutableArray<Diagnostic> RunAnalyzers(
+        string userSource,
+        params DiagnosticAnalyzer[] analyzers) =>
+        RunAnalyzers(userSource, additionalReferences: [], analyzers);
+
+    internal static ImmutableArray<Diagnostic> RunAnalyzers(
+        string userSource,
+        IEnumerable<MetadataReference> additionalReferences,
+        params DiagnosticAnalyzer[] analyzers)
+    {
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var syntaxTree = CSharpSyntaxTree.ParseText(userSource, parseOptions);
+        var references = GetPlatformReferencesExcludingObservables()
+            .Concat(additionalReferences)
+            .ToArray();
+
+        var compilation = CSharpCompilation.Create(
+            "AnalyzerTests",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers.ToImmutableArray());
+        return compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult();
+    }
+
+    internal static IEnumerable<Diagnostic> FilterObservablesDiagnostics(IEnumerable<Diagnostic> diagnostics) =>
+        diagnostics.Where(static d => d.Id.StartsWith("OBS", StringComparison.Ordinal));
+
+    internal static MetadataReference[] GetPlatformReferencesExcludingObservables()
+    {
+        var trusted = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string
+            ?? throw new InvalidOperationException("TRUSTED_PLATFORM_ASSEMBLIES is unavailable.");
+
+        return trusted
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(static path => !Path.GetFileNameWithoutExtension(path).StartsWith("Observables.", StringComparison.Ordinal))
+            .Select(static path => MetadataReference.CreateFromFile(path))
+            .ToArray();
+    }
+
+    internal static MetadataReference[] GetMinimalCoreReferences() =>
+    [
+        MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+    ];
+
+    internal static MetadataReference CreateReference<T>() =>
+        MetadataReference.CreateFromFile(typeof(T).Assembly.Location);
+
+    internal static MetadataReference CreateReferenceFromAssemblyOf(Type type) =>
+        MetadataReference.CreateFromFile(type.Assembly.Location);
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/AnalyzerTestHarnessTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/AnalyzerTestHarnessTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class AnalyzerTestHarnessTests
+{
+    [Fact]
+    public void Harness_with_only_r3_does_not_include_reactive_bridge_assemblies()
+    {
+        var compilation = CreateCompilation(
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::R3.Unit>()]);
+
+        var assemblyNames = compilation.References
+            .Select(compilation.GetAssemblyOrModuleSymbol)
+            .OfType<IAssemblySymbol>()
+            .Select(static symbol => symbol.Name)
+            .ToArray();
+
+        Assert.Contains("R3", assemblyNames);
+        Assert.DoesNotContain(assemblyNames, name => name.StartsWith("Observables.", StringComparison.Ordinal));
+    }
+
+    static CSharpCompilation CreateCompilation(IEnumerable<MetadataReference> additionalReferences)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText("namespace Test; public interface IMarker { }");
+        var references = AnalyzerTestHarness.GetPlatformReferencesExcludingObservables()
+            .Concat(additionalReferences)
+            .ToArray();
+
+        return CSharpCompilation.Create(
+            "HarnessTests",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class EmptyProxyInterfaceAnalyzerTests
+{
+    [Fact]
+    public void OBS4007_on_empty_hub_interface()
+    {
+        const string source =
+            """
+            using Observables.SignalR;
+
+            [Hub]
+            public interface IChatHub
+            {
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            BuildSource(source, "Observables.SignalR"),
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::Observables.SignalR.HubAttribute>()],
+            new EmptyProxyInterfaceAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "OBS4007");
+    }
+
+    [Fact]
+    public void No_OBS4007_when_hub_interface_has_members()
+    {
+        const string source =
+            """
+            using Observables.SignalR;
+            using R3;
+
+            [Hub]
+            public interface IChatHub
+            {
+                [HubInvoke]
+                Observable<int> GetCount();
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            BuildSource(source, "Observables.SignalR", "R3"),
+            additionalReferences:
+            [
+                AnalyzerTestHarness.CreateReference<global::Observables.SignalR.HubAttribute>(),
+                AnalyzerTestHarness.CreateReference<global::R3.Unit>(),
+            ],
+            new EmptyProxyInterfaceAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "OBS4007");
+    }
+
+    [Fact]
+    public void OBS5007_on_empty_mqtt_interface()
+    {
+        const string source =
+            """
+            using Observables.Mqtt;
+
+            [Mqtt]
+            public interface ITopics
+            {
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            BuildSource(source, "Observables.Mqtt"),
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::Observables.Mqtt.MqttAttribute>()],
+            new EmptyProxyInterfaceAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "OBS5007");
+    }
+
+    [Fact]
+    public void OBS6007_on_empty_websocket_interface()
+    {
+        const string source =
+            """
+            using Observables.WebSocket;
+
+            [WebSocket]
+            public interface IStream
+            {
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            BuildSource(source, "Observables.WebSocket"),
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::Observables.WebSocket.WebSocketAttribute>()],
+            new EmptyProxyInterfaceAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "OBS6007");
+    }
+
+    static string BuildSource(string body, params string[] usings)
+    {
+        var usingLines = string.Join('\n', usings.Select(u => $"using {u};"));
+        return $$"""
+            {{usingLines}}
+
+            namespace Test;
+
+            {{body}}
+            """;
+    }
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
+++ b/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Observables.Analyzers.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Analyzers\Observables.Analyzers.csproj" />
+    <ProjectReference Include="..\..\Observables.SignalR\Observables.SignalR\Observables.SignalR.csproj" />
+    <ProjectReference Include="..\..\Observables.SignalR\Observables.SignalR.Reactive\Observables.SignalR.Reactive.csproj" />
+    <ProjectReference Include="..\..\Observables.Mqtt\Observables.Mqtt\Observables.Mqtt.csproj" />
+    <ProjectReference Include="..\..\Observables.WebSocket\Observables.WebSocket\Observables.WebSocket.csproj" />
+    <ProjectReference Include="..\..\Observables.RestAPI\Observables.RestAPI\Observables.RestAPI.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class ReactivePackageConflictAnalyzerTests
+{
+    [Fact]
+    public void OBS0001_when_r3_and_signalr_reactive_are_referenced()
+    {
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            """
+            namespace Test;
+
+            public interface IMarker { }
+            """,
+            additionalReferences:
+            [
+                AnalyzerTestHarness.CreateReference<global::R3.Unit>(),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.SignalR.HubAttribute)),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.SignalR.Reactive.SystemReactiveSignalRAdapter)),
+            ],
+            new ReactivePackageConflictAnalyzer());
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Id == "OBS0001" && d.GetMessage().Contains("SignalR", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void No_OBS0001_when_only_r3_is_referenced()
+    {
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            """
+            namespace Test;
+
+            public interface IMarker { }
+            """,
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::R3.Unit>()],
+            new ReactivePackageConflictAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "OBS0001");
+    }
+
+    [Fact]
+    public void No_OBS0001_when_neither_r3_nor_reactive_bridge_is_referenced()
+    {
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            """
+            namespace Test;
+
+            public interface IMarker { }
+            """,
+            new ReactivePackageConflictAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "OBS0001");
+    }
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/RestApiPathSuggestionsTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/RestApiPathSuggestionsTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class RestApiPathSuggestionsTests
+{
+    [Fact]
+    public void SuggestPath_uses_parameter_placeholders()
+    {
+        const string source =
+            """
+            public interface IApi
+            {
+                void GetUser(int id, string name);
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var path = RestApiPathSuggestions.SuggestPath(method);
+
+        Assert.Equal("/{id}/{name}", path);
+    }
+
+    [Fact]
+    public void SuggestPath_uses_method_name_when_parameterless()
+    {
+        const string source =
+            """
+            public interface IApi
+            {
+                void GetUsers();
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var path = RestApiPathSuggestions.SuggestPath(method);
+
+        Assert.Equal("/getusers", path);
+    }
+}

--- a/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
+++ b/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
@@ -1,0 +1,103 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Observables.Analyzers;
+
+[ExportCompletionProvider(nameof(BoundaryAttributeCompletionProvider), LanguageNames.CSharp)]
+[Shared]
+public sealed class BoundaryAttributeCompletionProvider : CompletionProvider
+{
+    public override bool ShouldTriggerCompletion(
+        SourceText text,
+        int caretPosition,
+        CompletionTrigger trigger,
+        OptionSet options) =>
+        trigger.Kind == CompletionTriggerKind.Insertion
+        && caretPosition > 0
+        && text[caretPosition - 1] == '[';
+
+    public override async Task ProvideCompletionsAsync(CompletionContext context)
+    {
+        var document = context.Document;
+        var position = context.Position;
+        var cancellationToken = context.CancellationToken;
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        if (root.FindToken(position - 1).Parent is not AttributeListSyntax)
+        {
+            return;
+        }
+
+        var member = root.FindToken(position).Parent?
+            .AncestorsAndSelf()
+            .OfType<MemberDeclarationSyntax>()
+            .FirstOrDefault();
+        if (member is null)
+        {
+            return;
+        }
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var interfaceSyntax = member.Ancestors().OfType<InterfaceDeclarationSyntax>().FirstOrDefault();
+        if (interfaceSyntax is null
+            || semanticModel.GetDeclaredSymbol(interfaceSyntax, cancellationToken) is not INamedTypeSymbol interfaceSymbol)
+        {
+            return;
+        }
+
+        var domain = ProxyDomainCatalog.TryGetInterfaceProxyDomain(interfaceSymbol, semanticModel.Compilation);
+        if (domain is null)
+        {
+            return;
+        }
+
+        var suggestions = member switch
+        {
+            MethodDeclarationSyntax => domain.MethodAttributes,
+            PropertyDeclarationSyntax => domain.PropertyAttributes,
+            _ => null,
+        };
+
+        if (suggestions is null || suggestions.Count == 0)
+        {
+            return;
+        }
+
+        var memberName = member switch
+        {
+            MethodDeclarationSyntax method => method.Identifier.Text,
+            PropertyDeclarationSyntax property => property.Identifier.Text,
+            _ => "Member",
+        };
+
+        foreach (var suggestion in suggestions)
+        {
+            context.AddItem(CreateItem(suggestion, memberName));
+        }
+    }
+
+    static CompletionItem CreateItem(ProxyDomainCatalog.BoundaryAttributeSuggestion suggestion, string memberName)
+    {
+        var insertText = suggestion.InsertText.Contains('(')
+            ? suggestion.InsertText
+            : $"{suggestion.InsertText}(\"{memberName}\")]";
+
+        return CompletionItemFactory.Create(suggestion.DisplayText, insertText);
+    }
+}

--- a/Observables.Shared/Observables.Analyzers/CompletionItemFactory.cs
+++ b/Observables.Shared/Observables.Analyzers/CompletionItemFactory.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Completion;
+
+namespace Observables.Analyzers;
+
+internal static class CompletionItemFactory
+{
+    private const string InsertTextPropertyName = "InsertText";
+
+    internal static CompletionItem Create(string displayText, string insertText, string? sortText = null) =>
+        CompletionItem
+            .Create(
+                displayText: displayText,
+                sortText: sortText ?? displayText,
+                rules: CompletionItemRules.Default)
+            .AddProperty(InsertTextPropertyName, insertText);
+}

--- a/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
+++ b/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.Analyzers;
+
+internal static class DiagnosticDescriptors
+{
+#pragma warning disable RS2008
+    public static readonly DiagnosticDescriptor ConflictingReactivePackages =
+        new(
+            "OBS0001",
+            "Conflicting Observables reactive packages",
+            "Both R3 and System.Reactive Observables packages are referenced for {0}. Remove either the .R3 or .Reactive package for this feature.",
+            "Observables",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
+    public static readonly DiagnosticDescriptor EmptyHubInterface =
+        new(
+            "OBS4007",
+            "Empty hub proxy interface",
+            "Interface '{0}' is marked with [Hub] but declares no members. Add hub boundary members or remove [Hub].",
+            "Observables.SignalR",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor EmptyMqttInterface =
+        new(
+            "OBS5007",
+            "Empty MQTT proxy interface",
+            "Interface '{0}' is marked with [Mqtt] but declares no members. Add MQTT boundary members or remove [Mqtt].",
+            "Observables.Mqtt",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor EmptyWebSocketInterface =
+        new(
+            "OBS6007",
+            "Empty WebSocket proxy interface",
+            "Interface '{0}' is marked with [WebSocket] but declares no members. Add WebSocket boundary members or remove [WebSocket].",
+            "Observables.WebSocket",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+#pragma warning restore RS2008
+}

--- a/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
+++ b/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Observables.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EmptyProxyInterfaceAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(
+            DiagnosticDescriptors.EmptyHubInterface,
+            DiagnosticDescriptors.EmptyMqttInterface,
+            DiagnosticDescriptors.EmptyWebSocketInterface);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeInterface, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeInterface(SymbolAnalysisContext context)
+    {
+        if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Interface } interfaceSymbol)
+        {
+            return;
+        }
+
+        var domain = ProxyDomainCatalog.TryGetInterfaceProxyDomain(interfaceSymbol, context.Compilation);
+        if (domain is null)
+        {
+            return;
+        }
+
+        if (ProxyDomainCatalog.CountPublicInstanceMembers(interfaceSymbol) > 0)
+        {
+            return;
+        }
+
+        var location = interfaceSymbol.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(
+            domain.EmptyInterfaceDescriptor,
+            location,
+            interfaceSymbol.Name));
+    }
+}

--- a/Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj
+++ b/Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Observables.Analyzers</RootNamespace>
+    <Description>Standalone Roslyn analyzers and completion providers for Observables.</Description>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RS2001;RS2002;RS1038</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Observables.Analyzers.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
+++ b/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
@@ -1,0 +1,152 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.Analyzers;
+
+internal static class ProxyDomainCatalog
+{
+    internal sealed class ProxyDomain
+    {
+        internal ProxyDomain(
+            string displayName,
+            string interfaceMarkerMetadataName,
+            string reactiveAdapterMetadataName,
+            DiagnosticDescriptor emptyInterfaceDescriptor,
+            IReadOnlyList<BoundaryAttributeSuggestion> methodAttributes,
+            IReadOnlyList<BoundaryAttributeSuggestion> propertyAttributes)
+        {
+            DisplayName = displayName;
+            InterfaceMarkerMetadataName = interfaceMarkerMetadataName;
+            ReactiveAdapterMetadataName = reactiveAdapterMetadataName;
+            EmptyInterfaceDescriptor = emptyInterfaceDescriptor;
+            MethodAttributes = methodAttributes;
+            PropertyAttributes = propertyAttributes;
+        }
+
+        internal string DisplayName { get; }
+        internal string InterfaceMarkerMetadataName { get; }
+        internal string ReactiveAdapterMetadataName { get; }
+        internal DiagnosticDescriptor EmptyInterfaceDescriptor { get; }
+        internal IReadOnlyList<BoundaryAttributeSuggestion> MethodAttributes { get; }
+        internal IReadOnlyList<BoundaryAttributeSuggestion> PropertyAttributes { get; }
+    }
+
+    internal sealed class BoundaryAttributeSuggestion
+    {
+        internal BoundaryAttributeSuggestion(string displayText, string insertText)
+        {
+            DisplayText = displayText;
+            InsertText = insertText;
+        }
+
+        internal string DisplayText { get; }
+        internal string InsertText { get; }
+    }
+
+    internal static readonly ProxyDomain SignalR = new(
+        displayName: "SignalR",
+        interfaceMarkerMetadataName: "Observables.SignalR.HubAttribute",
+        reactiveAdapterMetadataName: "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyHubInterface,
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("HubInvoke", "HubInvoke"),
+            new BoundaryAttributeSuggestion("HubSend", "HubSend"),
+            new BoundaryAttributeSuggestion("HubStream", "HubStream"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("HubOn", "HubOn"),
+        ]);
+
+    internal static readonly ProxyDomain Mqtt = new(
+        displayName: "Mqtt",
+        interfaceMarkerMetadataName: "Observables.Mqtt.MqttAttribute",
+        reactiveAdapterMetadataName: "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyMqttInterface,
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("MqttPublish", "MqttPublish"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("MqttSubscribe", "MqttSubscribe"),
+        ]);
+
+    internal static readonly ProxyDomain WebSocket = new(
+        displayName: "WebSocket",
+        interfaceMarkerMetadataName: "Observables.WebSocket.WebSocketAttribute",
+        reactiveAdapterMetadataName: "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyWebSocketInterface,
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("WebSocketSend", "WebSocketSend"),
+            new BoundaryAttributeSuggestion("WebSocketConnect", "WebSocketConnect"),
+            new BoundaryAttributeSuggestion("WebSocketClose", "WebSocketClose"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("WebSocketReceive", "WebSocketReceive"),
+        ]);
+
+    internal static readonly ProxyDomain RestApi = new(
+        displayName: "RestAPI",
+        interfaceMarkerMetadataName: string.Empty,
+        reactiveAdapterMetadataName: "Observables.RestAPI.Reactive.SystemReactiveObservableAdapter",
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyHubInterface,
+        methodAttributes: [],
+        propertyAttributes: []);
+
+    internal static readonly IReadOnlyList<ProxyDomain> InterfaceProxyDomains = [SignalR, Mqtt, WebSocket];
+
+    internal static readonly IReadOnlyList<ProxyDomain> ReactiveConflictDomains =
+        [SignalR, Mqtt, WebSocket, RestApi];
+
+    internal static readonly string[] RestApiHttpMethodNames =
+        ["Get", "Post", "Put", "Delete", "Patch", "Head", "Options"];
+
+    internal static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static int CountPublicInstanceMembers(INamedTypeSymbol interfaceSymbol)
+    {
+        var count = 0;
+        foreach (var member in interfaceSymbol.GetMembers())
+        {
+            if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
+            {
+                continue;
+            }
+
+            if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } or IPropertySymbol)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    internal static ProxyDomain? TryGetInterfaceProxyDomain(INamedTypeSymbol interfaceSymbol, Compilation compilation)
+    {
+        foreach (var domain in InterfaceProxyDomains)
+        {
+            var marker = compilation.GetTypeByMetadataName(domain.InterfaceMarkerMetadataName);
+            if (marker is not null && HasAttribute(interfaceSymbol, marker))
+            {
+                return domain;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Observables.Shared/Observables.Analyzers/ReactivePackageConflictAnalyzer.cs
+++ b/Observables.Shared/Observables.Analyzers/ReactivePackageConflictAnalyzer.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Observables.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ReactivePackageConflictAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.ConflictingReactivePackages);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    static void AnalyzeCompilation(CompilationAnalysisContext context)
+    {
+        if (!ReactivePackageConflictDetection.HasR3Reference(context.Compilation))
+        {
+            return;
+        }
+
+        foreach (var domain in ProxyDomainCatalog.ReactiveConflictDomains)
+        {
+            if (!ReactivePackageConflictDetection.HasReactiveBridgeReference(context.Compilation, domain))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.ConflictingReactivePackages,
+                Location.None,
+                domain.DisplayName));
+        }
+    }
+}

--- a/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
+++ b/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.Analyzers;
+
+internal static class ReactivePackageConflictDetection
+{
+    internal static bool HasAssemblyReference(Compilation compilation, string assemblyName)
+    {
+        foreach (var reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly
+                && string.Equals(assembly.Name, assemblyName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool HasR3Reference(Compilation compilation) =>
+        HasAssemblyReference(compilation, "R3");
+
+    internal static bool HasReactiveBridgeReference(Compilation compilation, ProxyDomainCatalog.ProxyDomain domain) =>
+        domain switch
+        {
+            { DisplayName: "SignalR" } => HasAssemblyReference(compilation, "Observables.SignalR.Reactive"),
+            { DisplayName: "Mqtt" } => HasAssemblyReference(compilation, "Observables.Mqtt.Reactive"),
+            { DisplayName: "WebSocket" } => HasAssemblyReference(compilation, "Observables.WebSocket.Reactive"),
+            { DisplayName: "RestAPI" } => HasAssemblyReference(compilation, "Observables.RestAPI.Reactive"),
+            _ => false,
+        };
+}

--- a/Observables.Shared/Observables.Analyzers/RestApiMemberCompletionProvider.cs
+++ b/Observables.Shared/Observables.Analyzers/RestApiMemberCompletionProvider.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Observables.Analyzers;
+
+[ExportCompletionProvider(nameof(RestApiMemberCompletionProvider), LanguageNames.CSharp)]
+[Shared]
+public sealed class RestApiMemberCompletionProvider : CompletionProvider
+{
+    public override bool ShouldTriggerCompletion(
+        SourceText text,
+        int caretPosition,
+        CompletionTrigger trigger,
+        OptionSet options)
+    {
+        if (trigger.Kind == CompletionTriggerKind.Insertion && caretPosition > 0)
+        {
+            var ch = text[caretPosition - 1];
+            return ch is '[' or '"';
+        }
+
+        return trigger.Kind == CompletionTriggerKind.Invoke;
+    }
+
+    public override async Task ProvideCompletionsAsync(CompletionContext context)
+    {
+        var document = context.Document;
+        var position = context.Position;
+        var cancellationToken = context.CancellationToken;
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var method = root.FindToken(position).Parent?
+            .AncestorsAndSelf()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault();
+        if (method is null)
+        {
+            return;
+        }
+
+        if (IsInsidePathLiteral(root, position, method, out _))
+        {
+            foreach (var item in CreatePathPlaceholderItems(method))
+            {
+                context.AddItem(item);
+            }
+
+            return;
+        }
+
+        if (root.FindToken(position - 1).Parent is AttributeListSyntax)
+        {
+            foreach (var item in CreateHttpMethodItems(method))
+            {
+                context.AddItem(item);
+            }
+        }
+    }
+
+    static IEnumerable<CompletionItem> CreateHttpMethodItems(MethodDeclarationSyntax method)
+    {
+        var path = RestApiPathSuggestions.SuggestPath(method);
+        foreach (var verb in ProxyDomainCatalog.RestApiHttpMethodNames)
+        {
+            yield return CompletionItemFactory.Create(verb, $"{verb}(\"{path}\")]");
+        }
+    }
+
+    static IEnumerable<CompletionItem> CreatePathPlaceholderItems(MethodDeclarationSyntax method)
+    {
+        foreach (var name in RestApiPathSuggestions.GetNonCancellationParameterNames(method))
+        {
+            yield return CompletionItemFactory.Create($"{{{name}}}", $"{{{name}}}", name);
+        }
+    }
+
+    static bool IsInsidePathLiteral(
+        SyntaxNode root,
+        int position,
+        MethodDeclarationSyntax method,
+        out TextSpan literalSpan)
+    {
+        literalSpan = default;
+        foreach (var attributeList in method.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                if (!IsHttpMethodAttributeName(attribute.Name.ToString()))
+                {
+                    continue;
+                }
+
+                var firstArg = attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression;
+                if (firstArg is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.StringLiteralExpression } literal
+                    && literal.Span.Contains(position))
+                {
+                    literalSpan = literal.Span;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsHttpMethodAttributeName(string name) =>
+        ProxyDomainCatalog.RestApiHttpMethodNames.Any(verb =>
+            name is var n && (n == verb || n == verb + "Attribute"));
+}

--- a/Observables.Shared/Observables.Analyzers/RestApiPathSuggestions.cs
+++ b/Observables.Shared/Observables.Analyzers/RestApiPathSuggestions.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Observables.Analyzers;
+
+internal static class RestApiPathSuggestions
+{
+    internal static string SuggestPath(MethodDeclarationSyntax method)
+    {
+        var parameters = GetNonCancellationParameterNames(method);
+        if (parameters.Count == 0)
+        {
+            return "/" + method.Identifier.Text.ToLowerInvariant();
+        }
+
+        return "/" + string.Join("/", parameters.Select(p => "{" + p + "}"));
+    }
+
+    internal static IReadOnlyList<string> GetNonCancellationParameterNames(MethodDeclarationSyntax method) =>
+        method.ParameterList.Parameters
+            .Where(p => p.Type?.ToString() is not ("CancellationToken" or "System.Threading.CancellationToken"))
+            .Select(p => p.Identifier.Text)
+            .ToArray();
+}

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -28,6 +28,10 @@
 
     <Project Path="Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj" />
 
+    <Project Path="Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj" />
+
+    <Project Path="Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj" />
+
   </Folder>
 
   <Folder Name="/Events/">

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -74,6 +74,8 @@ sealed class Build : NukeBuild
         "Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators.Tests/Observables.WebSocket.Reactive.SourceGenerators.Tests.csproj",
         "Observables.WebSocket/Observables.WebSocket.Tests/Observables.WebSocket.Tests.csproj",
         "Observables.WebSocket/Observables.WebSocket.Reactive.Tests/Observables.WebSocket.Reactive.Tests.csproj",
+        "Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj",
+        "Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj",
     ];
 
     static readonly string[] PackProjectRelativePaths =
@@ -214,6 +216,9 @@ sealed class Build : NukeBuild
                     Assert.True(
                         entries.Contains("analyzers/dotnet/roslyn4.12/cs/Observables.CodeFixes.dll"),
                         $"{packageId}: missing Observables.CodeFixes.dll under analyzers/dotnet/roslyn4.12/cs/");
+                    Assert.True(
+                        entries.Contains("analyzers/dotnet/roslyn4.12/cs/Observables.Analyzers.dll"),
+                        $"{packageId}: missing Observables.Analyzers.dll under analyzers/dotnet/roslyn4.12/cs/");
                 }
 
                 if (packageId.StartsWith("Observables.Events.", StringComparison.Ordinal))

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -18,6 +18,8 @@
     <ObservablesSharedGeneratorProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.SourceGenerators.Shared/Observables.SourceGenerators.Shared.csproj</ObservablesSharedGeneratorProject>
     <ObservablesCodeFixesProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj</ObservablesCodeFixesProject>
     <ObservablesCodeFixesOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/bin/$(Configuration)/netstandard2.0/'))</ObservablesCodeFixesOutputDir>
+    <ObservablesAnalyzersProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj</ObservablesAnalyzersProject>
+    <ObservablesAnalyzersOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.Analyzers/bin/$(Configuration)/netstandard2.0/'))</ObservablesAnalyzersOutputDir>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 

--- a/eng/PackRoslynAnalyzer.targets
+++ b/eng/PackRoslynAnalyzer.targets
@@ -15,12 +15,15 @@
     <ObservablesPackSharedOutputDir Condition="'$(ObservablesPackSharedOutputDir)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.SourceGenerators.Shared/bin/$(Configuration)/netstandard2.0/'))</ObservablesPackSharedOutputDir>
     <ObservablesPackCodeFixesProject Condition="'$(ObservablesPackCodeFixesProject)' == ''">$(ObservablesCodeFixesProject)</ObservablesPackCodeFixesProject>
     <ObservablesPackCodeFixesOutputDir Condition="'$(ObservablesPackCodeFixesOutputDir)' == ''">$(ObservablesCodeFixesOutputDir)</ObservablesPackCodeFixesOutputDir>
+    <ObservablesPackAnalyzersProject Condition="'$(ObservablesPackAnalyzersProject)' == ''">$(ObservablesAnalyzersProject)</ObservablesPackAnalyzersProject>
+    <ObservablesPackAnalyzersOutputDir Condition="'$(ObservablesPackAnalyzersOutputDir)' == ''">$(ObservablesAnalyzersOutputDir)</ObservablesPackAnalyzersOutputDir>
   </PropertyGroup>
 
   <Target Name="ObservablesPackBuildAnalyzerInputs" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="$(ObservablesPackGeneratorProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" />
     <MSBuild Projects="$(ObservablesPackSharedGeneratorProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" />
     <MSBuild Projects="$(ObservablesPackCodeFixesProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" Condition="'$(ObservablesPackCodeFixesProject)' != ''" />
+    <MSBuild Projects="$(ObservablesPackAnalyzersProject)" Targets="Build" Properties="Configuration=$(Configuration);NoBuild=false" Condition="'$(ObservablesPackAnalyzersProject)' != ''" />
   </Target>
 
   <Target Name="ObservablesPackIncludeAnalyzers"
@@ -30,6 +33,7 @@
       <_ObservablesPackGeneratorDll>$(ObservablesPackGeneratorOutputDir)$(ObservablesPackGeneratorAssemblyName)</_ObservablesPackGeneratorDll>
       <_ObservablesPackSharedDll>$(ObservablesPackSharedOutputDir)Observables.SourceGenerators.Shared.dll</_ObservablesPackSharedDll>
       <_ObservablesPackCodeFixesDll>$(ObservablesPackCodeFixesOutputDir)Observables.CodeFixes.dll</_ObservablesPackCodeFixesDll>
+      <_ObservablesPackAnalyzersDll>$(ObservablesPackAnalyzersOutputDir)Observables.Analyzers.dll</_ObservablesPackAnalyzersDll>
     </PropertyGroup>
     <Error Condition="!Exists('$(_ObservablesPackGeneratorDll)')"
            Text="Observables pack: missing generator assembly '$(_ObservablesPackGeneratorDll)'." />
@@ -37,10 +41,13 @@
            Text="Observables pack: missing shared assembly '$(_ObservablesPackSharedDll)'." />
     <Error Condition="'$(ObservablesPackCodeFixesProject)' != '' and !Exists('$(_ObservablesPackCodeFixesDll)')"
            Text="Observables pack: missing code fix assembly '$(_ObservablesPackCodeFixesDll)'." />
+    <Error Condition="'$(ObservablesPackAnalyzersProject)' != '' and !Exists('$(_ObservablesPackAnalyzersDll)')"
+           Text="Observables pack: missing analyzer assembly '$(_ObservablesPackAnalyzersDll)'." />
     <ItemGroup>
       <None Include="$(_ObservablesPackGeneratorDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" />
       <None Include="$(_ObservablesPackSharedDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" />
       <None Include="$(_ObservablesPackCodeFixesDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" Condition="'$(ObservablesPackCodeFixesProject)' != '' and Exists('$(_ObservablesPackCodeFixesDll)')" />
+      <None Include="$(_ObservablesPackAnalyzersDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" Condition="'$(ObservablesPackAnalyzersProject)' != '' and Exists('$(_ObservablesPackAnalyzersDll)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="build/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="buildTransitive/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

- Add `Observables.Analyzers` with standalone Roslyn analyzers and completion providers (Phase 3).
- **OBS0001**: report when both `R3` and an Observables `.Reactive` bridge assembly are referenced for the same feature domain.
- **OBS4007 / OBS5007 / OBS6007**: warn on empty `[Hub]` / `[Mqtt]` / `[WebSocket]` proxy interfaces.
- **Completion**: boundary attributes inside proxy interfaces; RestAPI HTTP verbs and `{parameter}` path placeholders.
- Pack `Observables.Analyzers.dll` alongside generator and CodeFix assemblies; extend `PackVerify` and Nuke unit-test list.

## Test plan

- [x] `dotnet test Observables.Shared/Observables.Analyzers.Tests` (10 tests)
- [x] Nuke `PackVerify` (Release)
- [ ] CI green after merge

Closes #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New compile-time errors (OBS0001) and warnings ship in consumer packages; incorrect reference or empty-interface detection could affect existing projects, though behavior is covered by tests and PackVerify.
> 
> **Overview**
> Introduces **`Observables.Analyzers`**, a standalone Roslyn assembly shipped inside existing feature NuGet packages (alongside generators and CodeFixes), with **unit tests** and **pack/CI wiring**.
> 
> **Diagnostics:** **OBS0001** (compilation-end error) when both **R3** and a domain **`.Reactive`** bridge are referenced (SignalR, Mqtt, WebSocket, RestAPI). **OBS4007 / OBS5007 / OBS6007** warn on empty **`[Hub]` / `[Mqtt]` / `[WebSocket]`** proxy interfaces with no public instance members.
> 
> **IDE completion:** **`BoundaryAttributeCompletionProvider`** suggests domain boundary attributes on methods/properties inside marked proxy interfaces (via **`ProxyDomainCatalog`**). **`RestApiMemberCompletionProvider`** offers HTTP verb attributes with **`RestApiPathSuggestions`**-derived paths and **`{param}`** placeholders inside path string literals.
> 
> **Build:** **`PackRoslynAnalyzer.targets`** and **`Observables.Package.props`** build and pack **`Observables.Analyzers.dll`**; **`build/Program.cs`** **`PackVerify`** and the Nuke test list include the new test project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325d4fc8dc2753da861d918beb290c1aa3c905e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->