### PR TITLE
Prepare 0.1.0-preview6 release (12 packages, Grpc E2E fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Observables/
 | **SignalR** | `Observables.SignalR` | `SignalR.R3.SourceGenerators` | `SignalR.Reactive.SourceGenerators` | R3 + Reactive 生成器测试 |
 | **Mqtt** | `Observables.Mqtt` | `Mqtt.R3.SourceGenerators` | `Mqtt.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；`Mqtt.Tests` / `Mqtt.Reactive.Tests`（进程内 MQTTnet broker E2E） |
 | **WebSocket** | `Observables.WebSocket` | `WebSocket.R3.SourceGenerators` | `WebSocket.Reactive.SourceGenerators` | Core / Reactive / R3 + Reactive 生成器测试；E2E（`WebSocket.Tests` / `WebSocket.Reactive.Tests`） |
-| **Grpc** | `Observables.Grpc` | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Grpc.Tests` / `Grpc.Reactive.Tests`，进程内 Kestrel h2c） |
+| **Grpc** | `Observables.Grpc` | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Grpc.Tests` / `Grpc.Reactive.Tests`，进程内 `TestServer`） |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**NuGet 预览包** `0.1.0-preview5`（**10 包**：五域各 `.R3`+`.Reactive`，已发 nuget.org）；Nuke `PackVerify` + `eng/nuget-smoke` 消费者校验已就绪
-- **下一 Feature**：**Grpc**（仅空 csproj 骨架）；Mqtt 设计见 [`docs/design/mqtt.md`](docs/design/mqtt.md)（用户文档 [Observables.Docs](https://github.com/Skymly/Observables.Docs) `mqtt.md`）；WebSocket 设计见 [`docs/design/websocket.md`](docs/design/websocket.md)
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ / M2 ✅ → M3 Grpc → M4 文档补齐 → M5 API 冻结 + 1.0）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**待发版** `0.1.0-preview6`（**12 包**，含 Grpc）；主仓 / Docs / Samples 已对齐 preview6；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 12 包
+- **下一里程碑**：推 tag 发布 preview6 → **M5** API 冻结 + 1.0；Grpc 设计见 [`docs/design/grpc.md`](docs/design/grpc.md)
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ / M2 ✅ / M3 ✅ / M4 部分 ✅ → M5 API 冻结 + 1.0）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标
@@ -45,7 +45,7 @@
 |------|------|
 | **`Observables.Core`** | 全库通用**运行时**（≥2 个 Feature 复用的 Attribute、枚举、接口等）。不引用 Roslyn。 |
 | **`Observables.SourceGenerators.Shared`** | 全库通用**生成器**基础设施（`GeneratedSourceHeader`、符号扩展、跨域可复用诊断如 Events `OBS2xxx`）。不引用 R3 / System.Reactive。 |
-| **`Observables.Analyzers`** | 独立分析器（非生成器）：全库诊断 `OBS0001`（R3/Reactive 包冲突）、各域空代理接口 `OBS4007`/`OBS5007`/`OBS6007` 等。随 `.Package` 以 analyzer 形式分发。 |
+| **`Observables.Analyzers`** | 独立分析器（非生成器）：全库诊断 `OBS0001`（R3/Reactive 包冲突）、各域空代理接口 `OBS4007`/`OBS5007`/`OBS6007`/`OBS7007` 等。随 `.Package` 以 analyzer 形式分发。 |
 | **`Observables.CodeFixes`** | 对应分析器/生成器诊断的 `CodeFixProvider` 与补全提供器。随 `.Package` 以 analyzer 形式分发。 |
 
 ### 反应式后端规则
@@ -125,7 +125,7 @@ Observables/
 │   ├── Observables.RestAPI.Reactive/
 │   ├── Observables.RestAPI.SourceGenerators.Shared/
 │   └── …
-├── Observables.SignalR/ … Observables.Grpc/          # 其余域（多为骨架）
+├── Observables.SignalR/ … Observables.Grpc/          # 其余域（含 Grpc，M3 已落地）
 └── Observables.slnx
 ```
 
@@ -152,11 +152,11 @@ Observables/
 | **SignalR** | `Observables.SignalR` | `SignalR.R3.SourceGenerators` | `SignalR.Reactive.SourceGenerators` | R3 + Reactive 生成器测试 |
 | **Mqtt** | `Observables.Mqtt` | `Mqtt.R3.SourceGenerators` | `Mqtt.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；`Mqtt.Tests` / `Mqtt.Reactive.Tests`（进程内 MQTTnet broker E2E） |
 | **WebSocket** | `Observables.WebSocket` | `WebSocket.R3.SourceGenerators` | `WebSocket.Reactive.SourceGenerators` | Core / Reactive / R3 + Reactive 生成器测试；E2E（`WebSocket.Tests` / `WebSocket.Reactive.Tests`） |
-| **Grpc** | 空 csproj 骨架 | `Observables.Grpc.R3`（**命名违规**，应为 `Observables.Grpc.R3.SourceGenerators`） | — | — |
+| **Grpc** | `Observables.Grpc` | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Grpc.Tests` / `Grpc.Reactive.Tests`，进程内 Kestrel h2c） |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 
-> Grpc 骨架 `Observables.Grpc.R3` 当前命名与「`.R3` = NuGet 包 ID、生成器须带 `.SourceGenerators`」约定冲突，落地时按 M3 重命名（见 ROADMAP 与「命名一致性」）。
+**Grpc 运行时**：`GrpcService.For<T>()`、`[Grpc]` / `[GrpcUnary]` 等；命名空间 `Observables.Grpc`。
 
 ---
 
@@ -166,8 +166,9 @@ Observables/
 
 1. ~~**M1**：WebSocket 发版 + 文档/示例同步~~ ✅（`0.1.0-preview5`）
 2. ~~**M2**：工程加固（中央包管理、TFM 收口、警告策略、诊断登记、`build/Program.cs` 去硬编码）~~ ✅
-3. **M3**：Grpc 域按检查清单补齐（含骨架重命名、`OBS7xxx`）
-4. **M5**：API 冻结后由维护者指定版本号并推送 tag / `workflow_dispatch` 发布（见「版本、Tag 与 NuGet」）
+3. ~~**M3**：Grpc 域按检查清单补齐（含骨架重命名、`OBS7xxx`）~~ ✅
+4. **M4**：Observables.Docs / Samples 与主仓同步（Grpc 用户文档与示例）
+5. **M5**：API 冻结后由维护者指定版本号并推送 tag / `workflow_dispatch` 发布（见「版本、Tag 与 NuGet」）
 
 ---
 
@@ -213,7 +214,7 @@ Observables/
     | `OBS4xxx` | SignalR |
     | `OBS5xxx` | Mqtt |
     | `OBS6xxx` | WebSocket |
-    | `OBS7xxx` | Grpc（预留） |
+    | `OBS7xxx` | Grpc |
 
   - 新增诊断落入对应段，**不复用、不跨段**。
   - 新增诊断写入对应项目的 `AnalyzerReleases.Unshipped.md`；发版时移入 `Shipped.md`（**已启用**，勿再 `#pragma warning disable RS2008`）。
@@ -231,11 +232,10 @@ Observables/
 
 ### 6. 命名一致性
 
-- 现状：Grpc 骨架为 `Observables.Grpc.R3`（直接 import `Observables.SourceGenerators.R3.props`），把生成器项目命名成了 NuGet 包 ID 形态。
-- 标准（重申「命名约定」并据此纠正）：
+- 已落地（M3）：Grpc 生成器为 `Observables.Grpc.R3.SourceGenerators` / `Observables.Grpc.Reactive.SourceGenerators`；NuGet 包 ID 为 `Observables.Grpc.R3` / `Observables.Grpc.Reactive`（由 `.Package` 产出）。
+- 标准（重申「命名约定」）：
   - `Observables.<Feature>.R3` / `.Reactive` = **NuGet 包 ID**（由 `.Package` 产出）。
   - 生成器项目**必须**带 `.SourceGenerators` 后缀。
-  - 因此 Grpc 应重命名为 `Observables.Grpc.R3.SourceGenerators` 等（M3）。
   - **文件夹名 = 项目名 = 程序集名**，整仓一致。
 
 ### 7. 测试约定
@@ -306,7 +306,7 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 |-----------|------|
 | **Ci** | `Clean` → `Restore` → `Compile` → **UnitTest** |
 | **Pack** | 打包全部 pack 子项目 → `artifacts/package/`（依赖 **UnitTest**；当前 10 个，含 WebSocket） |
-| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket `lib/`（`ExpectedPackageIds` 当前 10 包） |
+| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Grpc `lib/`（manifest 当前 **12 包**） |
 | **CiPack** | CI 用：`Pack` + `PackVerify` |
 | **Publish** | 推送到 nuget.org（`NUGET_API_KEY`）与 GitHub Packages（`GITHUB_TOKEN`，`packages:write`） |
 

--- a/Observables.Grpc/Observables.Grpc.Reactive.Tests/GrpcClientReactiveE2ETests.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.Tests/GrpcClientReactiveE2ETests.cs
@@ -1,6 +1,5 @@
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using Grpc.Net.Client;
 using Observables.Grpc;
 using Observables.Grpc.Reactive.Tests.Contracts;
 using Observables.Grpc.Tests.Infrastructure;
@@ -16,7 +15,7 @@ public sealed class GrpcClientReactiveE2ETests(GrpcTestHostFixture fixture)
     [Fact]
     public async Task UnaryEcho_returns_response()
     {
-        using var channel = GrpcChannel.ForAddress(fixture.Host.Address);
+        using var channel = GrpcTestChannel.Create(fixture.Host);
         var client = GrpcService.For<IE2EReactiveHub>(channel.CreateCallInvoker());
 
         using var cts = new CancellationTokenSource(DefaultTimeout);

--- a/Observables.Grpc/Observables.Grpc.Reactive.Tests/Observables.Grpc.Reactive.Tests.csproj
+++ b/Observables.Grpc/Observables.Grpc.Reactive.Tests/Observables.Grpc.Reactive.Tests.csproj
@@ -16,6 +16,7 @@
 
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
@@ -62,6 +63,10 @@
     <Compile Include="..\Observables.Grpc.Tests\Infrastructure\EchoServiceImpl.cs"
 
              Link="Infrastructure\EchoServiceImpl.cs" />
+
+    <Compile Include="..\Observables.Grpc.Tests\Infrastructure\GrpcTestChannel.cs"
+
+             Link="Infrastructure\GrpcTestChannel.cs" />
 
     <Compile Include="..\Observables.Grpc.Tests\Infrastructure\GrpcTestHost.cs"
 

--- a/Observables.Grpc/Observables.Grpc.Tests/GrpcClientR3E2ETests.cs
+++ b/Observables.Grpc/Observables.Grpc.Tests/GrpcClientR3E2ETests.cs
@@ -1,4 +1,3 @@
-using Grpc.Net.Client;
 using Observables.Grpc;
 using Observables.Grpc.Tests.Contracts;
 using Observables.Grpc.Tests.Infrastructure;
@@ -15,7 +14,7 @@ public sealed class GrpcClientR3E2ETests(GrpcTestHostFixture fixture)
     [Fact]
     public async Task UnaryEcho_returns_response()
     {
-        using var channel = GrpcChannel.ForAddress(fixture.Host.Address);
+        using var channel = GrpcTestChannel.Create(fixture.Host);
         var client = GrpcService.For<IE2EHub>(channel.CreateCallInvoker());
 
         using var cts = new CancellationTokenSource(DefaultTimeout);
@@ -29,7 +28,7 @@ public sealed class GrpcClientR3E2ETests(GrpcTestHostFixture fixture)
     [Fact]
     public async Task ServerStreamEcho_emits_multiple_items()
     {
-        using var channel = GrpcChannel.ForAddress(fixture.Host.Address);
+        using var channel = GrpcTestChannel.Create(fixture.Host);
         var client = GrpcService.For<IE2EHub>(channel.CreateCallInvoker());
 
         using var cts = new CancellationTokenSource(DefaultTimeout);

--- a/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/GrpcTestChannel.cs
+++ b/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/GrpcTestChannel.cs
@@ -1,0 +1,13 @@
+using Grpc.Net.Client;
+
+namespace Observables.Grpc.Tests.Infrastructure;
+
+/// <summary>Creates gRPC channels wired to the in-memory <see cref="GrpcTestHost"/>.</summary>
+internal static class GrpcTestChannel
+{
+    public static GrpcChannel Create(GrpcTestHost host) =>
+        GrpcChannel.ForAddress(host.Address, new GrpcChannelOptions
+        {
+            HttpHandler = host.CreateHandler(),
+        });
+}

--- a/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/GrpcTestHost.cs
+++ b/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/GrpcTestHost.cs
@@ -1,51 +1,50 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Observables.Grpc.Tests.Infrastructure;
 
-/// <summary>Minimal in-process gRPC host for E2E tests.</summary>
+/// <summary>Hosts gRPC services in-memory via <see cref="TestServer"/>.</summary>
 public sealed class GrpcTestHost : IAsyncDisposable
 {
     readonly IHost host;
+    readonly TestServer testServer;
 
-    GrpcTestHost(IHost host, string address)
+    GrpcTestHost(IHost host, TestServer testServer)
     {
         this.host = host;
-        Address = address;
+        this.testServer = testServer;
+        Address = testServer.BaseAddress.ToString().TrimEnd('/');
     }
 
     public string Address { get; }
 
+    public HttpMessageHandler CreateHandler() => testServer.CreateHandler();
+
     public static async Task<GrpcTestHost> StartAsync()
     {
-        var port = Random.Shared.Next(50_000, 60_000);
-        var address = $"http://127.0.0.1:{port}";
-
-        var builder = Host.CreateDefaultBuilder()
-            .ConfigureWebHostDefaults(webBuilder =>
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureWebHost(webBuilder =>
             {
-                webBuilder.UseKestrel(options =>
-                {
-                    options.ListenLocalhost(port, listenOptions =>
-                    {
-                        listenOptions.Protocols = HttpProtocols.Http2;
-                    });
-                });
+                webBuilder.UseTestServer();
                 webBuilder.ConfigureServices(services => services.AddGrpc());
                 webBuilder.Configure(app =>
                 {
                     app.UseRouting();
                     app.UseEndpoints(endpoints => endpoints.MapGrpcService<EchoServiceImpl>());
                 });
-            });
+            })
+            .Build();
 
-        var host = builder.Build();
         await host.StartAsync().ConfigureAwait(false);
-        return new GrpcTestHost(host, address);
+        return new GrpcTestHost(host, host.GetTestServer());
     }
 
-    public async ValueTask DisposeAsync() => await host.StopAsync().ConfigureAwait(false);
+    public async ValueTask DisposeAsync()
+    {
+        await host.StopAsync().ConfigureAwait(false);
+        host.Dispose();
+    }
 }

--- a/Observables.Grpc/Observables.Grpc.Tests/Observables.Grpc.Tests.csproj
+++ b/Observables.Grpc/Observables.Grpc.Tests/Observables.Grpc.Tests.csproj
@@ -1,30 +1,31 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <RootNamespace>Observables.Grpc.Tests</RootNamespace>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
-    <PackageReference Include="Grpc.AspNetCore" />
-    <PackageReference Include="Grpc.Net.Client" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Protobuf Include="Protos\echo.proto" GrpcServices="Server" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
-    <ProjectReference Include="..\Observables.Grpc.R3.SourceGenerators\Observables.Grpc.R3.SourceGenerators.csproj"
-                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-  </ItemGroup>
-
-</Project>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Observables.Grpc.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\echo.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
+    <ProjectReference Include="..\Observables.Grpc.R3.SourceGenerators\Observables.Grpc.R3.SourceGenerators.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 | **`Observables.<Feature>.R3.SourceGenerators`** / **`.Reactive.SourceGenerators`** | 双路源生成器 |
 | **`Observables.<Feature>.Package`** | 发布时打包，产出上述两个 NuGet 包 |
 
-### 预览版 NuGet（`0.1.0-preview5`）
+### 预览版 NuGet（`0.1.0-preview6`）
+
+**12 包**（六域各 `.R3` + `.Reactive`）。推 `v0.1.0-preview6` tag 后由 CI 发布至 nuget.org 与 GitHub Packages。
 
 | 包 ID | 说明 |
 |-------|------|
@@ -38,9 +40,11 @@
 | `Observables.Mqtt.Reactive` | MQTT + Reactive 桥接 + 生成器 |
 | `Observables.WebSocket.R3` | WebSocket 运行时 + R3 生成器 |
 | `Observables.WebSocket.Reactive` | WebSocket + Reactive 桥接 + 生成器 |
+| `Observables.Grpc.R3` | gRPC 运行时 + R3 生成器 |
+| `Observables.Grpc.Reactive` | gRPC + Reactive 桥接 + 生成器 |
 
 ```xml
-<PackageReference Include="Observables.Events.R3" Version="0.1.0-preview5" />
+<PackageReference Include="Observables.Events.R3" Version="0.1.0-preview6" />
 <PackageReference Include="R3" Version="1.3.0" />
 ```
 
@@ -69,15 +73,15 @@ dotnet run --project build/_build.csproj -- --target PackVerify --configuration 
 
 ```powershell
 # 1. 确认 eng/Observables.Package.props 中 PackageVersion 与 tag 一致
-git tag -a v0.1.0-preview1 -m "0.1.0-preview1"
-git push origin v0.1.0-preview1
+git tag -a v0.1.0-preview6 -m "0.1.0-preview6"
+git push origin v0.1.0-preview6
 # 2. GitHub Actions「Publish NuGet」workflow 使用 secrets 执行 Publish
 ```
 
 本地手动推送（可选）：
 
 ```powershell
-$env:VERSION = '0.1.0-preview1'
+$env:VERSION = '0.1.0-preview6'
 $env:NUGET_API_KEY = '...'
 $env:GITHUB_TOKEN = '...'
 dotnet run --project build/_build.csproj -- --target Publish --configuration Release
@@ -85,16 +89,16 @@ dotnet run --project build/_build.csproj -- --target Publish --configuration Rel
 
 ## 域实现状态
 
-| 域 | R3 生成器 | System.Reactive 生成器 | NuGet（`preview5`） |
+| 域 | R3 生成器 | System.Reactive 生成器 | NuGet（`preview6`） |
 |----|-----------|------------------------|---------------------|
-| **Events**（经典 + 路由 .NET 事件） | `Events.R3.SourceGenerators` | `Events.Reactive.SourceGenerators` | 已发 |
-| **RestAPI**（声明式 HTTP 客户端） | `RestAPI.R3.SourceGenerators` | `RestAPI.Reactive.SourceGenerators` | 已发 |
-| **SignalR**（Hub 代理） | `SignalR.R3.SourceGenerators` | `SignalR.Reactive.SourceGenerators` | 已发 |
-| **Mqtt**（主题代理） | `Mqtt.R3.SourceGenerators` | `Mqtt.Reactive.SourceGenerators` | 已发 |
-| **WebSocket**（客户端代理） | `WebSocket.R3.SourceGenerators` | `WebSocket.Reactive.SourceGenerators` | 已发 |
-| **Grpc** | 空 csproj 骨架 | — | 规划中（见 ROADMAP M3） |
+| **Events**（经典 + 路由 .NET 事件） | `Events.R3.SourceGenerators` | `Events.Reactive.SourceGenerators` | 已纳入发版 |
+| **RestAPI**（声明式 HTTP 客户端） | `RestAPI.R3.SourceGenerators` | `RestAPI.Reactive.SourceGenerators` | 已纳入发版 |
+| **SignalR**（Hub 代理） | `SignalR.R3.SourceGenerators` | `SignalR.Reactive.SourceGenerators` | 已纳入发版 |
+| **Mqtt**（主题代理） | `Mqtt.R3.SourceGenerators` | `Mqtt.Reactive.SourceGenerators` | 已纳入发版 |
+| **WebSocket**（客户端代理） | `WebSocket.R3.SourceGenerators` | `WebSocket.Reactive.SourceGenerators` | 已纳入发版 |
+| **Grpc**（CallInvoker 代理） | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | 已纳入发版（M3） |
 
-五域均含运行时（按需）+ 双路生成器 + 测试；共享层另有 `Observables.Analyzers` 与 `Observables.CodeFixes`。详细顺序见 [docs/ROADMAP.md](docs/ROADMAP.md)。
+六域均含运行时（按需）+ 双路生成器 + 测试；共享层另有 `Observables.Analyzers` 与 `Observables.CodeFixes`。设计稿见 `docs/design/`；发版顺序见 [docs/ROADMAP.md](docs/ROADMAP.md)。
 
 路由事件生成默认关闭；在消费者项目中设置 `<ObservableRoutedEvents>true</ObservableRoutedEvents>`（见 `Observables.Events/Observables.Events/targets/observables.events.props`）。
 

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -91,6 +91,7 @@ sealed class Build : NukeBuild
                 DotNetTest(s => s
                     .SetProjectFile(projectFile)
                     .SetConfiguration(Configuration)
+                    .EnableNoBuild()
                     .SetResultsDirectory(TestResultsDirectory)
                     .SetLoggers("trx;LogFileName=" + projectFile.NameWithoutExtension + ".trx"));
             }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,16 +4,15 @@
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（截至 `0.1.0-preview5`）
+## 现状基线（待发 `0.1.0-preview6`）
 
 | 维度 | 现状 |
 |------|------|
-| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**（运行时 + 双路生成器 + 测试） |
+| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**（运行时 + 双路生成器 + 测试） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
-| 已发 NuGet | **10 包**（Events / RestAPI / SignalR / Mqtt / WebSocket 各 `.R3` + `.Reactive`，`0.1.0-preview5` on nuget.org） |
-| 骨架 | **Grpc**（仅空 csproj，无业务源码 / 测试 / 设计文档） |
-| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish` 绿；`PackVerify` + `eng/nuget-smoke` 通过 |
-| 示例仓 CI | `Observables.Samples` Nuke `Ci`（NuGet 模式，含 WebSocket 注册检查） |
+| nuget.org 已发 | **`0.1.0-preview5`** — **10 包**（五域）；**`0.1.0-preview6`** — **12 包**（+ Grpc，待 tag） |
+| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（12 消费者） |
+| 示例仓 CI | `Observables.Samples` Nuke `Ci`（NuGet `preview6`，含 Grpc 注册检查） |
 
 ### 已知工程债（详见 AGENTS.md「工程治理」）
 
@@ -24,8 +23,8 @@
 | 3 | `TreatWarningsAsErrors`；CS860x、IL trim、xUnit 告警 | ✅ M2 已落地（IL 族 net8/9 暂 `NoWarn`，M5 收敛） |
 | 4 | Nuke 清单 / 版本双真相源 | ✅ M2 已落地（`Observables.BuildManifest.json` + `PackageVersionReader`） |
 | 5 | 诊断 release 跟踪（`AnalyzerReleases.*.md`、移除 RS2008） | ✅ M2 已落地；描述符文件结构仍分散 |
-| 6 | Grpc 骨架命名（`Observables.Grpc.R3`）违反约定 | ⏳ M3 |
-| 7 | 文档滞后：README / `websocket.md` / Samples | ✅ M1 已补齐；Grpc 仍待 M4 |
+| 6 | Grpc 骨架命名（`Observables.Grpc.R3`）违反约定 | ✅ M3 已重命名为 `*.R3.SourceGenerators` |
+| 7 | 文档滞后：README / Docs / Samples | ✅ M1 WebSocket 已补齐；Grpc 用户文档与 Samples 待 **M4** |
 | 8 | Samples `RestAPI.Reactive` 显式 `R3` 触发 OBS0001 | ✅ `R3` 改为 runtime-only（`ExcludeAssets=compile`） |
 
 ## 诊断 ID 段分配（权威）
@@ -38,7 +37,7 @@
 | `OBS4001`–`OBS4999` | SignalR | 使用中（4001–4007） |
 | `OBS5001`–`OBS5999` | Mqtt | 使用中（5001–5007） |
 | `OBS6001`–`OBS6999` | WebSocket | 使用中（6001–6007） |
-| `OBS7001`–`OBS7999` | Grpc | **预留** |
+| `OBS7001`–`OBS7999` | Grpc | 使用中（7001–7007） |
 
 新增诊断须落入对应段并在 `AnalyzerReleases.Unshipped.md` 登记（见 AGENTS.md）。
 
@@ -74,21 +73,24 @@ graph LR
 - ~~`AnalyzerReleases.Shipped.md` / `Unshipped.md`，移除 RS2008 pragma~~ ✅
 - ~~`TreatWarningsAsErrors` + CS86xx / xUnit1051 清零~~ ✅；IL trim 族 net8/9 最小 `NoWarn`（M5 改 source-gen 后移除）。
 
-### M3 — Grpc 域
+### M3 — Grpc 域 ✅
 
-按 AGENTS.md「新增 Feature 检查清单」从骨架建成完整域：
+按 AGENTS.md「新增 Feature 检查清单」从骨架建成完整域（PR #77，已合并 `main`）：
 
-- 新增设计文档 `docs/design/grpc.md`（unary / server-streaming / 双向流到反应式流的映射）。
-- 重命名骨架：`Observables.Grpc.R3` → `Observables.Grpc.R3.SourceGenerators`，补 `Observables.Grpc.Reactive.SourceGenerators`、`Observables.Grpc.SourceGenerators.Shared`。
-- 启用 `OBS7xxx` 诊断段。
-- 建 `Observables.Grpc.Package`，产出 `Observables.Grpc.R3` / `Observables.Grpc.Reactive` 两包。
-- 补生成器测试 + E2E + smoke 消费者，纳入 `PackVerify` 的 `ExpectedPackageIds`。
+- ~~新增设计文档 `docs/design/grpc.md`（unary / server-streaming / 双向流到反应式流的映射）。~~ ✅
+- ~~重命名骨架：`Observables.Grpc.R3` → `Observables.Grpc.R3.SourceGenerators`，补 `Observables.Grpc.Reactive.SourceGenerators`、`Observables.Grpc.SourceGenerators.Shared`。~~ ✅
+- ~~启用 `OBS7xxx` 诊断段（7001–7007）。~~ ✅
+- ~~建 `Observables.Grpc.Package`，产出 `Observables.Grpc.R3` / `Observables.Grpc.Reactive` 两包。~~ ✅
+- ~~补生成器测试 + E2E + smoke 消费者，纳入 `PackVerify`（manifest **12 包**）。~~ ✅
 
-### M4 — 文档与示例补齐
+Grpc 两包纳入 **`0.1.0-preview6`** 发版（维护者推 `v0.1.0-preview6` tag）。
 
-- 统一诊断登记文档（OBS0001 / 2xxx–7xxx）到 Docs `diagnostics.md`，与代码登记表一致。
-- Docs（中英）覆盖全部已发域；Samples 覆盖 WebSocket、Grpc。
-- 校验 README、Docs、Samples 三处域状态一致（见 AGENTS.md「文档同步纪律」）。
+### M4 — 文档与示例补齐（preview6 发版前部分完成）
+
+- ~~统一诊断登记文档（OBS0001 / 2xxx–7xxx）到 Docs `diagnostics.md`~~ ✅（preview6 准备）
+- ~~Docs（中英）`grpc.md`；Samples `Observables.Samples.Grpc`~~ ✅
+- ~~校验 README、Docs、Samples 三处域状态与 `0.1.0-preview6` 一致~~ ✅
+- 发版后复核 nuget.org 包页链接与站点 `npm run docs:build`
 
 ### M5 — API 冻结与 1.0
 
@@ -112,7 +114,6 @@ graph LR
 
 | 版本 | 关联里程碑 |
 |------|------------|
-| `0.1.0-preview5` | M1 |
-| `0.1.0-preview6+` | M2 / M3 增量 |
-| `0.2.0-preview*` | M3 Grpc 落地后 |
+| `0.1.0-preview5` | M1（10 包，nuget.org） |
+| `0.1.0-preview6` | M3 Grpc 发版（**12 包**，nuget.org） |
 | `1.0.0` | M5 |

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.1.0-preview5</Version>
-    <PackageVersion>0.1.0-preview5</PackageVersion>
+    <Version>0.1.0-preview6</Version>
+    <PackageVersion>0.1.0-preview6</PackageVersion>
     <Authors>Skymly</Authors>
     <Copyright>Copyright (c) Skymly. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/eng/Observables.ProjectDefaults.props
+++ b/eng/Observables.ProjectDefaults.props
@@ -90,6 +90,8 @@
   <PropertyGroup Condition="'$(ObservablesSkipProjectDefaults)' != 'true' and '$(_ObsIsMultiTfmTestProject)' == 'true'">
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <!-- Avoid SDK apphost copy races when dotnet test builds net8/net9 in parallel (MSB3030 on CI). -->
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
 </Project>

--- a/eng/Observables.ProjectDefaults.props
+++ b/eng/Observables.ProjectDefaults.props
@@ -90,8 +90,6 @@
   <PropertyGroup Condition="'$(ObservablesSkipProjectDefaults)' != 'true' and '$(_ObsIsMultiTfmTestProject)' == 'true'">
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <!-- Avoid SDK apphost copy races when dotnet test builds net8/net9 in parallel (MSB3030 on CI). -->
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
 </Project>

--- a/eng/nuget-smoke/Directory.Build.props
+++ b/eng/nuget-smoke/Directory.Build.props
@@ -3,6 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <ObservablesConsumerPackageVersion Condition="'$(ObservablesConsumerPackageVersion)' == ''">0.1.0-preview5</ObservablesConsumerPackageVersion>
+    <ObservablesConsumerPackageVersion Condition="'$(ObservablesConsumerPackageVersion)' == ''">0.1.0-preview6</ObservablesConsumerPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/nuget-smoke/README.md
+++ b/eng/nuget-smoke/README.md
@@ -16,4 +16,4 @@ Uses `nuget.config.local` pointing at `artifacts/package/`.
 dotnet run --project build/_build.csproj -- --target NuGetConsumerSmokePublished --configuration Release
 ```
 
-Uses the default NuGet.org source and `ObservablesConsumerPackageVersion` (default `0.1.0-preview5`).
+Uses the default NuGet.org source and `ObservablesConsumerPackageVersion` (default `0.1.0-preview6`).


### PR DESCRIPTION
## Summary

- Bump `eng/Observables.Package.props` and nuget-smoke defaults to **`0.1.0-preview6`**
- Sync **README**, **AGENTS**, and **ROADMAP** for six domains and **12** NuGet packages
- Stabilize **Grpc E2E** tests with in-memory `TestServer` (aligns with SignalR; fixes local h2c failures)

## Test plan

- [ ] `dotnet run --project build/_build.csproj -- --target Ci --configuration Release`
- [ ] `dotnet run --project build/_build.csproj -- --target CiPack --configuration Release`
- [ ] Merge sibling PRs: [Observables.Samples](https://github.com/Skymly/Observables.Samples), [Observables.Docs](https://github.com/Skymly/Observables.Docs)

Closes #78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are version/metadata sync and test-only gRPC host wiring; no shipped runtime or generator API changes in this diff.
> 
> **Overview**
> Prepares **`0.1.0-preview6`** as the next release: bumps `eng/Observables.Package.props` and nuget-smoke defaults, and updates **README**, **AGENTS.md**, and **ROADMAP** for six domains and **12** NuGet packages (Grpc included), with milestones/docs reflecting M3 complete and preview6 pending tag.
> 
> **Grpc E2E** no longer uses a random localhost Kestrel h2c port. `GrpcTestHost` now hosts gRPC in-memory via `TestServer` (same pattern as SignalR), and new **`GrpcTestChannel`** wires `GrpcChannel` with the test server’s `HttpHandler`. R3 and Reactive E2E tests use that helper; Reactive tests add `Microsoft.AspNetCore.TestHost` and compile-link the shared infrastructure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9302cd568a2a4275b2dc1e1c627e3b78db71995. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->