### PR TITLE
Close M4 post-preview6 hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**待发版** `0.1.0-preview6`（**12 包**，含 Grpc）；主仓 / Docs / Samples 已对齐 preview6；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 12 包
-- **下一里程碑**：推 tag 发布 preview6 → **M5** API 冻结 + 1.0；Grpc 设计见 [`docs/design/grpc.md`](docs/design/grpc.md)
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ / M2 ✅ / M3 ✅ / M4 部分 ✅ → M5 API 冻结 + 1.0）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.0-preview6`（**12 包**，含 Grpc）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 12 包
+- **下一里程碑**：**M5** API 冻结 + 1.0；Grpc 设计见 [`docs/design/grpc.md`](docs/design/grpc.md)
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ / M2 ✅ / M3 ✅ / M4 ✅ → M5 API 冻结 + 1.0）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### 预览版 NuGet（`0.1.0-preview6`）
 
-**12 包**（六域各 `.R3` + `.Reactive`）。推 `v0.1.0-preview6` tag 后由 CI 发布至 nuget.org 与 GitHub Packages。
+**12 包**（六域各 `.R3` + `.Reactive`）。**`0.1.0-preview6`** 已发布至 [nuget.org](https://www.nuget.org/profiles/Skymly) 与 GitHub Packages（tag `v0.1.0-preview6`）。
 
 | 包 ID | 说明 |
 |-------|------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,13 +4,13 @@
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（待发 `0.1.0-preview6`）
+## 现状基线（`0.1.0-preview6` 已发 nuget.org）
 
 | 维度 | 现状 |
 |------|------|
 | 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**（运行时 + 双路生成器 + 测试） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
-| nuget.org 已发 | **`0.1.0-preview5`** — **10 包**（五域）；**`0.1.0-preview6`** — **12 包**（+ Grpc，待 tag） |
+| nuget.org 已发 | **`0.1.0-preview5`** — **10 包**（五域）；**`0.1.0-preview6`** — **12 包**（+ Grpc，`v0.1.0-preview6` tag） |
 | 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（12 消费者） |
 | 示例仓 CI | `Observables.Samples` Nuke `Ci`（NuGet `preview6`，含 Grpc 注册检查） |
 
@@ -24,7 +24,7 @@
 | 4 | Nuke 清单 / 版本双真相源 | ✅ M2 已落地（`Observables.BuildManifest.json` + `PackageVersionReader`） |
 | 5 | 诊断 release 跟踪（`AnalyzerReleases.*.md`、移除 RS2008） | ✅ M2 已落地；描述符文件结构仍分散 |
 | 6 | Grpc 骨架命名（`Observables.Grpc.R3`）违反约定 | ✅ M3 已重命名为 `*.R3.SourceGenerators` |
-| 7 | 文档滞后：README / Docs / Samples | ✅ M1 WebSocket 已补齐；Grpc 用户文档与 Samples 待 **M4** |
+| 7 | 文档滞后：README / Docs / Samples | ✅ M4 已补齐（含 Grpc 用户文档与 Samples） |
 | 8 | Samples `RestAPI.Reactive` 显式 `R3` 触发 OBS0001 | ✅ `R3` 改为 runtime-only（`ExcludeAssets=compile`） |
 
 ## 诊断 ID 段分配（权威）
@@ -83,14 +83,14 @@ graph LR
 - ~~建 `Observables.Grpc.Package`，产出 `Observables.Grpc.R3` / `Observables.Grpc.Reactive` 两包。~~ ✅
 - ~~补生成器测试 + E2E + smoke 消费者，纳入 `PackVerify`（manifest **12 包**）。~~ ✅
 
-Grpc 两包纳入 **`0.1.0-preview6`** 发版（维护者推 `v0.1.0-preview6` tag）。
+Grpc 两包已于 **`0.1.0-preview6`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 GitHub Packages。
 
-### M4 — 文档与示例补齐（preview6 发版前部分完成）
+### M4 — 文档与示例补齐 ✅
 
-- ~~统一诊断登记文档（OBS0001 / 2xxx–7xxx）到 Docs `diagnostics.md`~~ ✅（preview6 准备）
+- ~~统一诊断登记文档（OBS0001 / 2xxx–7xxx）到 Docs `diagnostics.md`~~ ✅
 - ~~Docs（中英）`grpc.md`；Samples `Observables.Samples.Grpc`~~ ✅
 - ~~校验 README、Docs、Samples 三处域状态与 `0.1.0-preview6` 一致~~ ✅
-- 发版后复核 nuget.org 包页链接与站点 `npm run docs:build`
+- ~~发版后复核 nuget.org 包页链接与站点 `npm run docs:build`~~ ✅（M4 收尾 PR）
 
 ### M5 — API 冻结与 1.0
 


### PR DESCRIPTION
## Summary
- Mark M4 complete and `0.1.0-preview6` as shipped in ROADMAP, AGENTS, and README
- Set next milestone to M5 without bumping package version

## Test plan
- [x] `dotnet run --project build/_build.csproj -- --target NuGetConsumerSmokePublished --configuration Release --consumer-feed Published` (12 packages)
- [ ] CI green on PR

Closes #80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only milestone and release-status updates; no runtime, build, or package version changes.
> 
> **Overview**
> **Documentation hygiene** after shipping **`0.1.0-preview6`**: planning docs now treat preview6 as **published** on nuget.org/GitHub Packages (tag `v0.1.0-preview6`) instead of “pending tag,” and **M4** is marked complete.
> 
> **`AGENTS.md`** updates project status (12 packages shipped), removes “push tag for preview6” as the next step, and sets **M5 API freeze + 1.0** as the next milestone with the roadmap line **M4 ✅**.
> 
> **`README.md`** states preview6 is already on nuget.org with profile link and tag reference (replacing CI-after-tag wording).
> 
> **`docs/ROADMAP.md`** retitles the baseline to shipped preview6, marks M4 ✅ (including post-release nuget/docs checks), updates Grpc package release wording, and closes engineering-debt item 7 as M4-complete. **No package version bump** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db58b74c3ace599682074c7ecfbb675af6dd3dbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->