### PR TITLE
Ship OBS7007 analyzer releases for preview6

### DIFF
--- a/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Shipped.md
@@ -8,3 +8,4 @@ OBS0001 | Observables | Error | Conflicting R3 and Reactive packages
 OBS4007 | Observables.SignalR | Warning | Empty hub proxy interface
 OBS5007 | Observables.Mqtt | Warning | Empty MQTT proxy interface
 OBS6007 | Observables.WebSocket | Warning | Empty WebSocket proxy interface
+OBS7007 | Observables.Grpc | Error | Empty gRPC proxy interface

--- a/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-OBS7007 | Observables.Grpc | Error | Empty gRPC proxy interface


### PR DESCRIPTION
## Summary
- Move OBS7007 (empty gRPC proxy interface) from Analyzers Unshipped to Shipped for preview6 release hygiene

## Test plan
- [ ] CI green on PR

Closes #82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release manifest updates; no runtime or analyzer logic changes.
> 
> **Overview**
> **Ships analyzer rule OBS7007** for the preview6 release by moving it from `AnalyzerReleases.Unshipped.md` to `AnalyzerReleases.Shipped.md`.
> 
> The rule (**Observables.Grpc**, **Error**) flags empty gRPC proxy interfaces marked with `[Grpc]`—same release bookkeeping pattern as the other empty-proxy rules (OBS4007/5007/6007). No analyzer code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a955cd806b8dd4c48f5717587af589cec4d89fc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->