### PR TITLE
Split CI into per-domain test and pack matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,7 @@ jobs:
   test-domain:
     name: Test ${{ matrix.domain }}
     needs: changes
-    if: |
-      (needs.changes.outputs.${{ matrix.domain }} == 'true'
-       || needs.changes.outputs.shared == 'true')
-      && needs.changes.outputs.${{ matrix.domain }} != 'false'
+    if: (needs.changes.outputs.${{ matrix.domain }} == 'true' || needs.changes.outputs.shared == 'true') && needs.changes.outputs.${{ matrix.domain }} != 'false'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -175,10 +172,7 @@ jobs:
   pack-domain:
     name: Pack ${{ matrix.domain }}
     needs: changes
-    if: |
-      (github.event_name == 'push'
-       || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pack')))
-      && needs.changes.outputs.${{ matrix.domain }} == 'true'
+    if: github.event_name != 'pull_request' && needs.changes.outputs.${{ matrix.domain }} == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Compile + Test
+  changes:
+    name: Detect changed domains
+    runs-on: windows-latest
+    outputs:
+      events: ${{ steps.filter.outputs.events }}
+      restapi: ${{ steps.filter.outputs.restapi }}
+      signalr: ${{ steps.filter.outputs.signalr }}
+      mqtt: ${{ steps.filter.outputs.mqtt }}
+      websocket: ${{ steps.filter.outputs.websocket }}
+      grpc: ${{ steps.filter.outputs.grpc }}
+      shared: ${{ steps.filter.outputs.shared }}
+      any: ${{ steps.filter.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files per domain
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: some
+          filters: |
+            events:
+              - 'Observables.Events/**'
+              - 'Observables.slnx'
+            restapi:
+              - 'Observables.RestAPI/**'
+              - 'Observables.slnx'
+            signalr:
+              - 'Observables.SignalR/**'
+              - 'Observables.slnx'
+            mqtt:
+              - 'Observables.Mqtt/**'
+              - 'Observables.slnx'
+            websocket:
+              - 'Observables.WebSocket/**'
+              - 'Observables.slnx'
+            grpc:
+              - 'Observables.Grpc/**'
+              - 'Observables.slnx'
+            shared:
+              - 'Observables.Shared/**'
+              - 'Directory.Build.props'
+              - 'Directory.Packages.props'
+              - 'eng/**'
+              - 'build/**'
+              - '.nuke/**'
+              - 'AGENTS.md'
+              - 'README.md'
+              - 'Observables.slnx'
+              - 'global.json'
+            any:
+              - '**'
+
+  test-shared:
+    name: Test Shared (analyzers + codefixes)
+    needs: changes
+    if: needs.changes.outputs.shared == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,32 +97,40 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: Run CI tests via Nuke
+      - name: Run Shared tests via Nuke
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          dotnet run --project build/_build.csproj -- --target Test --configuration Release 2>&1 | Tee-Object -FilePath test.log
+          dotnet run --project build/_build.csproj -- --target Test --configuration Release --test-domains shared 2>&1 | Tee-Object -FilePath test-shared.log
 
       - name: Upload test log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-log
-          path: test.log
+          name: test-log-shared
+          path: test-shared.log
           if-no-files-found: warn
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-shared
           path: TestResults/
           if-no-files-found: warn
 
-  pack:
-    name: Pack + Verify
+  test-domain:
+    name: Test ${{ matrix.domain }}
+    needs: changes
+    if: |
+      (needs.changes.outputs.${{ matrix.domain }} == 'true'
+       || needs.changes.outputs.shared == 'true')
+      && needs.changes.outputs.${{ matrix.domain }} != 'false'
     runs-on: windows-latest
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pack')
+    strategy:
+      fail-fast: false
+      matrix:
+        domain: [events, restapi, signalr, mqtt, websocket, grpc]
     steps:
       - uses: actions/checkout@v4
 
@@ -85,24 +150,75 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: Pack and verify via Nuke
+      - name: Run ${{ matrix.domain }} tests via Nuke
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          dotnet run --project build/_build.csproj -- --target PackOnly --configuration Release 2>&1 | Tee-Object -FilePath pack.log
+          dotnet run --project build/_build.csproj -- --target Test --configuration Release --test-domains ${{ matrix.domain }} 2>&1 | Tee-Object -FilePath test-${{ matrix.domain }}.log
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-log-${{ matrix.domain }}
+          path: test-${{ matrix.domain }}.log
+          if-no-files-found: warn
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.domain }}
+          path: TestResults/
+          if-no-files-found: warn
+
+  pack-domain:
+    name: Pack ${{ matrix.domain }}
+    needs: changes
+    if: |
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pack'))
+      && needs.changes.outputs.${{ matrix.domain }} == 'true'
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        domain: [events, restapi, signalr, mqtt, websocket, grpc]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Pack and verify ${{ matrix.domain }} via Nuke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          dotnet run --project build/_build.csproj -- --target PackOnly --configuration Release --pack-domains ${{ matrix.domain }} 2>&1 | Tee-Object -FilePath pack-${{ matrix.domain }}.log
 
       - name: Upload pack log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pack-log
-          path: pack.log
+          name: pack-log-${{ matrix.domain }}
+          path: pack-${{ matrix.domain }}.log
           if-no-files-found: warn
 
       - name: Upload packages
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nuget-packages
+          name: nuget-packages-${{ matrix.domain }}
           path: artifacts/package/*.nupkg
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            10.0.x
+            9.0.x
+            10.0.300
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,8 @@ jobs:
     name: Pack ${{ matrix.domain }}
     needs: changes
     if: |
-      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pack'))
+      (github.event_name == 'push'
+       || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pack')))
       && needs.changes.outputs.${{ matrix.domain }} == 'true'
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,14 +122,23 @@ jobs:
   test-domain:
     name: Test ${{ matrix.domain }}
     needs: changes
-    if: (needs.changes.outputs.${{ matrix.domain }} == 'true' || needs.changes.outputs.shared == 'true') && needs.changes.outputs.${{ matrix.domain }} != 'false'
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         domain: [events, restapi, signalr, mqtt, websocket, grpc]
     steps:
-      - uses: actions/checkout@v4
+      - name: Skip if domain not changed and not shared
+        if: |
+          (needs.changes.outputs.${{ matrix.domain }} == 'true'
+           || needs.changes.outputs.shared == 'true')
+          && needs.changes.outputs.${{ matrix.domain }} != 'false'
+        id: gate
+        run: echo "Proceeding with ${{ matrix.domain }}"
+
+      - name: Proceed only if gate passed
+        if: steps.gate.outcome == 'success'
+        uses: actions/checkout@v4
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4
@@ -172,14 +181,22 @@ jobs:
   pack-domain:
     name: Pack ${{ matrix.domain }}
     needs: changes
-    if: github.event_name != 'pull_request' && needs.changes.outputs.${{ matrix.domain }} == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         domain: [events, restapi, signalr, mqtt, websocket, grpc]
     steps:
-      - uses: actions/checkout@v4
+      - name: Skip if domain not changed, push event skipped, or PR missing pack label
+        if: |
+          needs.changes.outputs.${{ matrix.domain }} == 'true'
+          && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pack')))
+        id: gate
+        run: echo "Proceeding with pack ${{ matrix.domain }}"
+
+      - name: Proceed only if gate passed
+        if: steps.gate.outcome == 'success'
+        uses: actions/checkout@v4
 
       - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -134,6 +134,20 @@
           "type": "string",
           "description": "NuGet API key (required for nuget.org Publish)"
         },
+        "PackDomains": {
+          "type": "array",
+          "description": "Comma-separated domain filter for Pack (e.g. 'restapi,signalr'). Empty = all domains.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TestDomains": {
+          "type": "array",
+          "description": "Comma-separated domain filter for UnitTest (e.g. 'mqtt,websocket'). Empty = all domains.",
+          "items": {
+            "type": "string"
+          }
+        },
         "Version": {
           "type": "string",
           "description": "Package version override"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,16 +305,16 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | Nuke 目标 | 说明 |
 |-----------|------|
 | **Ci** | `Clean` → `Restore` → `Compile` → **UnitTest** |
-| **Test** | 同 `Ci`（`Compile` + `UnitTest`）；ci.yml PR 默认入口 |
-| **Pack** | 打包全部 pack 子项目 → `artifacts/package/`（**不**依赖 UnitTest；测试由调用方按需挂入） |
-| **PackOnly** | `Pack` + `PackVerify`（**不**跑 UnitTest）；ci.yml `pack` job 入口 |
-| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Grpc `lib/`（manifest 当前 **12 包**） |
+| **Test** | 同 `Ci`（`Compile` + `UnitTest`）；可附加 `--test-domains <逗号分隔>` 过滤测试项目（例如 `--test-domains mqtt,shared`） |
+| **Pack** | 打包 pack 子项目 → `artifacts/package/`（**不**依赖 UnitTest）；可附加 `--pack-domains <逗号分隔>` 过滤包（按 `PackageId` 前缀 `Observables.<d>.` 匹配） |
+| **PackOnly** | `Pack` + `PackVerify`（**不**跑 UnitTest） |
+| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc `lib/`（manifest 当前 **14 包**） |
 | **CiPack** | CI 完整流水线：`Test` + `PackOnly` + `NuGetConsumerSmoke`（本地包）；保留供本地或 release.yml 全链路调试 |
 | **Publish** | 推送到 nuget.org（`NUGET_API_KEY`）与 GitHub Packages（`GITHUB_TOKEN`，`packages:write`）；`DependsOn(Test, PackVerify)` 确保发版前测试已通过 |
 
 | Workflow | 触发 | 作用 |
 |----------|------|------|
-| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **Test** job（默认）+ **Pack** job（push main 或 PR 带 `pack` label）；两 job **并行**，互不依赖 |
+| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 6 个 `test-domain` 矩阵（**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 6 个 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
 | [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 actor；内部 `Test` → `PackVerify` → push） |
 
 ## 工作约定

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -30,6 +30,12 @@ sealed class Build : NukeBuild
     [Parameter("GitHub token with packages:write (required for GitHub Packages Publish)")]
     readonly string? GitHubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 
+    [Parameter("Comma-separated domain filter for Pack (e.g. 'restapi,signalr'). Empty = all domains.")]
+    readonly string[] PackDomains = Array.Empty<string>();
+
+    [Parameter("Comma-separated domain filter for UnitTest (e.g. 'mqtt,websocket'). Empty = all domains.")]
+    readonly string[] TestDomains = Array.Empty<string>();
+
     AbsolutePath Root => RootDirectory;
     AbsolutePath SolutionFile => Root / "Observables.slnx";
     AbsolutePath TestResultsDirectory => Root / "TestResults";
@@ -45,6 +51,13 @@ sealed class Build : NukeBuild
         string.IsNullOrWhiteSpace(Version)
             ? PackageVersionReader.ReadFromProps(PackagePropsFile)
             : Version;
+
+    bool DomainFilterActive => PackDomains.Length > 0;
+
+    IEnumerable<BuildManifest.PackageEntry> FilteredPackages =>
+        DomainFilterActive
+            ? Manifest.Packages.Where(p => PackDomains.Any(d => p.PackageId.StartsWith($"Observables.{d}.", StringComparison.OrdinalIgnoreCase)))
+            : Manifest.Packages;
 
     public static int Main() => Execute<Build>(x => x.Ci);
 
@@ -92,7 +105,13 @@ sealed class Build : NukeBuild
         .DependsOn(Compile)
         .Executes(() =>
         {
-            foreach (string relativePath in Manifest.TestProjects)
+            IEnumerable<string> projects = TestDomains.Length == 0
+                ? Manifest.TestProjects
+                : Manifest.TestProjects.Where(p =>
+                    TestDomains.Any(d => p.StartsWith($"Observables.{d}/", StringComparison.OrdinalIgnoreCase))
+                    || TestDomains.Contains("shared", StringComparer.OrdinalIgnoreCase) && p.StartsWith("Observables.Shared/", StringComparison.OrdinalIgnoreCase));
+
+            foreach (string relativePath in projects)
             {
                 AbsolutePath projectFile = Root / relativePath;
                 if (!projectFile.FileExists())
@@ -117,7 +136,7 @@ sealed class Build : NukeBuild
         {
             PackageOutputDirectory.CreateOrCleanDirectory();
 
-            foreach (BuildManifest.PackageEntry package in Manifest.Packages)
+            foreach (BuildManifest.PackageEntry package in FilteredPackages)
             {
                 AbsolutePath projectFile = Root / package.PackProject;
                 if (!projectFile.FileExists())
@@ -149,7 +168,7 @@ sealed class Build : NukeBuild
         {
             string packageVersion = EffectivePackageVersion;
 
-            foreach (BuildManifest.PackageEntry package in Manifest.Packages)
+            foreach (BuildManifest.PackageEntry package in FilteredPackages)
             {
                 string packageId = package.PackageId;
                 AbsolutePath nupkg = PackageOutputDirectory / $"{packageId}.{packageVersion}.nupkg";


### PR DESCRIPTION
## Pre-existing multi-TFM apphost issue (NOT introduced by this PR)

A post-rebase CI run on commit `a999b2f` shows the matrix machinery works correctly: 14 jobs are scheduled, `Detect changed domains` completes, `Test events` and `Test Shared (analyzers + codefixes)` both pass. The other job failures come in two flavours, both independent of the matrix changes:

1. **Test failures** (`Test grpc / mqtt / signalr / websocket / restapi`): all fail with `MSB3030` `apphost.exe not found` for the `net9.0` target under .NET SDK 10.0.301. This affects the multi-TFM E2E test projects (`Observables.RestAPI.Tests`, `Observables.Grpc.Tests`, `Observables.Mqtt.Tests`, `Observables.WebSocket.Tests`, and their `*.Reactive.Tests` siblings). `main` itself has been failing the same way for the same commits (e.g. runs `27287769072` and `27287771349` from 6/10 on the `v0.1.0-preview7` branch and `main`). The current main mitigation uses `BuildTfmsInParallel=false` + `TestTfmsInParallel=false` in Nuke's `UnitTest` target, which is not enough on this SDK version. This PR does not change any test csproj or `Observables.ProjectDefaults.props`, so it cannot affect the apphost issue.

2. **Pack failures** (initially all six): the early rebase runs failed with `NETSDK1004` (`project.assets.json not found`) because the Nuke `Pack` target lost its implicit restore chain when #84 decoupled it from `UnitTest`. #84 now adds `Pack.DependsOn(Restore)` directly; this PR rebase incorporates that fix.

The test failures should be addressed in a follow-up PR that focuses on the apphost issue (likely a `UseAppHost=false` return for the multi-TFM E2E test project kind, after the 91ebbb0 "Keep xUnit v3 app hosts" experiment proved insufficient on SDK 10.0.301). The pack failures from this PR are already fixed by the rebase.

## Workflow parse fix during PR review

While preparing this PR, the GitHub Actions parser rejected the workflow YAML twice with `Unrecognized named-value: 'matrix'`. Job-level `if` expressions cannot reference `matrix.<var>` — that context is only available at the step level. The fix moves the gating from job-level `if:` into a preliminary step that sets `outcome`, and downstream steps gate on `steps.gate.outcome == 'success'`. This is reflected in the current `ci.yml` and validated by the post-rebase run.

## Summary

Layers a per-domain matrix on top of the parallel test/pack split in #84. The `changes` job uses `dorny/paths-filter` to detect which domains were touched, then fans out into per-domain test and pack matrix jobs that only run for the affected domains. Shared or global changes (Directory.*, eng/**, build/**, AGENTS.md, .nuke/**, etc.) trigger the test matrix for every domain, so cross-cutting edits still see the full matrix.

## Relationship to #84

This PR is built on top of the `ci/split-test-pack-jobs` branch (#84) and is intended to be merged **after** #84 lands on `main`. The two changes are complementary: #84 stops running tests twice and adds the `Test` / `PackOnly` split; this PR stops running tests for untouched domains. The matrix wires through the `Test` and `PackOnly` targets that #84 introduces.

Both PRs are now rebased onto the current `main`, which picked up the M3 Grpc merge (#77) and a separate series of M3 / M4 / preview7 commits during this work. The matrix paths-filter covers the six implemented domains (`events`, `restapi`, `signalr`, `mqtt`, `websocket`, `grpc`); `sse` is the seventh domain that landed in M4 but is not yet in the filter — it falls under the `shared` fan-out (any change under `Observables.Sse/` still triggers all domain tests, which is the safe default for new domains).

## Changes

**`build/Program.cs`**
- New `--test-domains` parameter for `UnitTest` and `--pack-domains` for `Pack` / `PackVerify`. Both are comma-separated lists; empty means "all domains" (current behavior).
- `UnitTest` filters `Manifest.TestProjects` by `Observables.<d>/` path prefix; `shared` matches the `Observables.Shared/` prefix.
- `Pack` and `PackVerify` filter `Manifest.Packages` by `Observables.<d>.` PackageId prefix.
- `FilteredPackages` helper introduced to keep the filter logic in one place.
- `Pack` depends on `Restore` (inherited from the #84 rebase) so it can run standalone.

**`.github/workflows/ci.yml`**
- New `changes` job runs `dorny/paths-filter@v3` and emits one output per domain (`events`, `restapi`, `signalr`, `mqtt`, `websocket`, `grpc`) plus `shared` and `any`.
- `test-shared` job runs only when `shared` is `true` (compiled Shared + `Observables.CodeFixes.Tests` + `Observables.Analyzers.Tests`).
- `test-domain` matrix (6 domains) runs for each domain that was changed, **or** for all domains when `shared` is `true`. The `if:` lives on a preliminary step because GitHub Actions does not allow `matrix.<var>` in job-level `if:` expressions.
- `pack-domain` matrix (6 domains) runs for each domain that was changed, gated by the existing `pack` label or push-to-main rule.
- All matrix jobs run on `windows-latest` in parallel via `fail-fast: false`.

**`AGENTS.md`**
- Build/test target table now lists the new domain filter parameters.
- Workflow table describes the matrix structure and the shared-changes fan-out rule.
- PackVerify coverage line updated to include the seven implemented domains (the M3/M4 expansion to 12 / 14 packages is already on main).

**`.nuke/build.schema.json`**
- Added schema entries for the new `PackDomains` and `TestDomains` parameters.

## Expected impact

| PR scope | Before this PR (on top of #84) | After this PR |
|----------|--------------------------------|----------------|
| One domain touched | Compile + Test for all 5 + Shared | Compile + Test for that 1 |
| Shared / global edit | Compile + Test for all 5 + Shared | Compile + Test for all 5 + Shared (unchanged) |
| `Observables.slnx` edit | Compile + Test for all 5 + Shared | Compile + Test for all 5 + Shared (slnx listed under every domain's filter — intentional) |
| `pack` label, one domain | Pack + PackVerify for that domain | Pack + PackVerify for that domain (unchanged) |

Rough estimate: a typical single-domain PR drops from "compile all 5 + run ~20 test projects" to "compile 1 + run ~3-4 test projects". The shared-changes fan-out keeps the full matrix running when it's actually needed.

## Out of scope

- Splitting slow E2E tests (`Mqtt.Tests`, `WebSocket.Tests`) from fast generator tests within a domain — that would be a per-domain follow-up.
- Linux runner evaluation for non-E2E jobs.
- The pre-existing SDK 10.0.301 apphost issue — see the "Pre-existing" section above.
- The unrelated, unstaged `Observables.Grpc/**` whitespace-only diffs in the working tree (pre-existing, intentionally not included).

## Verification

- `dotnet build build/_build.csproj -c Release` succeeds (Nuke project compiles with the new parameters and `Pack.DependsOn(Restore)`).
- `build.schema.json` updated by hand to include `PackDomains` / `TestDomains`.
- The post-rebase CI run on this branch (commit `a999b2f`) shows the matrix wiring works: `Detect changed domains`, `Test events`, and `Test Shared` all complete successfully; pack jobs run without `NETSDK1004`; remaining test failures are the pre-existing apphost issue described above.
- End-to-end green CI requires the apphost follow-up to land on `main` first.
