### PR TITLE
Disable apphost for multi-TFM E2E test projects

### DIFF
--- a/eng/Observables.ProjectDefaults.props
+++ b/eng/Observables.ProjectDefaults.props
@@ -90,6 +90,7 @@
   <PropertyGroup Condition="'$(ObservablesSkipProjectDefaults)' != 'true' and '$(_ObsIsMultiTfmTestProject)' == 'true'">
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Multi-TFM test projects (the runtime E2E tests like `Grpc.Tests`, `Mqtt.Tests`, `WebSocket.Tests`, `SignalR.Tests`, `RestAPI.Tests`, and their `*.Reactive.Tests` counterparts) are configured by `Observables.ProjectDefaults` to target `net8.0;net9.0`. Under .NET SDK 10.0.301, the per-TFM `apphost.exe` is no longer generated for the secondary framework, and `Microsoft.Common.CurrentVersion.targets` then fails with:

```
error MSB3030: Could not copy the file "...\obj\Release\net9.0\apphost.exe" because it was not found.
```

This blocks every `dotnet test` on those projects on CI (see runs `27287769072` on `main` and the dispatch run on `ci/matrix-by-feature` referenced in #85).

## Relationship to past work

The M2 hardening pass (commit "Disable apphost for multi-TFM E2E test projects.") added per-csproj `<UseAppHost>false</UseAppHost>` to the Mqtt/WebSocket/SignalR/RestAPI E2E tests. The Grpc E2E tests landed in M3 (#77) without the same fix, and re-adding the property per-csproj is easy to forget for the next domain. Setting it once in the multi-TFM test project default in `ProjectDefaults` covers all existing and future E2E test projects.

## Changes

**`eng/Observables.ProjectDefaults.props`**
- One-line addition: `<UseAppHost>false</UseAppHost>` inside the existing `<PropertyGroup>` that drives the `_ObsIsMultiTfmTestProject` project kind.

This applies the property to every project that:
1. Is a test project (project name ends with `.Tests` and not already classified as a single-TFM test), and
2. Is not a source-generator test project.

That covers `Observables.Grpc.Tests`, `Observables.Grpc.Reactive.Tests`, `Observables.Mqtt.Tests`, `Observables.Mqtt.Reactive.Tests`, `Observables.WebSocket.Tests`, `Observables.WebSocket.Reactive.Tests`, `Observables.SignalR.Tests`, `Observables.SignalR.Reactive.Tests`, `Observables.RestAPI.Tests`, and `Observables.RestAPI.Reactive.Tests`. The previously-applied per-csproj overrides are now redundant; they could be cleaned up in a follow-up if desired, but removing them is not required for this fix.

## Verification

- `dotnet build Observables.Grpc/Observables.Grpc.Tests/Observables.Grpc.Tests.csproj -c Release` succeeds for both `net8.0` and `net9.0` (0 warnings, 0 errors) on the affected machine.
- `dotnet test` on the same project runs the test suite successfully for both TFMs (2 tests, 0 failed, 0 skipped, ~650 ms).
- Other multi-TFM E2E projects inherit the same property and should be covered without per-project changes.
- End-to-end CI verification will happen on a follow-up re-run of #85's `gh workflow run ci.yml` dispatch, or via the standard PR / push event once this lands on `main`.

## Out of scope

- Removing the now-redundant `<UseAppHost>false</UseAppHost>` overrides in the per-csproj M2 hardening (clean up, not required for the fix).
- Investigating the underlying SDK 10.0.301 apphost regression — that's a .NET runtime / SDK issue, not a project issue.
- The unrelated, unstaged `Observables.Grpc/**` whitespace-only diffs in the working tree (pre-existing, intentionally not included).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only MSBuild configuration with no changes to product code, auth, or data paths.
> 
> **Overview**
> Adds **`<UseAppHost>false</UseAppHost>`** to the shared MSBuild defaults for **runtime E2E test** projects (`_ObsIsMultiTfmTestProject`), which target **`net8.0;net9.0`**.
> 
> This avoids **MSB3030** on **.NET SDK 10.0.301**, where the secondary TFM no longer produces **`apphost.exe`** but the build still tries to copy it. The setting applies to all current and future multi-TFM E2E test projects (Grpc/Mqtt/WebSocket/SignalR/RestAPI and their Reactive test counterparts), replacing the need to repeat the property in each **`.csproj`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2438cd6379f580e1d2973be48c9359fabd03ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->