### PR TITLE
Pin CI SDK to 10.0.300 to fix multi-TFM apphost failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            10.0.x
+            9.0.x
+            10.0.300
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -71,7 +72,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            10.0.x
+            9.0.x
+            10.0.300
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-            10.0.x
+            9.0.x
+            10.0.300
 
       - name: Resolve version
         shell: bash


### PR DESCRIPTION
## Summary
- Pin GitHub Actions `setup-dotnet` to `8.0.x`, `9.0.x`, and **10.0.300** instead of floating `10.0.x` (which resolves to **10.0.301** on runners).
- Fixes `MSB3030: apphost.exe not found` for multi-TFM E2E test projects (`net8.0;net9.0`) on CI.
- Applies the same pin to `release.yml`.

## Root cause
SDK **10.0.301** (GA) fails to produce/copy `apphost.exe` for net9.0 when building multi-TFM xUnit v3 test projects. Local **10.0.300** and preview SDKs do not reproduce the bug.

## Notes
- Nuke `_build.csproj` targets `net10.0`, so we cannot drop SDK 10 entirely; pinning a known-good patch is the minimal fix.
- Revisit when a fixed 10.0.x GA (e.g. 10.0.302+) is available.

## Test plan
- [ ] Merge and confirm `main` CI `build-test` + `pack` jobs pass
- [ ] Then merge #84 / #85 (matrix CI already cherry-picked this commit on `ci/matrix-by-feature`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI/release workflow SDK installation lines change; no application or packaging logic is modified.
> 
> **Overview**
> GitHub Actions **Setup .NET SDKs** steps in `ci.yml` (`build-test`, `pack`) and `release.yml` no longer use floating **`10.0.x`** alone alongside **`8.0.x`**. They now install **`8.0.x`**, **`9.0.x`**, and a fixed **`10.0.300`**.
> 
> This pins CI/release to a known-good SDK 10 patch so runners don’t pick **10.0.301**, which was breaking multi-TFM E2E builds with **`MSB3030: apphost.exe not found`** for **`net9.0`** while still keeping SDK 10 for Nuke **`net10.0`** builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a4e23946bc7f4608bb92eb0ab69f946672c67a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->