### PR TITLE
Add Sse domain to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       mqtt: ${{ steps.filter.outputs.mqtt }}
       websocket: ${{ steps.filter.outputs.websocket }}
       grpc: ${{ steps.filter.outputs.grpc }}
+      sse: ${{ steps.filter.outputs.sse }}
       shared: ${{ steps.filter.outputs.shared }}
       any: ${{ steps.filter.outputs.any }}
     steps:
@@ -58,6 +59,9 @@ jobs:
               - 'Observables.slnx'
             grpc:
               - 'Observables.Grpc/**'
+              - 'Observables.slnx'
+            sse:
+              - 'Observables.Sse/**'
               - 'Observables.slnx'
             shared:
               - 'Observables.Shared/**'
@@ -126,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse]
     steps:
       - name: Skip if domain not changed and not shared
         if: |
@@ -185,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse]
     steps:
       - name: Skip if domain not changed, push event skipped, or PR missing pack label
         if: |


### PR DESCRIPTION
## Summary
- Add `sse` to `dorny/paths-filter` outputs and `Observables.Sse/**` path globs.
- Extend `test-domain` and `pack-domain` matrices to include `sse`.

## Why
SSE domain shipped in preview7 (14 packages) but was omitted when #85 introduced per-domain CI matrices (only 6 domains).

## Test plan
- [ ] CI matrix runs `Test sse` / `Pack sse` on this PR (shared change triggers all domains)
- [ ] Merge and confirm main push CI includes sse jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application or build script logic modified beyond job matrices and path globs.
> 
> **Overview**
> Wires the **SSE** domain into the same per-domain CI flow as the other Observables domains, which was missing after the matrix split in #85.
> 
> The `changes` job now exposes an **`sse`** path-filter output for `Observables.Sse/**` (and solution file), and both **`test-domain`** and **`pack-domain`** matrices include `sse` so Nuke runs `--test-domains sse` and `--pack-domains sse` when that domain (or shared) changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b05fa78a111ba5fce011e65896358ea487af4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->