### PR TITLE
fix: RestApi domain uses own empty interface descriptor (OBS3007)

### DIFF
--- a/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
@@ -116,6 +116,15 @@ public sealed class EmptyProxyInterfaceAnalyzerTests
         Assert.Contains(diagnostics, d => d.Id == "OBS9007");
     }
 
+    [Fact]
+    public void ProxyDomainCatalog_RestApi_uses_own_empty_interface_descriptor()
+    {
+        // Regression: RestApi used to incorrectly reuse EmptyHubInterface (OBS4007).
+        var domain = ProxyDomainCatalog.RestApi;
+        Assert.Equal("OBS3007", domain.EmptyInterfaceDescriptor.Id);
+        Assert.Equal("Empty RestAPI proxy interface", domain.EmptyInterfaceDescriptor.Title);
+    }
+
     static string BuildSource(string body, params string[] usings)
     {
         var usingLines = string.Join('\n', usings.Select(u => $"using {u};"));

--- a/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,5 +2,6 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+OBS3007 | Observables.RestAPI | Warning | Empty RestAPI proxy interface
 OBS8007 | Observables.Sse | Warning | Empty SSE proxy interface
 OBS9007 | Observables.Nats | Warning | Empty NATS proxy interface

--- a/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
+++ b/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
@@ -67,4 +67,13 @@ internal static class DiagnosticDescriptors
             "Observables.Nats",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor EmptyRestApiInterface =
+        new(
+            "OBS3007",
+            "Empty RestAPI proxy interface",
+            "Interface '{0}' is marked with HTTP method attributes but declares no valid members. Add HTTP boundary members or remove the attributes.",
+            "Observables.RestAPI",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
 }

--- a/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
+++ b/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
@@ -14,7 +14,8 @@ public sealed class EmptyProxyInterfaceAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.EmptyWebSocketInterface,
             DiagnosticDescriptors.EmptyGrpcInterface,
             DiagnosticDescriptors.EmptySseInterface,
-            DiagnosticDescriptors.EmptyNatsInterface);
+            DiagnosticDescriptors.EmptyNatsInterface,
+            DiagnosticDescriptors.EmptyRestApiInterface);
 
     public override void Initialize(AnalysisContext context)
     {

--- a/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
+++ b/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
@@ -132,7 +132,7 @@ internal static class ProxyDomainCatalog
         displayName: "RestAPI",
         interfaceMarkerMetadataName: string.Empty,
         reactiveAdapterMetadataName: "Observables.RestAPI.Reactive.SystemReactiveObservableAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyHubInterface,
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyRestApiInterface,
         methodAttributes: [],
         propertyAttributes: []);
 


### PR DESCRIPTION
Fixes #89

## Problem

ProxyDomainCatalog.RestApi was incorrectly reusing DiagnosticDescriptors.EmptyHubInterface (OBS4007), which is a SignalR-specific diagnostic. RestApi should have its own empty interface diagnostic (OBS3007) consistent with other domains.

## Changes

- Added EmptyRestApiInterface descriptor with ID OBS3007 in DiagnosticDescriptors.cs
- Updated ProxyDomainCatalog.RestApi to use EmptyRestApiInterface
- Added EmptyRestApiInterface to EmptyProxyInterfaceAnalyzer.SupportedDiagnostics
- Added regression test ProxyDomainCatalog_RestApi_uses_own_empty_interface_descriptor
- Updated AnalyzerReleases.Unshipped.md with the new OBS3007 rule

## Note

This is a minimal fix for the catalog inconsistency. RestApi is currently not included in InterfaceProxyDomains, so the analyzer does not yet actively report empty RestApi interfaces. A follow-up could add RestApi detection when an appropriate interface-level marker is defined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small analyzer metadata and descriptor wiring with a unit test; no runtime or security impact, and RestAPI empty-interface reporting is not enabled yet.
> 
> **Overview**
> **RestAPI** in `ProxyDomainCatalog` no longer points at the SignalR **OBS4007** empty-interface diagnostic; it now uses a dedicated **OBS3007** RestAPI descriptor with RestAPI-specific messaging.
> 
> Adds `EmptyRestApiInterface` in `DiagnosticDescriptors`, registers it on `EmptyProxyInterfaceAnalyzer`, documents **OBS3007** in `AnalyzerReleases.Unshipped.md`, and adds a regression test on `ProxyDomainCatalog.RestApi.EmptyInterfaceDescriptor`. RestAPI is still not in `InterfaceProxyDomains`, so empty RestAPI interfaces are not analyzed yet—this is catalog/metadata alignment ahead of future detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b02c4a2b58d33a65a4a8746cddf21012da3f847. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->