### PR TITLE
docs: add Refit license attribution for Observables.RestAPI

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,35 @@
+# Third-Party Notices
+
+Observables uses or is derived from the following third-party projects.
+
+## Refit
+
+The `Observables.RestAPI` domain contains code adapted from **Refit**.
+
+- Repository: https://github.com/reactiveui/refit
+- License: Apache-2.0
+- Copyright: Copyright (c) .NET Foundation and Contributors
+
+The adapted code includes, but is not limited to, HTTP request construction,
+`RestMethodInfo`, `RequestBuilderImplementation`, `ApiResponse`, `ApiException`,
+`ValidationApiException`, `FormValueMultimap`, `ValueStringBuilder`, and related
+infrastructure. Refit is a trademark of its respective authors and is not
+affiliated with the Observables project.
+
+## Apache-2.0 License Notice
+
+```
+Copyright (c) .NET Foundation and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 
 声明式类型安全 HTTP 客户端：`Observables.RestAPI`（运行时）+ `Observables.RestAPI.R3.SourceGenerators` 或 `Observables.RestAPI.Reactive.SourceGenerators` + 可选 `Observables.RestAPI.Reactive` / `HttpClientFactory`。
 
+该域的运行时部分包含由 [Refit](https://github.com/reactiveui/refit) 适配而来的代码，许可信息见 [NOTICE.md](NOTICE.md)。
+
 ```xml
 <ProjectReference Include="Observables.RestAPI" />
 <ProjectReference Include="Observables.RestAPI.R3.SourceGenerators" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
@@ -130,4 +132,6 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+Observables is licensed under the MIT License — see [LICENSE](LICENSE).
+
+Third-party attributions, including the Refit-derived code used by `Observables.RestAPI`, are listed in [NOTICE.md](NOTICE.md).


### PR DESCRIPTION
Fixes #91

## Problem

Observables.RestAPI contains code adapted from [Refit](https://github.com/reactiveui/refit), licensed under Apache-2.0. The repository did not include any attribution or notice for this third-party code.

## Changes

- Added NOTICE.md at the repository root with Refit Apache-2.0 license attribution
- Updated the ## License section in README.md to reference NOTICE.md
- Added a note in the ## RestAPI section mentioning that the runtime includes Refit-derived code

## Notes

This is a documentation-only change. The code itself is not modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only compliance update; no application code, APIs, or build behavior changes.
> 
> **Overview**
> Adds **third-party licensing documentation** for Refit-derived code in `Observables.RestAPI`, with no runtime or generator changes.
> 
> A new root **`NOTICE.md`** credits [Refit](https://github.com/reactiveui/refit) (Apache-2.0), lists representative adapted types (e.g. `RequestBuilderImplementation`, `RestMethodInfo`, `ApiException`), and includes the full Apache-2.0 license text.
> 
> **`README.md`** now notes in **RestAPI** that the runtime includes Refit-adapted code and points to `NOTICE.md`. The **License** section clarifies MIT for Observables and directs readers to `NOTICE.md` for third-party attributions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7078eef7217b5c755902b882dbc84bd324b4d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->