### PR TITLE
test: add Verify snapshots to 5 remaining generator test domains

### DIFF
--- a/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.Grpc_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.Grpc_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,74 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- EchoServiceGeneratedProxy.Grpc.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Grpc.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("gRPC proxy uses reflection for message marshalling and method invocation. Preserve required members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("gRPC proxy uses reflection for message marshalling and method invocation.")]
+#endif
+    internal sealed class EchoServiceGeneratedProxy : global::IEchoService
+    {
+        private readonly global::Grpc.Core.CallInvoker _invoker;
+
+        public EchoServiceGeneratedProxy(global::Grpc.Core.CallInvoker invoker)
+        {
+            _invoker = invoker;
+        }
+
+        private static readonly global::Grpc.Core.Method<global::System.String, global::System.String> UnaryEchoMethod =
+            new(global::Grpc.Core.MethodType.Unary, "echo.Echo", "UnaryEcho", global::Observables.Grpc.GrpcMarshallers.String, global::Observables.Grpc.GrpcMarshallers.String);
+
+        private static readonly global::Grpc.Core.Method<global::System.String, global::System.String> StreamEchoMethod =
+            new(global::Grpc.Core.MethodType.ServerStreaming, "echo.Echo", "StreamEcho", global::Observables.Grpc.GrpcMarshallers.String, global::Observables.Grpc.GrpcMarshallers.String);
+
+        private static readonly global::Grpc.Core.Method<global::System.String, global::System.String> CollectMethod =
+            new(global::Grpc.Core.MethodType.ClientStreaming, "echo.Echo", "Collect", global::Observables.Grpc.GrpcMarshallers.String, global::Observables.Grpc.GrpcMarshallers.String);
+
+        private static readonly global::Grpc.Core.Method<global::System.String, global::System.String> ChatMethod =
+            new(global::Grpc.Core.MethodType.DuplexStreaming, "echo.Echo", "Chat", global::Observables.Grpc.GrpcMarshallers.String, global::Observables.Grpc.GrpcMarshallers.String);
+
+
+        public global::R3.Observable<global::System.String> UnaryEcho(global::System.String request, global::System.Threading.CancellationToken cancellationToken = default) =>
+            global::Observables.Grpc.GrpcObservable.FromUnary(_invoker, UnaryEchoMethod, request, cancellationToken);
+
+        public global::R3.Observable<global::System.String> StreamEcho(global::System.String request, global::System.Threading.CancellationToken cancellationToken = default) =>
+            global::Observables.Grpc.GrpcObservable.FromServerStreaming(_invoker, StreamEchoMethod, request, cancellationToken);
+
+        public global::R3.Observable<global::System.String> Collect(global::R3.Observable<global::System.String> requests, global::System.Threading.CancellationToken cancellationToken = default) =>
+            global::Observables.Grpc.GrpcObservable.FromClientStreaming(_invoker, CollectMethod, requests, cancellationToken);
+
+        public global::R3.Observable<global::System.String> Chat(global::R3.Observable<global::System.String> requests, global::System.Threading.CancellationToken cancellationToken = default) =>
+            global::Observables.Grpc.GrpcObservable.FromDuplexStreaming(_invoker, ChatMethod, requests, cancellationToken);
+
+    }
+}
+#pragma warning restore
+
+--- GrpcProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Grpc.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class GrpcProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Grpc.Generated.EchoServiceGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Grpc.GrpcService.RegisterGeneratedFactory(typeof(global::IEchoService), static c => new Observables.Grpc.Generated.EchoServiceGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.cs
+++ b/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Grpc.R3.SourceGenerators.Tests;
 
 public sealed class GrpcInterfaceGeneratorTests
 {
     [Fact]
-    public void Grpc_interface_generates_proxy_and_registration()
+    public Task Grpc_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -25,15 +27,7 @@ public sealed class GrpcInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS7002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("EchoServiceGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromUnary", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromServerStreaming", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromClientStreaming", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromDuplexStreaming", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/Observables.Grpc.R3.SourceGenerators.Tests.csproj
+++ b/Observables.Grpc/Observables.Grpc.R3.SourceGenerators.Tests/Observables.Grpc.R3.SourceGenerators.Tests.csproj
@@ -1,25 +1,51 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+
   <PropertyGroup>
+
     <RootNamespace>Observables.Grpc.R3.SourceGenerators.Tests</RootNamespace>
+
   </PropertyGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="R3" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+
 
   <ItemGroup>
-    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
-    <ProjectReference Include="..\Observables.Grpc.R3.SourceGenerators\Observables.Grpc.R3.SourceGenerators.csproj" />
+
+    <Using Include="Xunit" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+
+    <PackageReference Include="R3" />
+
+    <PackageReference Include="Verify.XunitV3" />
+
+    <PackageReference Include="xunit.v3" />
+
+    <PackageReference Include="xunit.runner.visualstudio">
+
+      <PrivateAssets>all</PrivateAssets>
+
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+
+    </PackageReference>
+
   </ItemGroup>
+
+
+
+  <ItemGroup>
+
+    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
+
+    <ProjectReference Include="..\Observables.Grpc.R3.SourceGenerators\Observables.Grpc.R3.SourceGenerators.csproj" />
+
+  </ItemGroup>
+
+
 
 </Project>
-
+
+

--- a/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.Grpc_interface_generates_reactive_proxy.verified.txt
+++ b/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.Grpc_interface_generates_reactive_proxy.verified.txt
@@ -1,0 +1,56 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- EchoServiceGeneratedProxy.Grpc.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Grpc.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("gRPC proxy uses reflection for message marshalling and method invocation. Preserve required members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("gRPC proxy uses reflection for message marshalling and method invocation.")]
+#endif
+    internal sealed class EchoServiceGeneratedProxy : global::IEchoService
+    {
+        private readonly global::Grpc.Core.CallInvoker _invoker;
+
+        public EchoServiceGeneratedProxy(global::Grpc.Core.CallInvoker invoker)
+        {
+            _invoker = invoker;
+        }
+
+        private static readonly global::Grpc.Core.Method<global::System.String, global::System.String> UnaryEchoMethod =
+            new(global::Grpc.Core.MethodType.Unary, "echo.Echo", "UnaryEcho", global::Observables.Grpc.GrpcMarshallers.String, global::Observables.Grpc.GrpcMarshallers.String);
+
+
+        public global::System.IObservable<global::System.String> UnaryEcho(global::System.String request, global::System.Threading.CancellationToken cancellationToken = default) =>
+            global::Observables.Grpc.Reactive.SystemReactiveGrpcAdapter.FromUnary(_invoker, UnaryEchoMethod, request, cancellationToken);
+
+    }
+}
+#pragma warning restore
+
+--- GrpcProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Grpc.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class GrpcProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Grpc.Reactive.Generated.EchoServiceGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Grpc.GrpcService.RegisterGeneratedFactory(typeof(global::IEchoService), static c => new Observables.Grpc.Reactive.Generated.EchoServiceGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/GrpcInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Grpc.Reactive.SourceGenerators.Tests;
 
 public sealed class GrpcInterfaceGeneratorTests
 {
     [Fact]
-    public void Grpc_interface_generates_reactive_proxy()
+    public Task Grpc_interface_generates_reactive_proxy()
     {
         const string userSource =
             """
@@ -16,10 +18,6 @@ public sealed class GrpcInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS7005", snapshot, StringComparison.Ordinal);
-        Assert.Contains("EchoServiceGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("SystemReactiveGrpcAdapter", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 }

--- a/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/Observables.Grpc.Reactive.SourceGenerators.Tests.csproj
+++ b/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators.Tests/Observables.Grpc.Reactive.SourceGenerators.Tests.csproj
@@ -1,26 +1,53 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+
+
   <PropertyGroup>
+
     <RootNamespace>Observables.Grpc.Reactive.SourceGenerators.Tests</RootNamespace>
+
   </PropertyGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="System.Reactive" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+
 
   <ItemGroup>
-    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
-    <ProjectReference Include="..\Observables.Grpc.Reactive\Observables.Grpc.Reactive.csproj" />
-    <ProjectReference Include="..\Observables.Grpc.Reactive.SourceGenerators\Observables.Grpc.Reactive.SourceGenerators.csproj" />
+
+    <Using Include="Xunit" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+
+    <PackageReference Include="System.Reactive" />
+
+    <PackageReference Include="Verify.XunitV3" />
+
+    <PackageReference Include="xunit.v3" />
+
+    <PackageReference Include="xunit.runner.visualstudio">
+
+      <PrivateAssets>all</PrivateAssets>
+
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+
+    </PackageReference>
+
   </ItemGroup>
+
+
+
+  <ItemGroup>
+
+    <ProjectReference Include="..\Observables.Grpc\Observables.Grpc.csproj" />
+
+    <ProjectReference Include="..\Observables.Grpc.Reactive\Observables.Grpc.Reactive.csproj" />
+
+    <ProjectReference Include="..\Observables.Grpc.Reactive.SourceGenerators\Observables.Grpc.Reactive.SourceGenerators.csproj" />
+
+  </ItemGroup>
+
+
 
 </Project>
-
+
+

--- a/Observables.Nats/Observables.Nats.R3.SourceGenerators.Tests/NatsInterfaceGeneratorTests.Nats_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.Nats/Observables.Nats.R3.SourceGenerators.Tests/NatsInterfaceGeneratorTests.Nats_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,59 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- NatsProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Nats.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class NatsProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Nats.Generated.OrderHubGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Nats.NatsService.RegisterGeneratedFactory(typeof(global::IOrderHub), static c => new Observables.Nats.Generated.OrderHubGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore
+
+--- OrderHubGeneratedProxy.Nats.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Nats.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("NATS payload serialization uses reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("NATS payload serialization uses reflection.")]
+#endif
+    internal sealed class OrderHubGeneratedProxy : global::IOrderHub
+    {
+        private readonly global::NATS.Client.Core.INatsConnection _connection;
+
+        public OrderHubGeneratedProxy(global::NATS.Client.Core.INatsConnection connection)
+        {
+            _connection = connection;
+        }
+
+    public global::R3.Observable<global::R3.Unit> Cancel(global::System.String id) =>
+        global::Observables.Nats.NatsObservable.FromPublish(_connection, global::Observables.Nats.NatsSubject.Format("orders.{id}.cancel", "id", id), default);
+
+    private global::R3.Observable<global::OrderEvent>? _OrderEvents;
+    public global::R3.Observable<global::OrderEvent> OrderEvents =>
+        _OrderEvents ??= global::Observables.Nats.NatsObservable.FromSubscribe<global::OrderEvent>(_connection, "orders.>");
+
+    public global::R3.Observable<global::System.String> Validate(global::System.String payload) =>
+        global::Observables.Nats.NatsObservable.FromRequest<global::System.String, global::System.String>(_connection, "orders.validate", payload, default);
+
+    }
+}
+#pragma warning restore

--- a/Observables.Nats/Observables.Nats.R3.SourceGenerators.Tests/NatsInterfaceGeneratorTests.cs
+++ b/Observables.Nats/Observables.Nats.R3.SourceGenerators.Tests/NatsInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Nats.R3.SourceGenerators.Tests;
 
 public sealed class NatsInterfaceGeneratorTests
 {
     [Fact]
-    public void Nats_interface_generates_proxy_and_registration()
+    public Task Nats_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -27,15 +29,7 @@ public sealed class NatsInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS9002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("OrderHubGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromPublish", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromSubscribe", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromRequest", snapshot, StringComparison.Ordinal);
-        Assert.Contains("NatsSubject.Format", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.Nats/Observables.Nats.Reactive.SourceGenerators.Tests/NatsInterfaceGeneratorTests.Nats_interface_generates_reactive_proxy.verified.txt
+++ b/Observables.Nats/Observables.Nats.Reactive.SourceGenerators.Tests/NatsInterfaceGeneratorTests.Nats_interface_generates_reactive_proxy.verified.txt
@@ -1,0 +1,53 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- NatsProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Nats.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class NatsProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Nats.Reactive.Generated.OrderHubGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Nats.NatsService.RegisterGeneratedFactory(typeof(global::IOrderHub), static c => new Observables.Nats.Reactive.Generated.OrderHubGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore
+
+--- OrderHubGeneratedProxy.Nats.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Nats.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("NATS payload serialization uses reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("NATS payload serialization uses reflection.")]
+#endif
+    internal sealed class OrderHubGeneratedProxy : global::IOrderHub
+    {
+        private readonly global::NATS.Client.Core.INatsConnection _connection;
+
+        public OrderHubGeneratedProxy(global::NATS.Client.Core.INatsConnection connection)
+        {
+            _connection = connection;
+        }
+
+    private global::System.IObservable<global::System.String>? _OrderEvents;
+    public global::System.IObservable<global::System.String> OrderEvents =>
+        _OrderEvents ??= global::Observables.Nats.Reactive.SystemReactiveNatsAdapter.FromSubscribe<global::System.String>(_connection, "orders.>");
+
+    }
+}
+#pragma warning restore

--- a/Observables.Nats/Observables.Nats.Reactive.SourceGenerators.Tests/NatsInterfaceGeneratorTests.cs
+++ b/Observables.Nats/Observables.Nats.Reactive.SourceGenerators.Tests/NatsInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Nats.Reactive.SourceGenerators.Tests;
 
 public sealed class NatsInterfaceGeneratorTests
 {
     [Fact]
-    public void Nats_interface_generates_reactive_proxy()
+    public Task Nats_interface_generates_reactive_proxy()
     {
         const string userSource =
             """
@@ -16,10 +18,6 @@ public sealed class NatsInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS9002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("OrderHubGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromSubscribe", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 }

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/HubInterfaceGeneratorTests.Hub_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/HubInterfaceGeneratorTests.Hub_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,56 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- ChatHubGeneratedProxy.SignalR.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.SignalR.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SignalR hub proxy uses reflection for method invocation and serialization. Preserve required members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("SignalR hub proxy uses reflection for method invocation and serialization.")]
+#endif
+    internal sealed class ChatHubGeneratedProxy : global::IChatHub
+    {
+        private readonly global::Microsoft.AspNetCore.SignalR.Client.HubConnection _connection;
+
+        public ChatHubGeneratedProxy(global::Microsoft.AspNetCore.SignalR.Client.HubConnection connection)
+        {
+            _connection = connection;
+        }
+
+    public global::R3.Observable<global::System.Int32> GetUserCount() =>
+        global::Observables.SignalR.SignalRObservable.FromInvoke<global::System.Int32>(_connection, "GetUserCount", global::System.Array.Empty<object?>(), default);
+
+    private global::R3.Observable<global::ChatMessage>? _ReceiveMessage;
+    public global::R3.Observable<global::ChatMessage> ReceiveMessage =>
+        _ReceiveMessage ??= global::Observables.SignalR.SignalRObservable.FromOn<global::ChatMessage>(_connection, "ReceiveMessage");
+
+    }
+}
+#pragma warning restore
+
+--- HubProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.SignalR.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class HubProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.SignalR.Generated.ChatHubGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.SignalR.HubService.RegisterGeneratedFactory(typeof(global::IChatHub), static c => new Observables.SignalR.Generated.ChatHubGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/HubInterfaceGeneratorTests.cs
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/HubInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.SignalR.R3.SourceGenerators.Tests;
 
 public sealed class HubInterfaceGeneratorTests
 {
     [Fact]
-    public void Hub_interface_generates_proxy_and_registration()
+    public Task Hub_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -24,13 +26,7 @@ public sealed class HubInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS4002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("ChatHubGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromInvoke", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromOn", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.Sse/Observables.Sse.R3.SourceGenerators.Tests/SseInterfaceGeneratorTests.Sse_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.Sse/Observables.Sse.R3.SourceGenerators.Tests/SseInterfaceGeneratorTests.Sse_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,57 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- PriceFeedGeneratedProxy.Sse.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Sse.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SSE payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("SSE payload deserialization uses System.Text.Json reflection.")]
+#endif
+    internal sealed class PriceFeedGeneratedProxy : global::IPriceFeed
+    {
+        private readonly global::Observables.Sse.SseConnection _connection;
+
+        public PriceFeedGeneratedProxy(global::Observables.Sse.SseConnection connection)
+        {
+            _connection = connection;
+        }
+
+    private global::R3.Observable<global::System.String>? _Prices;
+    public global::R3.Observable<global::System.String> Prices =>
+        _Prices ??= global::Observables.Sse.SseObservable.FromEvent<global::System.String>(_connection, "price");
+
+    private global::R3.Observable<global::System.String>? _Heartbeats;
+    public global::R3.Observable<global::System.String> Heartbeats =>
+        _Heartbeats ??= global::Observables.Sse.SseObservable.FromEvent<global::System.String>(_connection, "message");
+
+    }
+}
+#pragma warning restore
+
+--- SseProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Sse.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class SseProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Sse.Generated.PriceFeedGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Sse.SseService.RegisterGeneratedFactory(typeof(global::IPriceFeed), static c => new Observables.Sse.Generated.PriceFeedGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.Sse/Observables.Sse.R3.SourceGenerators.Tests/SseInterfaceGeneratorTests.cs
+++ b/Observables.Sse/Observables.Sse.R3.SourceGenerators.Tests/SseInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Sse.R3.SourceGenerators.Tests;
 
 public sealed class SseInterfaceGeneratorTests
 {
     [Fact]
-    public void Sse_interface_generates_proxy_and_registration()
+    public Task Sse_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -19,16 +21,7 @@ public sealed class SseInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS8002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("PriceFeedGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromEvent", snapshot, StringComparison.Ordinal);
-        // explicit event name routed through
-        Assert.Contains("\"price\"", snapshot, StringComparison.Ordinal);
-        // default event name for parameterless [SseEvent]
-        Assert.Contains("\"message\"", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.Sse/Observables.Sse.Reactive.SourceGenerators.Tests/SseInterfaceGeneratorTests.Sse_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.Sse/Observables.Sse.Reactive.SourceGenerators.Tests/SseInterfaceGeneratorTests.Sse_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,57 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- PriceFeedGeneratedProxy.Sse.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.Sse.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SSE payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("SSE payload deserialization uses System.Text.Json reflection.")]
+#endif
+    internal sealed class PriceFeedGeneratedProxy : global::IPriceFeed
+    {
+        private readonly global::Observables.Sse.SseConnection _connection;
+
+        public PriceFeedGeneratedProxy(global::Observables.Sse.SseConnection connection)
+        {
+            _connection = connection;
+        }
+
+    private global::System.IObservable<global::System.String>? _Prices;
+    public global::System.IObservable<global::System.String> Prices =>
+        _Prices ??= global::Observables.Sse.Reactive.SystemReactiveSseAdapter.FromEvent<global::System.String>(_connection, "price");
+
+    private global::System.IObservable<global::System.String>? _Heartbeats;
+    public global::System.IObservable<global::System.String> Heartbeats =>
+        _Heartbeats ??= global::Observables.Sse.Reactive.SystemReactiveSseAdapter.FromEvent<global::System.String>(_connection, "message");
+
+    }
+}
+#pragma warning restore
+
+--- SseProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.Sse.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class SseProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.Sse.Reactive.Generated.PriceFeedGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.Sse.SseService.RegisterGeneratedFactory(typeof(global::IPriceFeed), static c => new Observables.Sse.Reactive.Generated.PriceFeedGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.Sse/Observables.Sse.Reactive.SourceGenerators.Tests/SseInterfaceGeneratorTests.cs
+++ b/Observables.Sse/Observables.Sse.Reactive.SourceGenerators.Tests/SseInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.Sse.Reactive.SourceGenerators.Tests;
 
 public sealed class SseInterfaceGeneratorTests
 {
     [Fact]
-    public void Sse_interface_generates_proxy_and_registration()
+    public Task Sse_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -19,14 +21,7 @@ public sealed class SseInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS8", snapshot, StringComparison.Ordinal);
-        Assert.Contains("PriceFeedGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromEvent", snapshot, StringComparison.Ordinal);
-        Assert.Contains("\"price\"", snapshot, StringComparison.Ordinal);
-        Assert.Contains("\"message\"", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.WebSocket_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.WebSocket_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,62 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- MyHubGeneratedProxy.WebSocket.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.WebSocket.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WebSocket payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("WebSocket payload serialization uses System.Text.Json reflection.")]
+#endif
+    internal sealed class MyHubGeneratedProxy : global::IMyHub
+    {
+        private readonly global::System.Net.WebSockets.ClientWebSocket _socket;
+
+        public MyHubGeneratedProxy(global::System.Net.WebSockets.ClientWebSocket socket)
+        {
+            _socket = socket;
+        }
+
+    public global::R3.Observable<global::R3.Unit> Connect(global::System.Uri uri, global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.WebSocketObservable.FromConnect(_socket, uri, cancellationToken);
+
+    public global::R3.Observable<global::R3.Unit> Close(global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.WebSocketObservable.FromClose(_socket, cancellationToken);
+
+    public global::R3.Observable<global::R3.Unit> Ping(global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.WebSocketObservable.FromSend(_socket, global::System.Array.Empty<byte>(), cancellationToken);
+
+    private global::R3.Observable<global::System.String>? _Messages;
+    public global::R3.Observable<global::System.String> Messages =>
+        _Messages ??= global::Observables.WebSocket.WebSocketObservable.FromReceive<global::System.String>(_socket);
+
+    }
+}
+#pragma warning restore
+
+--- WebSocketProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.WebSocket.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class WebSocketProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.WebSocket.Generated.MyHubGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.WebSocket.WebSocketService.RegisterGeneratedFactory(typeof(global::IMyHub), static c => new Observables.WebSocket.Generated.MyHubGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.cs
+++ b/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.WebSocket.R3.SourceGenerators.Tests;
 
 public sealed class WebSocketInterfaceGeneratorTests
 {
     [Fact]
-    public void WebSocket_interface_generates_proxy_and_registration()
+    public Task WebSocket_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -25,15 +27,7 @@ public sealed class WebSocketInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS6002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("MyHubGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromConnect", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromClose", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromSend", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromReceive", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]

--- a/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.WebSocket_interface_generates_proxy_and_registration.verified.txt
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.WebSocket_interface_generates_proxy_and_registration.verified.txt
@@ -1,0 +1,62 @@
+﻿Diagnostics:
+  <none>
+
+Generated Sources:
+--- MyHubGeneratedProxy.WebSocket.g.cs ---
+#nullable enable
+#pragma warning disable
+namespace Observables.WebSocket.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WebSocket payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("WebSocket payload serialization uses System.Text.Json reflection.")]
+#endif
+    internal sealed class MyHubGeneratedProxy : global::IMyHub
+    {
+        private readonly global::System.Net.WebSockets.ClientWebSocket _socket;
+
+        public MyHubGeneratedProxy(global::System.Net.WebSockets.ClientWebSocket socket)
+        {
+            _socket = socket;
+        }
+
+    public global::System.IObservable<global::System.Reactive.Unit> Connect(global::System.Uri uri, global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter.FromConnect(_socket, uri, cancellationToken);
+
+    public global::System.IObservable<global::System.Reactive.Unit> Close(global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter.FromClose(_socket, cancellationToken);
+
+    public global::System.IObservable<global::System.Reactive.Unit> Ping(global::System.Threading.CancellationToken cancellationToken = default) =>
+        global::Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter.FromSend(_socket, global::System.Array.Empty<byte>(), cancellationToken);
+
+    private global::System.IObservable<global::System.String>? _Messages;
+    public global::System.IObservable<global::System.String> Messages =>
+        _Messages ??= global::Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter.FromReceive<global::System.String>(_socket);
+
+    }
+}
+#pragma warning restore
+
+--- WebSocketProxyRegistration.g.cs ---
+
+#pragma warning disable
+namespace Observables.WebSocket.Reactive.Generated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static class WebSocketProxyRegistration
+    {
+#if NET5_0_OR_GREATER
+                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Observables.WebSocket.Reactive.Generated.MyHubGeneratedProxy))]
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+        internal static void Initialize()
+        {
+            global::Observables.WebSocket.WebSocketService.RegisterGeneratedFactory(typeof(global::IMyHub), static c => new Observables.WebSocket.Reactive.Generated.MyHubGeneratedProxy(c));
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators.Tests/WebSocketInterfaceGeneratorTests.cs
@@ -1,9 +1,11 @@
+using VerifyXunit;
+
 namespace Observables.WebSocket.Reactive.SourceGenerators.Tests;
 
 public sealed class WebSocketInterfaceGeneratorTests
 {
     [Fact]
-    public void WebSocket_interface_generates_proxy_and_registration()
+    public Task WebSocket_interface_generates_proxy_and_registration()
     {
         const string userSource =
             """
@@ -25,15 +27,7 @@ public sealed class WebSocketInterfaceGeneratorTests
             """;
 
         var output = GeneratorTestHarness.Run(userSource);
-        var snapshot = GeneratorTestHarness.ToSnapshot(output);
-
-        Assert.DoesNotContain("OBS6002", snapshot, StringComparison.Ordinal);
-        Assert.Contains("MyHubGeneratedProxy", snapshot, StringComparison.Ordinal);
-        Assert.Contains("RegisterGeneratedFactory", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromConnect", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromClose", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromSend", snapshot, StringComparison.Ordinal);
-        Assert.Contains("FromReceive", snapshot, StringComparison.Ordinal);
+        return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #101

Add Verify-validated snapshots to 5 remaining generator test domains (SignalR R3, Nats, Sse, WebSocket, Grpc) to match the pattern established by Events, SignalR Reactive, and RestAPI.

### Problem

5 of 8 domains referenced `Verify.XunitV3` but never called `Verifier.Verify()`. Their happy-path tests used `Assert.Contains` for spot-checks only, meaning generated output changes (e.g. trim annotations, adapter call changes) would go undetected. Grpc didn't even reference the package.

### Changes

For each domain, convert the main "generates_proxy_and_registration" (or "generates_reactive_proxy") test from `Assert.Contains` to `Verifier.Verify()`:

| Domain | R3 | Reactive | New snapshots |
|--------|-----|----------|---------------|
| SignalR | 1 | (already had 1) | 1 |
| Nats | 1 | 1 | 2 |
| Sse | 1 | 1 | 2 |
| WebSocket | 1 | 1 | 2 |
| Grpc | 1 + package | 1 + package | 2 |

- 9 new `.verified.txt` snapshot files capturing full generated proxy + registration output including trim annotations (`DynamicDependency`, `RequiresUnreferencedCode`, `RequiresDynamicCode`, `UnconditionalSuppressMessage`)
- 11 test files modified (happy-path → `Verifier.Verify()`, diagnostic tests kept as `Assert.Contains`)
- 2 Grpc csproj files: added missing `Verify.XunitV3` package reference

20 files changed, +676/-131 lines.

#### Test plan

- [x] All 9 generator test projects pass individually (27 tests total)
- [x] Nuke `Ci` (Clean/Restore/Compile/UnitTest) — green, 1:50
