### PR TITLE
fix(pack): replace global NU5128 suppression with _._ placeholder

### DIFF
--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -19,7 +19,6 @@
     <ObservablesCodeFixesOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/bin/$(Configuration)/netstandard2.0/'))</ObservablesCodeFixesOutputDir>
     <ObservablesAnalyzersProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj</ObservablesAnalyzersProject>
     <ObservablesAnalyzersOutputDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../Observables.Shared/Observables.Analyzers/bin/$(Configuration)/netstandard2.0/'))</ObservablesAnalyzersOutputDir>
-    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/PackReferencedProjects.targets
+++ b/eng/PackReferencedProjects.targets
@@ -7,6 +7,7 @@
   -->
 
   <PropertyGroup>
+    <ObservablesPackHasLibOutput>true</ObservablesPackHasLibOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);ObservablesPackCollectLibOutputs</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 

--- a/eng/PackRoslynAnalyzer.targets
+++ b/eng/PackRoslynAnalyzer.targets
@@ -43,6 +43,13 @@
       <None Include="$(_ObservablesPackAnalyzersDll)" Pack="true" PackagePath="$(ObservablesAnalyzerRoslynFolder)" Visible="false" Condition="'$(ObservablesPackAnalyzersProject)' != '' and Exists('$(_ObservablesPackAnalyzersDll)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="build/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
       <None Include="$(ObservablesPackPackagePropsFile)" Pack="true" PackagePath="buildTransitive/$(PackageId).props" Visible="false" Condition="'$(ObservablesPackPackagePropsFile)' != '' and Exists('$(ObservablesPackPackagePropsFile)')" />
+      <!-- _._ placeholder: analyzer-only packages have no lib/ output (DLLs go to analyzers/),
+           but runtime deps (R3, System.Reactive) must flow to consumers via the
+           netstandard2.0 dependency group. The _._ file satisfies NU5128 by giving
+           the dependency group a matching lib/ entry. Only needed when the package
+           has no real lib/ content (ObservablesPackHasLibOutput is not set). -->
+      <None Include="$(MSBuildThisFileDirectory)_._" Pack="true" PackagePath="lib/netstandard2.0/" Visible="false"
+            Condition="'$(ObservablesPackHasLibOutput)' != 'true'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Summary

Closes #107

Replace the global `NoWarn NU5128` suppression with a structural fix: add a `_._` placeholder file to `lib/netstandard2.0/` for analyzer-only packages that have no `lib/` content.

### Root cause

NU5128 fires when a nuspec has a dependency group for a TFM but no matching `lib/<tfm>/` files. Analyzer-only packages (Events) have a `netstandard2.0` dependency group (for R3/System.Reactive runtime deps) but no `lib/` content — DLLs go to `analyzers/dotnet/roslyn4.12/cs/`. The global `NoWarn` masked this instead of fixing it.

### Fix

- **`eng/_._`** — empty placeholder file (NuGet convention for "no assemblies in this TFM")
- **`eng/PackRoslynAnalyzer.targets`** — pack `_._` to `lib/netstandard2.0/`, conditioned on `ObservablesPackHasLibOutput != true` (avoids NU5109 in packages with real `lib/` content)
- **`eng/PackReferencedProjects.targets`** — set `ObservablesPackHasLibOutput=true` so packages with runtime DLLs skip the placeholder
- **`eng/Observables.Package.props`** — remove `<NoWarn>$(NoWarn);NU5128</NoWarn>`

### Package classification

| Type | Domains | Has `lib/` | Needs `_._` |
|------|---------|-----------|-------------|
| Analyzer-only | Events | No | Yes |
| Analyzer + runtime | RestAPI, SignalR, Mqtt, WebSocket, Grpc, Sse, Nats | Yes | No |

#### Test plan

- [x] Events pack: 0 NU5128, 0 NU5109, `_._` in `lib/netstandard2.0/`
- [x] RestAPI pack: 0 NU5128, 0 NU5109, no `_._` (has real `lib/` content)
- [x] All 16 packages created successfully
- [x] PackVerify: Succeeded
- [x] Full CI (Clean + Restore + Compile + UnitTest): Succeeded
- [ ] CI green
