### PR TITLE
 ci: add NuGet consumer smoke job and unify RestAPI reactive constant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,46 @@ jobs:
           path: artifacts/package/*.nupkg
           if-no-files-found: warn
 
+  smoke:
+    name: NuGet consumer smoke (Local)
+    needs: [changes, pack-domain]
+    runs-on: windows-latest
+    if: |
+      needs.changes.outputs.any == 'true'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pack')))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.300
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Run NuGet consumer smoke via Nuke (Local, skip Test)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          dotnet run --project build/_build.csproj -- --target NuGetConsumerSmoke --configuration Release --consumer-feed Local --skip Test 2>&1 | Tee-Object -FilePath smoke.log
+
+      - name: Upload smoke log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-log
+          path: smoke.log
+          if-no-files-found: warn
+
   doc-loc:
     name: Doc localization parity
     needs: changes

--- a/Observables.RestAPI/Observables.RestAPI.Reactive.SourceGenerators/Observables.RestAPI.Reactive.SourceGenerators.csproj
+++ b/Observables.RestAPI/Observables.RestAPI.Reactive.SourceGenerators/Observables.RestAPI.Reactive.SourceGenerators.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Source generator for declarative REST clients → System.Reactive IObservable.</Description>
-    <DefineConstants>$(DefineConstants);ROSLYN_4;RESTAPI_SYSTEM_REACTIVE</DefineConstants>
+    <DefineConstants>$(DefineConstants);ROSLYN_4;RESTAPI_REACTIVE</DefineConstants>
   </PropertyGroup>
 
 

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Emitter.cs
@@ -216,7 +216,7 @@ internal static class Emitter
     {
 #if RESTAPI_R3
         source.WriteLine($"return global::R3.Observable.FromAsync(async ______ct =>");
-#elif RESTAPI_SYSTEM_REACTIVE
+#elif RESTAPI_REACTIVE
         source.WriteLine($"return global::Observables.RestAPI.Reactive.SystemReactiveObservableAdapter.FromAsync(async ______ct =>");
 #else
         source.WriteLine($"return global::R3.Observable.FromAsync(async ______ct =>");

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
@@ -400,7 +400,7 @@ internal static class Parser
                     methodSymbol.Locations.FirstOrDefault(), returnType.ToDisplayString()));
                 return ReturnTypeInfo.Unsupported;
             }
-#elif RESTAPI_SYSTEM_REACTIVE
+#elif RESTAPI_REACTIVE
             if (metadata == "Observable`1" && def.ContainingNamespace?.ToDisplayString() == "R3")
             {
                 diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnsupportedReturnType,

--- a/docs/design/restapi.md
+++ b/docs/design/restapi.md
@@ -260,7 +260,7 @@ R3 与 System.Reactive 的切换通过 `#if` 编译指令实现：
 | 生成器项目 | `DefineConstants` | Parser 行为 | Emitter 行为 |
 |------------|-------------------|-------------|--------------|
 | `RestAPI.R3.SourceGenerators` | `RESTAPI_R3` | `Observable<T>` → `R3Observable`；`IObservable<T>` → OBS3005 | `R3.Observable.FromAsync(...)` |
-| `RestAPI.Reactive.SourceGenerators` | `RESTAPI_SYSTEM_REACTIVE` | `IObservable<T>` → `SystemReactiveObservable`；`Observable<T>` → OBS3003 | `SystemReactiveObservableAdapter.FromAsync(...)` |
+| `RestAPI.Reactive.SourceGenerators` | `RESTAPI_REACTIVE` | `IObservable<T>` → `SystemReactiveObservable`；`Observable<T>` → OBS3003 | `SystemReactiveObservableAdapter.FromAsync(...)` |
 
 两生成器共享同一份 `Parser.cs` / `Emitter.cs`（shproj），通过 `#if` 切换后端特定逻辑。
 
@@ -303,7 +303,7 @@ Observables.RestAPI/
 ├── Observables.RestAPI.Reactive/                     # System.Reactive 桥接（SystemReactiveObservableAdapter）
 ├── Observables.RestAPI.SourceGenerators.Shared/      # shproj（Parser、Emitter、Models、诊断）
 ├── Observables.RestAPI.R3.SourceGenerators/          # R3 生成器（RESTAPI_R3）
-├── Observables.RestAPI.Reactive.SourceGenerators/    # Reactive 生成器（RESTAPI_SYSTEM_REACTIVE）
+├── Observables.RestAPI.Reactive.SourceGenerators/    # Reactive 生成器（RESTAPI_REACTIVE）
 ├── Observables.RestAPI.HttpClientFactory/            # DI 扩展（独立包，不捆绑生成器）
 ├── Observables.RestAPI.Package/                      # Traversal 根，产出 2 个 NuGet 包
 │   ├── Observables.RestAPI.R3.csproj                 # PackageId = Observables.RestAPI.R3
@@ -323,7 +323,7 @@ Observables.RestAPI/
 | **`ModuleInitializer` 注册** | .NET 5+ 自动注册，AOT 友好；保留反射回退兼容旧框架 |
 | **`BodySerializationMethod` 镜像枚举** | 生成器（netstandard2.0）不引用运行时项目，用 internal 镜像枚举 + `int` 传递 |
 | **`#if NET6_0_OR_GREATER` 嵌入生成代码** | `HttpRequestMessage.Options` vs `Properties` 由消费者编译器选择 |
-| **`#if RESTAPI_R3` / `RESTAPI_SYSTEM_REACTIVE`** | shproj 共享一份 Parser/Emitter，编译期切换后端 |
+| **`#if RESTAPI_R3` / `RESTAPI_REACTIVE`** | shproj 共享一份 Parser/Emitter，编译期切换后端 |
 | **`PathFragmentModel` readonly record struct** | 路径模板编译期拆分，常量段直接拼接，参数段运行时格式化 |
 | **`IApiResponse<T>` 可选不抛异常** | 需要检查状态码/头的场景用 `IApiResponse<T>`；需要抛异常用 `Task<T>` |
 | **HttpClientFactory 独立包** | DI 集成可选，不强制依赖 `Microsoft.Extensions.Http` |


### PR DESCRIPTION
## Summary

- **A1 (P0, blocks release)**: Add `smoke` job to `ci.yml` that runs `NuGetConsumerSmoke` (Local feed) after `pack-domain` succeeds. This closes the critical gap where published packages were never consumer-validated in CI — the only release-blocking defect identified in the engineering review.
- **A2**: Unify the RestAPI Reactive generator conditional compilation constant from `RESTAPI_SYSTEM_REACTIVE` to `RESTAPI_REACTIVE`, matching the `<DOMAIN>_REACTIVE` naming convention used by all other 7 domains. Updates the csproj, shared Parser/Emitter `#elif` branches, and 3 doc references.

### Design notes (A1)

- The smoke job does **not** download `pack-domain` artifacts. Instead it runs `NuGetConsumerSmoke` which depends on `Pack` (builds all 16 packages locally) + `--skip Test` (tests already ran in `test-domain`). This avoids partial-domain-change failures where only some packages exist.
- Trigger conditions match `pack-domain` exactly: push to main, workflow_dispatch, or PR with `pack` label.
- `needs: pack-domain` ensures PackVerify passes before smoke runs.

#### Test plan

- [x] RestAPI R3 + Reactive source generators compile (0 warnings, 0 errors)
- [x] RestAPI generator tests pass (4/4, snapshots unchanged)
- [x] `RESTAPI_SYSTEM_REACTIVE` full-repo search returns 0 matches
- [x] ci.yml YAML syntax validated
- [x] 6 boundary scenarios reviewed (push / PR no-label / PR pack-label / pack failed / pack all-skipped / workflow_dispatch)
- [ ] CI smoke job runs green on first real trigger
