### PR TITLE
 chore: P1 consistency improvements for 0.1.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Stable packages are published to [nuget.org](https://www.nuget.org/profiles/Skym
 |---------|---------|
 | **0.1.0** | First stable release — eight feature domains, 16 packages (`.R3` + `.Reactive` per domain), public API baseline. |
 | **0.1.1** | Stable follow-up — localized **zh-Hans** IntelliSense for Reactive packages. |
+| **0.1.2** | Maintenance release — Events incremental generator caching, diagnostic descriptor consolidation, ADR-0001 primitives backend decision. |
 
 Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with tags only (no GitHub Release). Details and milestone planning: [docs/ROADMAP.md](docs/ROADMAP.md).
 

--- a/Observables.Events/Observables.Events.Reactive.SourceGenerators/Observables.Events.Reactive.SourceGenerators.csproj
+++ b/Observables.Events/Observables.Events.Reactive.SourceGenerators/Observables.Events.Reactive.SourceGenerators.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Source generators for classic .NET events → System.Reactive (IObservable).</Description>
-    <DefineConstants>$(DefineConstants);EVENTS_REACTIVE</DefineConstants>
+    <DefineConstants>$(DefineConstants);ROSLYN_4;EVENTS_REACTIVE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Observables.RestAPI/Observables.RestAPI.Reactive/Observables.RestAPI.Reactive.csproj
+++ b/Observables.RestAPI/Observables.RestAPI.Reactive/Observables.RestAPI.Reactive.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Observables.RestAPI\Observables.RestAPI.csproj" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 

--- a/Observables.Sse/Observables.Sse.Tests/Infrastructure/SseTestServer.cs
+++ b/Observables.Sse/Observables.Sse.Tests/Infrastructure/SseTestServer.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 
 namespace Observables.Sse.Tests.Infrastructure;
@@ -38,11 +39,25 @@ public sealed class SseTestServer : IAsyncDisposable
 
     public static SseTestServer Start()
     {
-        var port = Random.Shared.Next(50_000, 60_000);
+        var port = ReserveFreeTcpPort();
         var listener = new HttpListener();
         listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         listener.Start();
         return new SseTestServer(listener, port);
+    }
+
+    static int ReserveFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     async Task AcceptLoopAsync(CancellationToken cancellationToken)

--- a/Observables.WebSocket/Observables.WebSocket.Tests/Infrastructure/WebSocketTestServer.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Tests/Infrastructure/WebSocketTestServer.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
 
@@ -23,11 +24,25 @@ public sealed class WebSocketTestServer : IAsyncDisposable
 
     public static WebSocketTestServer Start()
     {
-        var port = Random.Shared.Next(50_000, 60_000);
+        var port = ReserveFreeTcpPort();
         var listener = new HttpListener();
         listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         listener.Start();
         return new WebSocketTestServer(listener, port);
+    }
+
+    static int ReserveFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     public Uri Uri => new($"ws://127.0.0.1:{Port}/");

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -13,6 +13,8 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
     <ObservablesAnalyzerRoslynFolder>analyzers/dotnet/roslyn4.12/cs</ObservablesAnalyzerRoslynFolder>
     <ObservablesCodeFixesProject>$(MSBuildThisFileDirectory)../Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj</ObservablesCodeFixesProject>


### PR DESCRIPTION
## Summary

P1 consistency improvements for the upcoming 0.1.4 release.

- **B1**: Replace `Random.Shared.Next(50_000, 60_000)` with `ReserveFreeTcpPort` in WebSocket and Sse E2E test servers, matching the Mqtt/Nats pattern. Eliminates port collision risk under high-concurrency CI.
- **B2**: Add missing 0.1.2 entry to the CONTRIBUTING.md release history table.
- **B3**: Add `ProjectReference` to `Observables.RestAPI` in `Observables.RestAPI.Reactive.csproj`, aligning with the other 6 domains whose `.Reactive` projects all reference their respective domain runtime.
- **B4**: Enable symbol packages (`IncludeSymbols=true` + `SymbolPackageFormat=snupkg`) in `eng/Observables.Package.props`. SourceLink is already configured; this completes the debugging experience.
- **B5**: Add `ROSLYN_4` prefix to the Events Reactive generator `DefineConstants`, matching the convention used by all other 7 domains.

#### Test plan

- [x] RestAPI.Reactive compiles (3 TFMs, 0 warnings, 0 errors)
- [x] RestAPI.Reactive.Tests pass (4/4, net8.0 + net9.0)
- [x] Events Reactive generator compiles (0 warnings, 0 errors)
- [x] WebSocket.Tests pass (8/8, net8.0 + net9.0)
- [x] Sse.Tests pass (6/6, net8.0 + net9.0)
- [ ] CI green
