### PR TITLE
feat: source generator fail-safe (internal error diagnostics)

### DIFF
--- a/Observables.Events/Observables.Events.R3.SourceGenerators/Observables.Events.R3.SourceGenerators.csproj
+++ b/Observables.Events/Observables.Events.R3.SourceGenerators/Observables.Events.R3.SourceGenerators.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Source generators for classic .NET events → R3 Observable.</Description>
-    <DefineConstants>$(DefineConstants);EVENTS_R3</DefineConstants>
+    <DefineConstants>$(DefineConstants);ROSLYN_4;EVENTS_R3</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS2005 | Observables.Events | Error | Internal source generator error

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -37,4 +37,12 @@ internal static class DiagnosticDescriptors
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError = new(
+        id: "OBS2005",
+        title: "Internal source generator error",
+        messageFormat: "An internal error occurred in the Events source generator: {0}: {1}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEvents/ObservableEventsEmissionModels.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEvents/ObservableEventsEmissionModels.cs
@@ -37,4 +37,5 @@ internal sealed record EventsDiagnosticModel(
     string? LocationFilePath,
     int LocationStartLine,
     int LocationStartColumn,
-    string MessageArg);
+    string MessageArg,
+    string? MessageArg2 = null);

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -75,62 +76,102 @@ public sealed partial class ObservableEventsGenerator : IIncrementalGenerator
         var parseStep = pipeline
             .Select(static (input, _) =>
             {
-                var model = ParseEvents(input.Compilation, input.Candidates, input.UseWpf, input.ObservableRoutedEvents);
-                return (input.ObservableRoutedEvents, Model: model);
+                try
+                {
+                    var model = ParseEvents(input.Compilation, input.Candidates, input.UseWpf, input.ObservableRoutedEvents);
+                    return (input.ObservableRoutedEvents, Model: model);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    return (input.ObservableRoutedEvents, Model: CreateInternalErrorModel(exception));
+                }
             })
             .WithTrackingName(EventsGeneratorStepName);
 
-        context.RegisterSourceOutput(parseStep, (spc, tuple) =>
+        context.RegisterSourceOutput(parseStep, static (spc, tuple) =>
         {
-            var (observableRoutedEvents, model) = tuple;
-
-            if (observableRoutedEvents)
-            {
-                spc.AddSource(
-                    $"{ObservableEventsConstants.GeneratedNamespace}.ObservableEventsBootstrapExtensions.Routed.g.cs",
-                    SourceText.From(
-                        GeneratedSourceHeader.ToSource(
-                            EventsBootstrapSyntaxFactory.CreateRoutedObservableEventsBootstrapExtensionsCompilationUnit()),
-                        Encoding.UTF8));
-            }
-
-            // Report captured diagnostics
-            foreach (var diag in model.Diagnostics)
-            {
-                var descriptor = diag.DescriptorId switch
-                {
-                    "OBS2001" => DiagnosticDescriptors.InvalidEventDelegate,
-                    "OBS2002" => DiagnosticDescriptors.InvalidEventHandlersDelegate,
-                    "OBS2003" => DiagnosticDescriptors.InvalidRoutedEventDelegate,
-                    "OBS2004" => DiagnosticDescriptors.InvalidRoutedEventHandlersDelegate,
-                    _ => null,
-                };
-                if (descriptor is null) continue;
-
-                var location = diag.LocationFilePath is not null
-                    ? Microsoft.CodeAnalysis.Location.Create(
-                        diag.LocationFilePath,
-                        new Microsoft.CodeAnalysis.Text.TextSpan(0, 0),
-                        new Microsoft.CodeAnalysis.Text.LinePositionSpan(
-                            new(diag.LocationStartLine, diag.LocationStartColumn),
-                            new(diag.LocationStartLine, diag.LocationStartColumn)))
-                    : Microsoft.CodeAnalysis.Location.None;
-                spc.ReportDiagnostic(Diagnostic.Create(descriptor, location, diag.MessageArg));
-            }
-
-            foreach (var iface in model.Interfaces)
-                spc.AddSource(iface.FileName, SourceText.From(iface.Source, Encoding.UTF8));
-
-            foreach (var impl in model.TypeImplementations)
-                spc.AddSource(impl.FileName, SourceText.From(impl.Source, Encoding.UTF8));
-
-            foreach (var gc in model.GenericConstraints)
-                spc.AddSource(gc.FileName, SourceText.From(gc.Source, Encoding.UTF8));
-
-            foreach (var ar in model.AttachedRoutedEvents)
-                spc.AddSource(ar.FileName, SourceText.From(ar.Source, Encoding.UTF8));
+            GeneratorFailSafe.TryEmit(
+                () => EmitParsedModel(spc, tuple),
+                spc.ReportDiagnostic,
+                DiagnosticDescriptors.InternalGeneratorError);
         });
     }
+
+    private static void EmitParsedModel(SourceProductionContext spc, (bool ObservableRoutedEvents, EventsEmissionModel Model) tuple)
+    {
+        var (observableRoutedEvents, model) = tuple;
+
+        if (observableRoutedEvents)
+        {
+            spc.AddSource(
+                $"{ObservableEventsConstants.GeneratedNamespace}.ObservableEventsBootstrapExtensions.Routed.g.cs",
+                SourceText.From(
+                    GeneratedSourceHeader.ToSource(
+                        EventsBootstrapSyntaxFactory.CreateRoutedObservableEventsBootstrapExtensionsCompilationUnit()),
+                    Encoding.UTF8));
+        }
+
+        // Report captured diagnostics
+        foreach (var diag in model.Diagnostics)
+        {
+            var descriptor = diag.DescriptorId switch
+            {
+                "OBS2001" => DiagnosticDescriptors.InvalidEventDelegate,
+                "OBS2002" => DiagnosticDescriptors.InvalidEventHandlersDelegate,
+                "OBS2003" => DiagnosticDescriptors.InvalidRoutedEventDelegate,
+                "OBS2004" => DiagnosticDescriptors.InvalidRoutedEventHandlersDelegate,
+                "OBS2005" => DiagnosticDescriptors.InternalGeneratorError,
+                _ => null,
+            };
+            if (descriptor is null) continue;
+
+            var location = diag.LocationFilePath is not null
+                ? Microsoft.CodeAnalysis.Location.Create(
+                    diag.LocationFilePath,
+                    new Microsoft.CodeAnalysis.Text.TextSpan(0, 0),
+                    new Microsoft.CodeAnalysis.Text.LinePositionSpan(
+                        new(diag.LocationStartLine, diag.LocationStartColumn),
+                        new(diag.LocationStartLine, diag.LocationStartColumn)))
+                : Microsoft.CodeAnalysis.Location.None;
+            spc.ReportDiagnostic(
+                diag.MessageArg2 is null
+                    ? Diagnostic.Create(descriptor, location, diag.MessageArg)
+                    : Diagnostic.Create(descriptor, location, diag.MessageArg, diag.MessageArg2));
+        }
+
+        foreach (var iface in model.Interfaces)
+            spc.AddSource(iface.FileName, SourceText.From(iface.Source, Encoding.UTF8));
+
+        foreach (var impl in model.TypeImplementations)
+            spc.AddSource(impl.FileName, SourceText.From(impl.Source, Encoding.UTF8));
+
+        foreach (var gc in model.GenericConstraints)
+            spc.AddSource(gc.FileName, SourceText.From(gc.Source, Encoding.UTF8));
+
+        foreach (var ar in model.AttachedRoutedEvents)
+            spc.AddSource(ar.FileName, SourceText.From(ar.Source, Encoding.UTF8));
+    }
+
+    private static EventsEmissionModel CreateInternalErrorModel(Exception exception) =>
+        new(
+            ImmutableEquatableArray.Empty<EventInterfaceEmissionModel>(),
+            ImmutableEquatableArray.Empty<TypeImplEmissionModel>(),
+            ImmutableEquatableArray.Empty<GenericConstraintEmissionModel>(),
+            ImmutableEquatableArray.Empty<AttachedRoutedEmissionModel>(),
+            new[]
+            {
+                new EventsDiagnosticModel(
+                    "OBS2005",
+                    null,
+                    0,
+                    0,
+                    exception.GetType().Name,
+                    exception.Message),
+            }.ToImmutableEquatableArray());
 
     private static bool IsGeneratorTestRoutedGeneration(Compilation compilation, ImmutableArray<SyntaxNode> candidates)
     {

--- a/Observables.Grpc/Observables.Grpc.R3.SourceGenerators/GrpcInterfaceStubGenerator.cs
+++ b/Observables.Grpc/Observables.Grpc.R3.SourceGenerators/GrpcInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Grpc.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Grpc.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateGrpcStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateGrpcStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(GrpcGeneratorStepName.BuildGrpc);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators/GrpcInterfaceStubGenerator.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators/GrpcInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Grpc.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Grpc.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateGrpcStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateGrpcStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(GrpcGeneratorStepName.BuildGrpc);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS7008 | Observables.Grpc | Error | Internal source generator error

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -57,6 +57,15 @@ internal static class DiagnosticDescriptors
             "Observables.Grpc",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS7008",
+            "Internal source generator error",
+            "An internal error occurred in the Grpc source generator: {0}: {1}",
+            "Observables.Grpc",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class GrpcGeneratorStepName

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Grpc.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/MqttInterfaceStubGenerator.cs
+++ b/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/MqttInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Mqtt.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Mqtt.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateMqttStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateMqttStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(MqttGeneratorStepName.BuildMqtt);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/MqttInterfaceStubGenerator.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/MqttInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Mqtt.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Mqtt.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateMqttStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateMqttStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(MqttGeneratorStepName.BuildMqtt);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS5008 | Observables.Mqtt | Error | Internal source generator error

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -57,6 +57,15 @@ internal static class DiagnosticDescriptors
             "Observables.Mqtt",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS5008",
+            "Internal source generator error",
+            "An internal error occurred in the Mqtt source generator: {0}: {1}",
+            "Observables.Mqtt",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class MqttGeneratorStepName

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Mqtt.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.Nats/Observables.Nats.R3.SourceGenerators/NatsInterfaceStubGenerator.cs
+++ b/Observables.Nats/Observables.Nats.R3.SourceGenerators/NatsInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Nats.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Nats.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateNatsStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateNatsStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(NatsGeneratorStepName.BuildNats);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Nats/Observables.Nats.Reactive.SourceGenerators/NatsInterfaceStubGenerator.cs
+++ b/Observables.Nats/Observables.Nats.Reactive.SourceGenerators/NatsInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Nats.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Nats.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateNatsStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateNatsStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(NatsGeneratorStepName.BuildNats);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS9008 | Observables.Nats | Error | Internal source generator error

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -57,6 +57,15 @@ internal static class DiagnosticDescriptors
             "Observables.Nats",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS9008",
+            "Internal source generator error",
+            "An internal error occurred in the Nats source generator: {0}: {1}",
+            "Observables.Nats",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class NatsGeneratorStepName

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Nats.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.RestAPI/Observables.RestAPI.R3.SourceGenerators/RestApiInterfaceStubGenerator.cs
+++ b/Observables.RestAPI/Observables.RestAPI.R3.SourceGenerators/RestApiInterfaceStubGenerator.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.RestAPI.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.RestAPI.R3.SourceGenerators;
 
@@ -33,11 +34,14 @@ public sealed class RestApiR3InterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = inputs.Select(
             static (collected, ct) =>
-                Parser.GenerateInterfaceStubs(
-                    (CSharpCompilation)collected.compilation,
-                    collected.Item1,
-                    collected.Item2,
-                    ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateInterfaceStubs(
+                        (CSharpCompilation)collected.compilation,
+                        collected.Item1,
+                        collected.Item2,
+                        ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<InterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -49,10 +53,6 @@ public sealed class RestApiR3InterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(RestApiGeneratorStepName.BuildRestApi);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) =>
-                Emitter.EmitSharedCode(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitSharedCode(contextModel);
     }
 }

--- a/Observables.RestAPI/Observables.RestAPI.Reactive.SourceGenerators/RestApiInterfaceStubGenerator.cs
+++ b/Observables.RestAPI/Observables.RestAPI.Reactive.SourceGenerators/RestApiInterfaceStubGenerator.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Observables.RestAPI.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.RestAPI.Reactive.SourceGenerators;
 
@@ -47,13 +48,14 @@ public sealed class RestApiInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = inputs.Select(
             static (collectedValues, cancellationToken) =>
-                Parser.GenerateInterfaceStubs(
-                    (CSharpCompilation)collectedValues.compilation,
-                    collectedValues.candidateMethods,
-                    collectedValues.candidateInterfaces,
-                    cancellationToken
-                )
-        );
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateInterfaceStubs(
+                        (CSharpCompilation)collectedValues.compilation,
+                        collectedValues.candidateMethods,
+                        collectedValues.candidateInterfaces,
+                        cancellationToken),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<InterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -65,13 +67,6 @@ public sealed class RestApiInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(RestApiGeneratorStepName.BuildRestApi);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) =>
-            {
-                Emitter.EmitSharedCode(model, (name, code) => spc.AddSource(name, code));
-            }
-        );
+        context.EmitSharedCode(contextModel);
     }
 }

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS3006 | Observables.RestAPI | Error | Internal source generator error

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -53,6 +53,16 @@ internal static class DiagnosticDescriptors
             DiagnosticSeverity.Error,
             true
         );
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS3006",
+            "Internal source generator error",
+            "An internal error occurred in the RestAPI source generator: {0}: {1}",
+            "Observables.RestAPI",
+            DiagnosticSeverity.Error,
+            true
+        );
 }
 
 internal static class RestApiGeneratorStepName

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,7 +1,7 @@
 #if ROSLYN_4
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.RestAPI.Generators;
 
@@ -36,11 +36,23 @@ internal static class IncrementalValuesProviderExtensions
         context.RegisterImplementationSourceOutput(
             model,
             static (spc, model) =>
-            {
-                var mapperText = Emitter.EmitInterface(model);
-                spc.AddSource(model.FileName, mapperText);
-            }
-        );
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitSharedCode(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitSharedCode(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.Shared/Observables.SourceGenerators.Shared/GeneratorFailSafe.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/GeneratorFailSafe.cs
@@ -1,0 +1,51 @@
+#if ROSLYN_4
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Converts unexpected generator exceptions into domain diagnostics instead of crashing compilation.
+/// </summary>
+internal static class GeneratorFailSafe
+{
+    public static Diagnostic CreateInternalError(DiagnosticDescriptor descriptor, Exception exception) =>
+        Diagnostic.Create(descriptor, Location.None, exception.GetType().Name, exception.Message);
+
+    public static void TryEmit(Action emit, Action<Diagnostic> report, DiagnosticDescriptor internalErrorDescriptor)
+    {
+        try
+        {
+            emit();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            report(CreateInternalError(internalErrorDescriptor, exception));
+        }
+    }
+
+    public static (List<Diagnostic> diagnostics, TModel model) ExecuteParse<TModel>(
+        Func<(List<Diagnostic> diagnostics, TModel model)> parse,
+        DiagnosticDescriptor internalErrorDescriptor,
+        Func<TModel> emptyModel)
+    {
+        try
+        {
+            return parse();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return (new List<Diagnostic> { CreateInternalError(internalErrorDescriptor, exception) }, emptyModel());
+        }
+    }
+}
+#endif

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/GeneratorFailSafeTests.cs
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators.Tests/GeneratorFailSafeTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.CodeAnalysis;
+using Observables.SignalR.Generators;
+using Observables.SourceGenerators.Shared;
+
+namespace Observables.SignalR.R3.SourceGenerators.Tests;
+
+public sealed class GeneratorFailSafeTests
+{
+    [Fact]
+    public void ExecuteParse_converts_exception_to_internal_diagnostic()
+    {
+        var (diagnostics, model) = GeneratorFailSafe.ExecuteParse(
+            () => throw new InvalidOperationException("probe"),
+            DiagnosticDescriptors.InternalGeneratorError,
+            () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>()));
+
+        Assert.Single(diagnostics);
+        Assert.Equal("OBS4008", diagnostics[0].Id);
+        Assert.Contains("InvalidOperationException", diagnostics[0].GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("probe", diagnostics[0].GetMessage(), StringComparison.Ordinal);
+        Assert.Empty(model.Interfaces);
+    }
+
+    [Fact]
+    public void TryEmit_converts_exception_to_internal_diagnostic()
+    {
+        Diagnostic? reported = null;
+        GeneratorFailSafe.TryEmit(
+            () => throw new InvalidOperationException("emit probe"),
+            d => reported = d,
+            DiagnosticDescriptors.InternalGeneratorError);
+
+        Assert.NotNull(reported);
+        Assert.Equal("OBS4008", reported.Id);
+        Assert.Contains("emit probe", reported.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hub_generator_reports_OBS4008_instead_of_crashing_on_internal_error()
+    {
+        const string userSource =
+            """
+            [Hub]
+            public interface IInternalErrorProbe
+            {
+                [HubInvoke]
+                Observable<int> Ping();
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+
+        Assert.Contains(
+            output.Diagnostics,
+            d => d.Id == "OBS4008"
+                && d.GetMessage().Contains("fail-safe probe", StringComparison.Ordinal));
+        Assert.DoesNotContain(output.GeneratedSources, s => s.HintName.Contains("IInternalErrorProbe"));
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/HubInterfaceStubGenerator.cs
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/HubInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.SignalR.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.SignalR.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateHubStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateHubStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(SignalRGeneratorStepName.BuildSignalR);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/Observables.SignalR.R3.SourceGenerators.csproj
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/Observables.SignalR.R3.SourceGenerators.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="R3" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Observables.SignalR.R3.SourceGenerators.Tests" />
+  </ItemGroup>
+
   <Import Project="..\Observables.SignalR.SourceGenerators.Shared\Observables.SignalR.SourceGenerators.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/HubInterfaceStubGenerator.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/HubInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.SignalR.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.SignalR.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateHubStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateHubStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(SignalRGeneratorStepName.BuildSignalR);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS4008 | Observables.SignalR | Error | Internal source generator error

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -57,6 +57,15 @@ internal static class DiagnosticDescriptors
             "Observables.SignalR",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS4008",
+            "Internal source generator error",
+            "An internal error occurred in the SignalR source generator: {0}: {1}",
+            "Observables.SignalR",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class SignalRGeneratorStepName

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.SignalR.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
@@ -47,6 +47,12 @@ internal static class Parser
             var semanticModel = compilation.GetSemanticModel(group.Key);
             foreach (var ifaceSyntax in group)
             {
+                if (string.Equals(compilation.AssemblyName, "GeneratorTests", StringComparison.Ordinal)
+                    && ifaceSyntax.Identifier.ValueText == "IInternalErrorProbe")
+                {
+                    throw new InvalidOperationException("fail-safe probe");
+                }
+
                 if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
                 {
                     continue;

--- a/Observables.SourceGenerators.SharedSource.props
+++ b/Observables.SourceGenerators.SharedSource.props
@@ -37,6 +37,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IdentifierHelper.cs">
       <Link>Shared/IdentifierHelper.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/GeneratorFailSafe.cs">
+      <Link>Shared/GeneratorFailSafe.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <!-- Global using to avoid qualifying shared types -->

--- a/Observables.Sse/Observables.Sse.R3.SourceGenerators/SseInterfaceStubGenerator.cs
+++ b/Observables.Sse/Observables.Sse.R3.SourceGenerators/SseInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Sse.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Sse.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateSseStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateSseStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(SseGeneratorStepName.BuildSse);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Sse/Observables.Sse.Reactive.SourceGenerators/SseInterfaceStubGenerator.cs
+++ b/Observables.Sse/Observables.Sse.Reactive.SourceGenerators/SseInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.Sse.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Sse.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateSseStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateSseStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(SseGeneratorStepName.BuildSse);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS8006 | Observables.Sse | Error | Internal source generator error

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -48,6 +48,15 @@ internal static class DiagnosticDescriptors
             "Observables.Sse",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS8006",
+            "Internal source generator error",
+            "An internal error occurred in the Sse source generator: {0}: {1}",
+            "Observables.Sse",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class SseGeneratorStepName

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.Sse.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/WebSocketInterfaceStubGenerator.cs
+++ b/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/WebSocketInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.WebSocket.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.WebSocket.R3.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateWebSocketStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateWebSocketStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(WebSocketGeneratorStepName.BuildWebSocket);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/WebSocketInterfaceStubGenerator.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/WebSocketInterfaceStubGenerator.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Observables.WebSocket.Generators;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.WebSocket.Reactive.SourceGenerators;
 
@@ -22,7 +23,10 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
 
         var parseStep = pipeline.Select(
             static (input, ct) =>
-                Parser.GenerateWebSocketStubs((CSharpCompilation)input.Right, input.Left, ct));
+                GeneratorFailSafe.ExecuteParse(
+                    () => Parser.GenerateWebSocketStubs((CSharpCompilation)input.Right, input.Left, ct),
+                    DiagnosticDescriptors.InternalGeneratorError,
+                    () => new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>())));
 
         var diagnostics = parseStep
             .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
@@ -34,9 +38,6 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
             .SelectMany(static (x, _) => x.Interfaces)
             .WithTrackingName(WebSocketGeneratorStepName.BuildWebSocket);
         context.EmitSource(interfaceModels);
-
-        context.RegisterImplementationSourceOutput(
-            contextModel,
-            static (spc, model) => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)));
+        context.EmitModuleInitializers(contextModel);
     }
 }

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+; Unshipped analyzer releases
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS6008 | Observables.WebSocket | Error | Internal source generator error

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -57,6 +57,15 @@ internal static class DiagnosticDescriptors
             "Observables.WebSocket",
             DiagnosticSeverity.Error,
             true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError =
+        new(
+            "OBS6008",
+            "Internal source generator error",
+            "An internal error occurred in the WebSocket source generator: {0}: {1}",
+            "Observables.WebSocket",
+            DiagnosticSeverity.Error,
+            true);
 }
 
 internal static class WebSocketGeneratorStepName

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/IncrementalValuesProviderExtensions.cs
@@ -1,6 +1,7 @@
 #if ROSLYN_4
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Observables.SourceGenerators.Shared;
 
 namespace Observables.WebSocket.Generators;
 
@@ -12,7 +13,24 @@ internal static class IncrementalValuesProviderExtensions
     {
         context.RegisterImplementationSourceOutput(
             model,
-            static (spc, model) => spc.AddSource(model.FileName, Emitter.EmitInterface(model)));
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => spc.AddSource(model.FileName, Emitter.EmitInterface(model)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
+    }
+
+    public static void EmitModuleInitializers(
+        this IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ContextGenerationModel> contextModel)
+    {
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            static (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => Emitter.EmitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    DiagnosticDescriptors.InternalGeneratorError));
     }
 }
 #endif

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,7 +186,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | # | 行动项 | 工作量 | 说明 |
 |---|--------|--------|------|
 | ~~E1~~ | ~~C# 关键字冲突处理（7/8 域）~~ | ~~M~~ | **已完成**：共享层新增 `IdentifierHelper.Escape(string)`（基于 `SyntaxFacts.IsKeywordKind`）；SignalR/Mqtt/WebSocket/Grpc/Sse/Nats 6 域 Parser 的 `MemberName`/`ParameterNames`/`ParameterDeclarations` 及 Nats `PayloadParameterName` 统一转义；Mqtt/Nats Emitter 的 Topic/SubjectParameterNames 标识符引用转义；6 域各 1 个关键字快照测试通过 |
-| E2 | 生成器内部异常 fail-safe | M | Parser 中 `throw`（RestAPI `ArgumentNullException`、SignalR `ArgumentOutOfRangeException` 等）会崩溃整个编译。建议捕获并转为 `OBSxxxx` "internal generator error" 诊断，`RegisterSourceOutput` 回调内 try-catch 包裹 Emitter |
+| ~~E2~~ | ~~生成器内部异常 fail-safe~~ | ~~M~~ | **已完成**：共享 `GeneratorFailSafe`（`ExecuteParse` / `TryEmit`）；8 域 `OBS*00x/008` 内部错误诊断；SignalR 回归测试（单元 + `IInternalErrorProbe` 集成探针） |
 
 #### P3-B — 影响开发体验与 IDE 集成
 


### PR DESCRIPTION
## Summary

- Add shared `GeneratorFailSafe` helper with `ExecuteParse` and `TryEmit` to convert unexpected generator exceptions into compile-time diagnostics instead of crashing Roslyn.
- Register per-domain internal error IDs: OBS2005, OBS3006, OBS4008, OBS5008, OBS6008, OBS7008, OBS8006, OBS9008.
- Wrap parse/emit pipelines across all eight domains; consolidate emit fail-safe in domain `IncrementalValuesProviderExtensions`.
- Fix Events OBS2005 message formatting for both parse and emit paths (`MessageArg` + `MessageArg2`).
- Add SignalR regression tests (unit tests + `IInternalErrorProbe` integration hook active only for `GeneratorTests` assembly).
- Mark ROADMAP P3-A E2 complete.

Closes #112

Companion docs PR: Skymly/Observables.Docs (internal error diagnostic tables).

## Test plan

- [x] `dotnet build Observables.slnx -c Release`
- [x] `dotnet test Observables.SignalR.R3.SourceGenerators.Tests --filter GeneratorFailSafeTests`
- [x] `dotnet test Observables.Events.R3.SourceGenerators.Tests`
- [x] Nuke `Test` target (full manifest)