### PR TITLE
Add RestAPI generator boundary tests (E8)

### DIFF
--- a/Observables.RestAPI/Observables.RestAPI.GeneratorTests/BoundaryGeneratorTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.GeneratorTests/BoundaryGeneratorTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.RestAPI.GeneratorTests;
+
+public sealed class BoundaryGeneratorTests
+{
+    [Fact]
+    public void Nested_interface_generates_compilable_proxy()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            namespace Demo;
+
+            public static class ApiContainer
+            {
+                public interface IUserApi
+                {
+                    [Get("/users/{id}")]
+                    Task<User> GetUser(int id);
+                }
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        Assert.DoesNotContain(
+            output.Diagnostics,
+            static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            output.GeneratedSources,
+            static source => source.Source.Contains(
+                "global::Demo.ApiContainer.IUserApi",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            output.GeneratedSources,
+            static source => source.Source.Contains(
+                "ApiContainerIUserApi",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Ref_struct_parameter_reports_generated_compilation_error()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            namespace Demo;
+
+            public ref struct RequestToken
+            {
+                public int Value;
+            }
+
+            public interface IUserApi
+            {
+                [Get("/users")]
+                Task<User> GetUser(RequestToken token);
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        Assert.Contains(
+            output.Diagnostics,
+            static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Ref_return_method_reports_generated_compilation_error()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            namespace Demo;
+
+            public interface IUserApi
+            {
+                [Get("/users/{id}")]
+                ref User GetUser(int id);
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        Assert.Contains(
+            output.Diagnostics,
+            static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #122.

Start roadmap item E8 with RestAPI generator boundary tests covering nested interfaces, `ref struct` parameters, and `ref` return methods.

## Behavior covered

- Nested REST API interfaces generate a compilable proxy with the correct fully qualified interface and generated class name.
- `ref struct` parameters and `ref` return methods currently surface generated-compilation errors, documenting unsupported by-ref proxy shapes without changing production code.

## Validation

- RestAPI GeneratorTests: 20 passed, 0 failed.
- Existing 17 tests remain green.
- Build completed with 0 warnings and 0 errors.

## Follow-up

If by-ref scenarios should be supported rather than rejected, add explicit parser diagnostics and production behavior in a separate change before updating these assertions.