### PR TITLE
refactor: fold IO TryParse wrappers into ObservableReturnTypeParser

### DIFF
--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
@@ -161,10 +161,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 method.ReturnType,
+                compilation,
+                "Observables.Grpc.Reactive.SystemReactiveGrpcAdapter",
                 observableType,
+                unitType: null,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 method.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -226,29 +231,6 @@ internal static class Parser
                 names.ToImmutableEquatableArray(),
                 hasCt));
     }
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.Grpc.Reactive.SystemReactiveGrpcAdapter",
-            observableType,
-            unitType: null,
-            requiresUnitPayload: false,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static string? GetServiceName(INamedTypeSymbol ifaceSymbol)
     {

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
@@ -164,12 +164,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 method.ReturnType,
+                compilation,
+                "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
                 observableType,
                 unitType,
-                MqttBoundaryKind.Publish,
+                requiresUnitPayload: true,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 method.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -248,12 +251,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 property.Type,
+                compilation,
+                "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
                 observableType,
                 unitType: null,
-                MqttBoundaryKind.Subscribe,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 property.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -405,31 +411,6 @@ internal static class Parser
         badLocation = attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation();
         return false;
     }
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        INamedTypeSymbol? unitType,
-        MqttBoundaryKind boundary,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
-            observableType,
-            unitType,
-            requiresUnitPayload: boundary == MqttBoundaryKind.Publish,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static (List<string> declarations, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
@@ -191,12 +191,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 method.ReturnType,
+                compilation,
+                "Observables.Nats.Reactive.SystemReactiveNatsAdapter",
                 observableType,
                 unitType,
-                boundary,
+                requiresUnitPayload: boundary == NatsBoundaryKind.Publish,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 method.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -288,12 +291,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 property.Type,
+                compilation,
+                "Observables.Nats.Reactive.SystemReactiveNatsAdapter",
                 observableType,
                 unitType: null,
-                NatsBoundaryKind.Subscribe,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 property.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -522,31 +528,6 @@ internal static class Parser
         badLocation = attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation();
         return false;
     }
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        INamedTypeSymbol? unitType,
-        NatsBoundaryKind boundary,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.Nats.Reactive.SystemReactiveNatsAdapter",
-            observableType,
-            unitType,
-            requiresUnitPayload: boundary == NatsBoundaryKind.Publish,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static (List<string> declarations, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)

--- a/Observables.Shared/Observables.SourceGenerators.Shared/Diagnostics/ObservableReturnTypeParser.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/Diagnostics/ObservableReturnTypeParser.cs
@@ -11,11 +11,11 @@ public static class ObservableReturnTypeParser
 
     /// <summary>
     /// Validates return type against the active generator backend (R3 vs System.Reactive).
+    /// Backend selection comes from <see cref="BackendTokens.IsR3"/>.
     /// </summary>
     public static bool TryParse(
         ITypeSymbol returnType,
         Compilation compilation,
-        bool isR3Generator,
         string reactiveAdapterMetadataName,
         INamedTypeSymbol? expectedObservableType,
         INamedTypeSymbol? unitType,
@@ -30,6 +30,7 @@ public static class ObservableReturnTypeParser
         resultTypeDisplay = string.Empty;
         returnTypeDisplay = returnType.ToDisplayString(DisplayFormat);
         location ??= Location.None;
+        var isR3Generator = BackendTokens.IsR3;
 
         if (returnType is not INamedTypeSymbol named || !named.IsGenericType)
         {

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
@@ -179,12 +179,15 @@ internal static class Parser
             }
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 method.ReturnType,
+                compilation,
+                "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
                 observableType,
                 unitType,
-                boundary.Value,
+                requiresUnitPayload: boundary.Value == HubBoundaryKind.Send,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 method.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -254,12 +257,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 property.Type,
+                compilation,
+                "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
                 observableType,
                 unitType: null,
-                HubBoundaryKind.On,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 property.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -414,31 +420,6 @@ internal static class Parser
         (invokeAttribute is not null && HasAttribute(property, invokeAttribute))
         || (sendAttribute is not null && HasAttribute(property, sendAttribute))
         || (streamAttribute is not null && HasAttribute(property, streamAttribute));
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        INamedTypeSymbol? unitType,
-        HubBoundaryKind boundary,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
-            observableType,
-            unitType,
-            requiresUnitPayload: boundary == HubBoundaryKind.Send,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static (List<string> declarations, List<string> names, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
@@ -146,10 +146,15 @@ internal static class Parser
 
         var eventName = GetEventName(property) ?? "message";
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 property.Type,
+                compilation,
+                "Observables.Sse.Reactive.SystemReactiveSseAdapter",
                 observableType,
+                unitType: null,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 property.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -166,29 +171,6 @@ internal static class Parser
                 returnDisplay,
                 resultType));
     }
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.Sse.Reactive.SystemReactiveSseAdapter",
-            observableType,
-            unitType: null,
-            requiresUnitPayload: false,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static string? GetEventName(IPropertySymbol property)
     {

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
@@ -163,12 +163,17 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 method.ReturnType,
+                compilation,
+                "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
                 observableType,
                 unitType,
-                boundary.Value,
+                requiresUnitPayload: boundary.Value is WebSocketBoundaryKind.Send
+                    or WebSocketBoundaryKind.Connect
+                    or WebSocketBoundaryKind.Close,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 method.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -263,12 +268,15 @@ internal static class Parser
             return;
         }
 
-        if (!TryParseObservableReturn(
-                compilation,
+        if (!ObservableReturnTypeParser.TryParse(
                 property.Type,
+                compilation,
+                "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
                 observableType,
                 unitType: null,
-                WebSocketBoundaryKind.Receive,
+                requiresUnitPayload: false,
+                DiagnosticDescriptors.UnsupportedReturnType,
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
                 property.Locations.FirstOrDefault(),
                 diagnostics,
                 out var resultType,
@@ -297,33 +305,6 @@ internal static class Parser
         (sendAttribute is not null && HasAttribute(property, sendAttribute))
         || (connectAttribute is not null && HasAttribute(property, connectAttribute))
         || (closeAttribute is not null && HasAttribute(property, closeAttribute));
-
-    static bool TryParseObservableReturn(
-        CSharpCompilation compilation,
-        ITypeSymbol returnType,
-        INamedTypeSymbol? observableType,
-        INamedTypeSymbol? unitType,
-        WebSocketBoundaryKind boundary,
-        Location? location,
-        List<Diagnostic> diagnostics,
-        out string resultTypeDisplay,
-        out string returnTypeDisplay) =>
-        ObservableReturnTypeParser.TryParse(
-            returnType,
-            compilation,
-            isR3Generator: BackendTokens.IsR3,
-            reactiveAdapterMetadataName: "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
-            observableType,
-            unitType,
-            requiresUnitPayload: boundary is WebSocketBoundaryKind.Send
-                or WebSocketBoundaryKind.Connect
-                or WebSocketBoundaryKind.Close,
-            DiagnosticDescriptors.UnsupportedReturnType,
-            DiagnosticDescriptors.SystemReactiveNotReferenced,
-            location,
-            diagnostics,
-            out resultTypeDisplay,
-            out returnTypeDisplay);
 
     static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
     {

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -67,7 +67,7 @@ flowchart LR
 | 运行时依赖 | `R3` 包 | `System.Reactive` + 域 `.Reactive` 桥接 |
 | 禁止 | R3 包引用 System.Reactive | Reactive 包引用 R3 |
 
-共享生成逻辑放在 `*.SourceGenerators.Shared`（`.projitems`），由两路生成器项目 Import；全库基础设施在 `Observables.Shared/Observables.SourceGenerators.Shared`（`BackendTokens`、`GeneratedSourceHeader`、`GeneratorFailSafe`、`DiagnosticHelpLink` 等），经 `Observables.SourceGenerators.SharedSource.props` 链接编译。IO 代理域 Parser 经 `BackendTokens` 读编译期后端；域特定 BridgeType / adapter 元数据仍留在各域 Emitter/Parser。
+共享生成逻辑放在 `*.SourceGenerators.Shared`（`.projitems`），由两路生成器项目 Import；全库基础设施在 `Observables.Shared/Observables.SourceGenerators.Shared`（`BackendTokens`、`GeneratedSourceHeader`、`GeneratorFailSafe`、`DiagnosticHelpLink` 等），经 `Observables.SourceGenerators.SharedSource.props` 链接编译。IO 代理域 Parser 经 `BackendTokens` 读编译期后端；返回类型校验经 `ObservableReturnTypeParser`（内部使用 `BackendTokens.IsR3`）；域特定 BridgeType / adapter 元数据仍留在各域 Emitter/Parser。
 
 ## 4. 源生成器管道（IO 域典型）
 


### PR DESCRIPTION
## Summary
- Deepen `ObservableReturnTypeParser.TryParse` to read `BackendTokens.IsR3` (remove `isR3Generator` parameter)
- Delete six IO-domain `TryParseObservableReturn` wrappers; call sites pass adapter metadata, unit payload rules, and diagnostics directly
- Document the path in `architecture.md`

## Test plan
- [x] 12 IO R3/Reactive SourceGenerators.Tests on net8
- [ ] CI green
- [ ] Bugbot review triaged

Made with [Cursor](https://cursor.com)