### PR TITLE
refactor(restapi): extract RestApiReturnTypeClassifier

### DIFF
--- a/Observables.RestAPI/Observables.RestAPI.GeneratorTests/CoreGeneratorTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.GeneratorTests/CoreGeneratorTests.cs
@@ -95,6 +95,51 @@ public class CoreGeneratorTests
         return Task.CompletedTask;
     }
 
+    [Fact]
+    public Task IObservable_on_R3_generator_reports_OBS3005()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            using System;
+
+            public interface IUserApi
+            {
+                [Get("/users/{id}")]
+                IObservable<User> GetUser(int id);
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """);
+
+        Assert.Contains("OBS3005", GeneratorTestHarness.ToSnapshot(output), StringComparison.Ordinal);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public Task R3_Observable_on_Reactive_generator_reports_OBS3003()
+    {
+        GeneratorRunOutput output = GeneratorTestHarness.Run(
+            """
+            public interface IUserApi
+            {
+                [Get("/users/{id}")]
+                Observable<User> GetUser(int id);
+            }
+
+            public sealed class User
+            {
+                public int Id { get; set; }
+            }
+            """,
+            generators: [new Observables.RestAPI.Reactive.SourceGenerators.RestApiInterfaceStubGenerator()]);
+
+        Assert.Contains("OBS3003", GeneratorTestHarness.ToSnapshot(output), StringComparison.Ordinal);
+        return Task.CompletedTask;
+    }
+
     // ── Path + [Body]/[Query] regression tests (issue #111) ──
 
     [Fact]

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Observables.RestAPI.SourceGenerators.Shared.projitems
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Observables.RestAPI.SourceGenerators.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\TypeConstraint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\WellKnownTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parser.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RestApiReturnTypeClassifier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Polyfills\IndexRange.cs" />
   </ItemGroup>
 </Project>

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/Parser.cs
@@ -323,7 +323,11 @@ internal static class Parser
             declaredBaseName += $"<{typeParams}>";
         }
 
-        var returnTypeInfo = ClassifyReturnType(methodSymbol.ReturnType, methodSymbol, wellKnownTypes, diagnostics);
+        var returnClassification = RestApiReturnTypeClassifier.Classify(
+            methodSymbol.ReturnType,
+            methodSymbol,
+            wellKnownTypes,
+            diagnostics);
 
         var httpSemantics = ParseHttpSemantics(methodSymbol, httpMethodBaseAttributeSymbol);
         ValidatePathTemplate(methodSymbol, httpSemantics, diagnostics);
@@ -334,10 +338,9 @@ internal static class Parser
 
         var isExplicit = explicitImpl is not null;
         var constraints = GenerateConstraints(methodSymbol.TypeParameters, isExplicit || !isImplicitInterface);
-        var (returnResultType, deserializedResultType, isApiResponse) = ExtractReturnTypeInfo(methodSymbol.ReturnType, returnTypeInfo);
 
         return new MethodModel(methodSymbol.Name, returnType, containingType, declaredBaseName,
-            returnTypeInfo, parameters, constraints, isExplicit,
+            returnClassification.Info, parameters, constraints, isExplicit,
             HttpMethod: httpSemantics.HttpMethod,
             PathFragments: httpSemantics.PathFragments,
             CancellationTokenIndex: httpSemantics.CancellationTokenIndex,
@@ -348,78 +351,9 @@ internal static class Parser
             IsMultipart: httpSemantics.IsMultipart,
             MultipartBoundary: httpSemantics.MultipartBoundary,
             QueryUriFormat: httpSemantics.QueryUriFormat,
-            IsApiResponse: isApiResponse,
-            ReturnResultType: returnResultType,
-            DeserializedResultType: deserializedResultType);
-    }
-
-    static (string ReturnResultType, string DeserializedResultType, bool IsApiResponse) ExtractReturnTypeInfo(
-        ITypeSymbol returnType, ReturnTypeInfo returnTypeInfo)
-    {
-        if (returnTypeInfo == ReturnTypeInfo.SyncVoid || returnTypeInfo == ReturnTypeInfo.AsyncVoid)
-            return ("void", "void", false);
-
-        ITypeSymbol? innerType = null;
-        if (returnType is INamedTypeSymbol { IsGenericType: true } namedType)
-            innerType = namedType.TypeArguments.FirstOrDefault();
-
-        if (innerType == null)
-            return (returnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    returnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), false);
-
-        var innerDisplay = innerType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        var isApiResponse = innerType is INamedTypeSymbol innerNamed
-            && (innerNamed.Name == "ApiResponse" || innerNamed.Name == "IApiResponse") && innerNamed.IsGenericType;
-
-        if (isApiResponse && innerType is INamedTypeSymbol apiResponseNamed)
-        {
-            var bodyType = apiResponseNamed.TypeArguments.FirstOrDefault();
-            var bodyDisplay = bodyType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? "object";
-            return (innerDisplay, bodyDisplay, true);
-        }
-
-        return (innerDisplay, innerDisplay, false);
-    }
-
-    static ReturnTypeInfo ClassifyReturnType(ITypeSymbol returnType, IMethodSymbol methodSymbol,
-        WellKnownTypes wellKnownTypes, List<Diagnostic> diagnostics)
-    {
-        if (returnType.SpecialType == SpecialType.System_Void) return ReturnTypeInfo.SyncVoid;
-        if (returnType.MetadataName == "Task") return ReturnTypeInfo.AsyncVoid;
-
-        if (returnType is INamedTypeSymbol { IsGenericType: true } namedType)
-        {
-            var def = namedType.OriginalDefinition;
-            var metadata = def.MetadataName;
-            if (metadata is "Task`1" or "ValueTask`1") return ReturnTypeInfo.AsyncResult;
-
-#if RESTAPI_R3
-            if (metadata == "Observable`1" && def.ContainingNamespace?.ToDisplayString() == "R3")
-                return ReturnTypeInfo.R3Observable;
-            if (metadata == "IObservable`1")
-            {
-                diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.SystemReactiveNotReferenced,
-                    methodSymbol.Locations.FirstOrDefault(), returnType.ToDisplayString()));
-                return ReturnTypeInfo.Unsupported;
-            }
-#elif RESTAPI_REACTIVE
-            if (metadata == "Observable`1" && def.ContainingNamespace?.ToDisplayString() == "R3")
-            {
-                diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnsupportedReturnType,
-                    methodSymbol.Locations.FirstOrDefault(), returnType.ToDisplayString()));
-                return ReturnTypeInfo.Unsupported;
-            }
-            if (metadata == "IObservable`1")
-            {
-                if (wellKnownTypes.TryGet("Observables.RestAPI.Reactive.SystemReactiveObservableAdapter") != null)
-                    return ReturnTypeInfo.SystemReactiveObservable;
-                diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.SystemReactiveNotReferenced,
-                    methodSymbol.Locations.FirstOrDefault(), returnType.ToDisplayString()));
-                return ReturnTypeInfo.Unsupported;
-            }
-#endif
-        }
-        return ReturnTypeInfo.Return;
+            IsApiResponse: returnClassification.IsApiResponse,
+            ReturnResultType: returnClassification.ReturnResultType,
+            DeserializedResultType: returnClassification.DeserializedResultType);
     }
 
     // ─── HTTP semantic parsing ───────────────────────────────────────────

--- a/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/RestApiReturnTypeClassifier.cs
+++ b/Observables.RestAPI/Observables.RestAPI.SourceGenerators.Shared/RestApiReturnTypeClassifier.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis;
+using Observables.SourceGenerators.Shared;
+
+namespace Observables.RestAPI.Generators;
+
+/// <summary>
+/// RestAPI return-type classification for HTTP method generation.
+/// Backend (R3 vs System.Reactive) selection uses <see cref="BackendTokens.IsR3"/>.
+/// </summary>
+internal static class RestApiReturnTypeClassifier
+{
+    internal readonly record struct RestApiReturnClassification(
+        ReturnTypeInfo Info,
+        string ReturnResultType,
+        string DeserializedResultType,
+        bool IsApiResponse);
+
+    internal static RestApiReturnClassification Classify(
+        ITypeSymbol returnType,
+        IMethodSymbol methodSymbol,
+        WellKnownTypes wellKnownTypes,
+        List<Diagnostic> diagnostics)
+    {
+        var info = ClassifyKind(returnType, methodSymbol, wellKnownTypes, diagnostics);
+        var (returnResultType, deserializedResultType, isApiResponse) = Extract(returnType, info);
+        return new RestApiReturnClassification(info, returnResultType, deserializedResultType, isApiResponse);
+    }
+
+    static ReturnTypeInfo ClassifyKind(
+        ITypeSymbol returnType,
+        IMethodSymbol methodSymbol,
+        WellKnownTypes wellKnownTypes,
+        List<Diagnostic> diagnostics)
+    {
+        if (returnType.SpecialType == SpecialType.System_Void)
+        {
+            return ReturnTypeInfo.SyncVoid;
+        }
+
+        if (returnType.MetadataName == "Task")
+        {
+            return ReturnTypeInfo.AsyncVoid;
+        }
+
+        if (returnType is not INamedTypeSymbol { IsGenericType: true } namedType)
+        {
+            return ReturnTypeInfo.Return;
+        }
+
+        var def = namedType.OriginalDefinition;
+        var metadata = def.MetadataName;
+        if (metadata is "Task`1" or "ValueTask`1")
+        {
+            return ReturnTypeInfo.AsyncResult;
+        }
+
+        var isR3 = BackendTokens.IsR3;
+        if (metadata == "Observable`1" && def.ContainingNamespace?.ToDisplayString() == "R3")
+        {
+            if (isR3)
+            {
+                return ReturnTypeInfo.R3Observable;
+            }
+
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.UnsupportedReturnType,
+                methodSymbol.Locations.FirstOrDefault(),
+                returnType.ToDisplayString()));
+            return ReturnTypeInfo.Unsupported;
+        }
+
+        if (metadata == "IObservable`1")
+        {
+            if (isR3)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    DiagnosticDescriptors.SystemReactiveNotReferenced,
+                    methodSymbol.Locations.FirstOrDefault(),
+                    returnType.ToDisplayString()));
+                return ReturnTypeInfo.Unsupported;
+            }
+
+            if (wellKnownTypes.TryGet("Observables.RestAPI.Reactive.SystemReactiveObservableAdapter") != null)
+            {
+                return ReturnTypeInfo.SystemReactiveObservable;
+            }
+
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.SystemReactiveNotReferenced,
+                methodSymbol.Locations.FirstOrDefault(),
+                returnType.ToDisplayString()));
+            return ReturnTypeInfo.Unsupported;
+        }
+
+        return ReturnTypeInfo.Return;
+    }
+
+    static (string ReturnResultType, string DeserializedResultType, bool IsApiResponse) Extract(
+        ITypeSymbol returnType,
+        ReturnTypeInfo returnTypeInfo)
+    {
+        if (returnTypeInfo is ReturnTypeInfo.SyncVoid or ReturnTypeInfo.AsyncVoid)
+        {
+            return ("void", "void", false);
+        }
+
+        ITypeSymbol? innerType = null;
+        if (returnType is INamedTypeSymbol { IsGenericType: true } namedType)
+        {
+            innerType = namedType.TypeArguments.FirstOrDefault();
+        }
+
+        if (innerType is null)
+        {
+            var display = returnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return (display, display, false);
+        }
+
+        var innerDisplay = innerType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var isApiResponse = innerType is INamedTypeSymbol innerNamed
+            && (innerNamed.Name == "ApiResponse" || innerNamed.Name == "IApiResponse")
+            && innerNamed.IsGenericType;
+
+        if (isApiResponse && innerType is INamedTypeSymbol apiResponseNamed)
+        {
+            var bodyType = apiResponseNamed.TypeArguments.FirstOrDefault();
+            var bodyDisplay = bodyType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? "object";
+            return (innerDisplay, bodyDisplay, true);
+        }
+
+        return (innerDisplay, innerDisplay, false);
+    }
+}

--- a/docs/design/restapi.md
+++ b/docs/design/restapi.md
@@ -322,7 +322,7 @@ Observables.RestAPI/
 | **`ModuleInitializer` 注册** | .NET 5+ 自动注册，AOT 友好；保留反射回退兼容旧框架 |
 | **`BodySerializationMethod` 镜像枚举** | 生成器（netstandard2.0）不引用运行时项目，用 internal 镜像枚举 + `int` 传递 |
 | **`#if NET6_0_OR_GREATER` 嵌入生成代码** | `HttpRequestMessage.Options` vs `Properties` 由消费者编译器选择 |
-| **`#if RESTAPI_R3` / `RESTAPI_REACTIVE`** | shproj 共享一份 Parser/Emitter，编译期切换后端 |
+| **`BackendTokens.IsR3` + `#if RESTAPI_R3`（Emitter）** | 返回类型分类与 IO 域共用 compile-time backend seam；Emitter 仍用域级 `#if` 切换发射文本 |
 | **`PathFragmentModel` readonly record struct** | 路径模板编译期拆分，常量段直接拼接，参数段运行时格式化 |
 | **`IApiResponse<T>` 可选不抛异常** | 需要检查状态码/头的场景用 `IApiResponse<T>`；需要抛异常用 `Task<T>` |
 | **HttpClientFactory 独立包** | DI 集成可选，不强制依赖 `Microsoft.Extensions.Http` |

--- a/docs/design/restapi.md
+++ b/docs/design/restapi.md
@@ -33,6 +33,7 @@ RestAPI 域的运行时部分包含由 [Refit](https://github.com/reactiveui/ref
 ### 2.2 新模型（Path B）
 
 - **Parser** 在编译期从接口方法符号提取全部 HTTP 语义（HTTP 方法、路径模板、参数绑定、序列化方式、静态头、multipart 设置等）。
+- **返回类型**：HTTP 方法经域内 `RestApiReturnTypeClassifier`（`Classify` → `RestApiReturnClassification`）分类；Observable / `IObservable` 分支读 `BackendTokens.IsR3`（不并入共享 `ObservableReturnTypeParser`，见 ROADMAP C1）。
 - **Emitter** 直接生成 `HttpRequestMessage` 构建代码与 `RestApiBridge` 调用，生成代码是直观的命令式方法体。
 - **运行时**不再反射接口元数据；`RestApiBridge` 仅提供静态助手（路径/查询格式化、请求发送、序列化）。
 - **代理注册**通过 `ModuleInitializer` + `RestService.RegisterGeneratedFactory` 自动注册（.NET 5+）；旧路径 `Type.GetType` + `Activator.CreateInstance` 保留为回退。
@@ -255,14 +256,12 @@ public static class RestApiBridge
 
 ## 6. 双后端条件编译
 
-R3 与 System.Reactive 的切换通过 `#if` 编译指令实现：
+| 生成器项目 | `DefineConstants` | 返回类型分类（`RestApiReturnTypeClassifier`） | Emitter 行为 |
+|------------|-------------------|-----------------------------------------------|--------------|
+| `RestAPI.R3.SourceGenerators` | `RESTAPI_R3`（+ `OBSERVABLES_R3` via R3.props） | `BackendTokens.IsR3`：`Observable<T>` → `R3Observable`；`IObservable<T>` → OBS3005 | `#if RESTAPI_R3` → `R3.Observable.FromAsync(...)` |
+| `RestAPI.Reactive.SourceGenerators` | `RESTAPI_REACTIVE` | `BackendTokens.IsR3 == false`：`IObservable<T>` → `SystemReactiveObservable`；`Observable<T>` → OBS3003 | `#else` → `SystemReactiveObservableAdapter.FromAsync(...)` |
 
-| 生成器项目 | `DefineConstants` | Parser 行为 | Emitter 行为 |
-|------------|-------------------|-------------|--------------|
-| `RestAPI.R3.SourceGenerators` | `RESTAPI_R3` | `Observable<T>` → `R3Observable`；`IObservable<T>` → OBS3005 | `R3.Observable.FromAsync(...)` |
-| `RestAPI.Reactive.SourceGenerators` | `RESTAPI_REACTIVE` | `IObservable<T>` → `SystemReactiveObservable`；`Observable<T>` → OBS3003 | `SystemReactiveObservableAdapter.FromAsync(...)` |
-
-两生成器共享同一份 `Parser.cs` / `Emitter.cs`（shproj），通过 `#if` 切换后端特定逻辑。
+两生成器共享同一份 shproj：返回类型分类走 `BackendTokens.IsR3`；Emitter 仍用 `#if RESTAPI_R3` 切换发射文本。
 
 ## 7. 诊断（OBS3xxx）
 


### PR DESCRIPTION
## Summary
- Extract `RestApiReturnTypeClassifier` (`Classify` → `RestApiReturnClassification`) from RestAPI `Parser`
- Use `BackendTokens.IsR3` for Observable / `IObservable` branches (not C1 / shared `ObservableReturnTypeParser`)
- Add negative tests for OBS3005 (R3 + `IObservable`) and OBS3003 (Reactive generator + R3 `Observable`)
- Sync `docs/design/restapi.md` §2.2 / §6 / §10 with the new seam

## Test plan
- [x] `dotnet test` Observables.RestAPI.GeneratorTests (net8) — 18 passed
- [ ] CI green
- [ ] Bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of source-generator parsing with behavior preserved via tests; no runtime API or auth/data changes.
> 
> **Overview**
> **Return-type classification** is pulled out of `Parser` into a new shared **`RestApiReturnTypeClassifier`** (`Classify` → `RestApiReturnClassification`), so HTTP method parsing only delegates classification and maps the result onto `MethodModel`.
> 
> R3 vs System.Reactive branching for `Observable<T>` / `IObservable<T>` now uses **`BackendTokens.IsR3`** instead of `#if RESTAPI_R3` / `RESTAPI_REACTIVE` inside the classifier (Emitter still uses domain `#if` for emitted code).
> 
> **Generator tests** assert **OBS3005** when the R3 generator sees `IObservable<T>`, and **OBS3003** when the Reactive generator sees R3 `Observable<T>`. **`docs/design/restapi.md`** §2.2, §6, and §10 describe the new seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e842b33ff3a885d3d60125b2ad461b21c81391. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->