### PR TITLE
eng: BannedApiAnalyzers + CI whitespace format verify (E13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Verify whitespace (LF / trailing)
         run: dotnet format whitespace Observables.slnx --verify-no-changes --verbosity diagnostic
 
-  changes:    name: Detect changed domains
+  changes:
+    name: Detect changed domains
     runs-on: windows-latest
     outputs:
       events: ${{ steps.filter.outputs.events }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,23 @@ jobs:
       - name: Lint workflows
         run: actionlint .github/workflows/*.yml
 
-  changes:
-    name: Detect changed domains
+  format-whitespace:
+    name: Format whitespace verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.300
+
+      - name: Verify whitespace (LF / trailing)
+        run: dotnet format whitespace Observables.slnx --verify-no-changes --verbosity diagnostic
+
+  changes:    name: Detect changed domains
     runs-on: windows-latest
     outputs:
       events: ${{ steps.filter.outputs.events }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,4 +12,11 @@
 
   <Import Project="eng\Observables.ProjectDefaults.props" />
 
+  <!-- Analyzers / code fixes: enable BannedApi (generators enable via Observables.SourceGenerators.props). -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Observables.Analyzers' or '$(MSBuildProjectName)' == 'Observables.CodeFixes'">
+    <ObservablesEnableBannedApiAnalyzers>true</ObservablesEnableBannedApiAnalyzers>
+  </PropertyGroup>
+  <Import Project="eng\Observables.BannedApi.props"
+          Condition="'$(MSBuildProjectName)' == 'Observables.Analyzers' or '$(MSBuildProjectName)' == 'Observables.CodeFixes'" />
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Features" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
   </ItemGroup>
 
   <!-- Packaging -->

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.AttachedRouted.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.AttachedRouted.cs
@@ -14,95 +14,95 @@ namespace Observables.Events.Generators;
 
 public sealed partial class ObservableEventsGenerator
 {
-private static string GenerateAttachedRoutedEventSourceForTarget(
-    AttachedRoutedEventTarget target,
-    ObservableEventsEntryKind entryKind)
-{
-    var receiverType = SyntaxFactory.ParseTypeName(ObservableEventsConstants.QualifiedType(target.ReceiverType));
-    var observableMethod = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
-        ? ObservableEventsConstants.AttachedRoutedEventEntryMethodName
-        : ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName;
-    var returnType = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
-        ? SyntaxFactory.ParseTypeName(
+    private static string GenerateAttachedRoutedEventSourceForTarget(
+        AttachedRoutedEventTarget target,
+        ObservableEventsEntryKind entryKind)
+    {
+        var receiverType = SyntaxFactory.ParseTypeName(ObservableEventsConstants.QualifiedType(target.ReceiverType));
+        var observableMethod = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
+            ? ObservableEventsConstants.AttachedRoutedEventEntryMethodName
+            : ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName;
+        var returnType = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
+            ? SyntaxFactory.ParseTypeName(
 #if EVENTS_R3
-            "global::R3.Observable<TEventArgs>"
+                "global::R3.Observable<TEventArgs>"
 #else
             "global::System.IObservable<TEventArgs>"
 #endif
-            )
-        : SyntaxFactory.ParseTypeName(
+                )
+            : SyntaxFactory.ParseTypeName(
 #if EVENTS_R3
-            "global::R3.Observable<(object? sender, TEventArgs e)>"
+                "global::R3.Observable<(object? sender, TEventArgs e)>"
 #else
             "global::System.IObservable<(object? sender, TEventArgs e)>"
 #endif
-            );
+                );
 
-    var routedEventParam = SyntaxFactory.IdentifierName("routedEvent");
-    var addHandler = SyntaxFactory.InvocationExpression(
-        SyntaxFactory.MemberAccessExpression(
-            SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxFactory.IdentifierName("source"),
-            SyntaxFactory.GenericName(SyntaxFactory.Identifier("AddHandler"))
-                .WithTypeArgumentList(
-                    SyntaxFactory.TypeArgumentList(
-                        SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
-                            SyntaxFactory.IdentifierName("TEventArgs"))))),
-        SyntaxFactory.ArgumentList(
-            SyntaxFactory.SeparatedList(
-            [
-                SyntaxFactory.Argument(routedEventParam),
+        var routedEventParam = SyntaxFactory.IdentifierName("routedEvent");
+        var addHandler = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName("source"),
+                SyntaxFactory.GenericName(SyntaxFactory.Identifier("AddHandler"))
+                    .WithTypeArgumentList(
+                        SyntaxFactory.TypeArgumentList(
+                            SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+                                SyntaxFactory.IdentifierName("TEventArgs"))))),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SeparatedList(
+                [
+                    SyntaxFactory.Argument(routedEventParam),
                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("h")),
                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("routes")),
                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("handledEventsToo")),
-            ])));
+                ])));
 
-    var removeHandler = SyntaxFactory.InvocationExpression(
-        SyntaxFactory.MemberAccessExpression(
-            SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxFactory.IdentifierName("source"),
-            SyntaxFactory.GenericName(SyntaxFactory.Identifier("RemoveHandler"))
-                .WithTypeArgumentList(
-                    SyntaxFactory.TypeArgumentList(
-                        SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
-                            SyntaxFactory.IdentifierName("TEventArgs"))))),
-        SyntaxFactory.ArgumentList(
-            SyntaxFactory.SeparatedList(
-            [
-                SyntaxFactory.Argument(routedEventParam),
+        var removeHandler = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName("source"),
+                SyntaxFactory.GenericName(SyntaxFactory.Identifier("RemoveHandler"))
+                    .WithTypeArgumentList(
+                        SyntaxFactory.TypeArgumentList(
+                            SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+                                SyntaxFactory.IdentifierName("TEventArgs"))))),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SeparatedList(
+                [
+                    SyntaxFactory.Argument(routedEventParam),
                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("h")),
-            ])));
+                ])));
 
-    var subscribeHandler = ObservableEventsSyntaxFactory.HandlerSubscriptionLambda(addHandler);
-    var unsubscribeHandler = ObservableEventsSyntaxFactory.HandlerSubscriptionLambda(removeHandler);
-    ExpressionSyntax body = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
-        ? ObservableEventsSyntaxFactory.FromEventInvocation(
-            SyntaxFactory.ParseTypeName("global::System.EventHandler<TEventArgs>"),
-            SyntaxFactory.IdentifierName("TEventArgs"),
-            ObservableEventsSyntaxFactory.EventHandlerFactorySenderAndArgs(),
-            subscribeHandler,
-            unsubscribeHandler)
-        : ObservableEventsSyntaxFactory.FromEventHandlerInvocation(
-            SyntaxFactory.IdentifierName("TEventArgs"),
-            subscribeHandler,
-            unsubscribeHandler);
+        var subscribeHandler = ObservableEventsSyntaxFactory.HandlerSubscriptionLambda(addHandler);
+        var unsubscribeHandler = ObservableEventsSyntaxFactory.HandlerSubscriptionLambda(removeHandler);
+        ExpressionSyntax body = entryKind == ObservableEventsEntryKind.AttachedRoutedEvent
+            ? ObservableEventsSyntaxFactory.FromEventInvocation(
+                SyntaxFactory.ParseTypeName("global::System.EventHandler<TEventArgs>"),
+                SyntaxFactory.IdentifierName("TEventArgs"),
+                ObservableEventsSyntaxFactory.EventHandlerFactorySenderAndArgs(),
+                subscribeHandler,
+                unsubscribeHandler)
+            : ObservableEventsSyntaxFactory.FromEventHandlerInvocation(
+                SyntaxFactory.IdentifierName("TEventArgs"),
+                subscribeHandler,
+                unsubscribeHandler);
 
-    var method = ObservableEventsSyntaxFactory.CreateAttachedRoutedEventMethod(
-        observableMethod,
-        returnType,
-        receiverType,
-        body);
+        var method = ObservableEventsSyntaxFactory.CreateAttachedRoutedEventMethod(
+            observableMethod,
+            returnType,
+            receiverType,
+            body);
 
-    var unit = SyntaxFactory.CompilationUnit()
+        var unit = SyntaxFactory.CompilationUnit()
 #if EVENTS_R3
-        .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("R3")))
+            .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("R3")))
 #endif
-        .AddMembers(
-            SyntaxFactory.FileScopedNamespaceDeclaration(SyntaxFactory.ParseName(ObservableEventsConstants.GeneratedNamespace))
-                .AddMembers(
-                    ObservableEventsSyntaxFactory.BootstrapExtensionsClassDeclaration()
-                        .AddMembers(method)));
+            .AddMembers(
+                SyntaxFactory.FileScopedNamespaceDeclaration(SyntaxFactory.ParseName(ObservableEventsConstants.GeneratedNamespace))
+                    .AddMembers(
+                        ObservableEventsSyntaxFactory.BootstrapExtensionsClassDeclaration()
+                            .AddMembers(method)));
 
-    return GeneratedSourceHeader.ToSource(unit);
-}
+        return GeneratedSourceHeader.ToSource(unit);
+    }
 }

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.Discovery.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.Discovery.cs
@@ -14,729 +14,729 @@ namespace Observables.Events.Generators;
 
 public sealed partial class ObservableEventsGenerator
 {
-private static void RegisterObservableEventsStaticsShellPostInit(IncrementalGeneratorInitializationContext context)
-{
+    private static void RegisterObservableEventsStaticsShellPostInit(IncrementalGeneratorInitializationContext context)
+    {
 #pragma warning disable CS0162 // Unreachable when ObservableEventsConstants.StaticObservableEventsGenerationEnabled is compile-time false
-    if (!ObservableEventsConstants.StaticObservableEventsGenerationEnabled)
-    {
-        return;
-    }
+        if (!ObservableEventsConstants.StaticObservableEventsGenerationEnabled)
+        {
+            return;
+        }
 
-    context.RegisterPostInitializationOutput(static ctx =>
-        ctx.AddSource(
-            $"{ObservableEventsConstants.GeneratedNamespace}.ObservableEventsStatics.g.cs",
-            SourceText.From(
-                GeneratedSourceHeader.ToSource(
-                    EventsBootstrapSyntaxFactory.CreateObservableEventsStaticsShellCompilationUnit()),
-                Encoding.UTF8)));
+        context.RegisterPostInitializationOutput(static ctx =>
+            ctx.AddSource(
+                $"{ObservableEventsConstants.GeneratedNamespace}.ObservableEventsStatics.g.cs",
+                SourceText.From(
+                    GeneratedSourceHeader.ToSource(
+                        EventsBootstrapSyntaxFactory.CreateObservableEventsStaticsShellCompilationUnit()),
+                    Encoding.UTF8)));
 #pragma warning restore CS0162
-}
+    }
 
-private static bool IsObservableEventsInstanceEntryInvocation(SyntaxNode node)
-{
-    if (node is not InvocationExpressionSyntax
+    private static bool IsObservableEventsInstanceEntryInvocation(SyntaxNode node)
+    {
+        if (node is not InvocationExpressionSyntax
+            {
+                Expression: MemberAccessExpressionSyntax
+                {
+                    Expression: not GenericNameSyntax,
+                    Name.Identifier.ValueText: var methodName,
+                },
+            })
         {
-            Expression: MemberAccessExpressionSyntax
-            {
-                Expression: not GenericNameSyntax,
-                Name.Identifier.ValueText: var methodName,
-            },
-        })
-    {
-        return false;
+            return false;
+        }
+
+        return methodName is ObservableEventsConstants.EventsEntryMethodName
+            or ObservableEventsConstants.EventHandlersEntryMethodName
+            or ObservableEventsConstants.RoutedEventsEntryMethodName
+            or ObservableEventsConstants.RoutedEventHandlersEntryMethodName
+            or ObservableEventsConstants.AttachedRoutedEventEntryMethodName
+            or ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName;
     }
 
-    return methodName is ObservableEventsConstants.EventsEntryMethodName
-        or ObservableEventsConstants.EventHandlersEntryMethodName
-        or ObservableEventsConstants.RoutedEventsEntryMethodName
-        or ObservableEventsConstants.RoutedEventHandlersEntryMethodName
-        or ObservableEventsConstants.AttachedRoutedEventEntryMethodName
-        or ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName;
-}
-
-/// <summary>
-/// Matches <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> (static entry property), not <c>receiver.Events()</c>.
-/// </summary>
-private static bool IsStaticEventsEntryMemberAccess(SyntaxNode node)
-{
-    if (node is not MemberAccessExpressionSyntax ma)
+    /// <summary>
+    /// Matches <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> (static entry property), not <c>receiver.Events()</c>.
+    /// </summary>
+    private static bool IsStaticEventsEntryMemberAccess(SyntaxNode node)
     {
-        return false;
-    }
-
-    if (!string.Equals(ma.Name.Identifier.ValueText, ObservableEventsConstants.EventsEntryMethodName, System.StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    // Exclude instance extension call shape: source.Events()
-    if (ma.Parent is InvocationExpressionSyntax inv && ReferenceEquals(inv.Expression, ma))
-    {
-        return false;
-    }
-
-    if (ma.Expression is not MemberAccessExpressionSyntax obsAccess)
-    {
-        return false;
-    }
-
-    if (obsAccess.Expression is not IdentifierNameSyntax outerId
-        || !string.Equals(outerId.Identifier.ValueText, "ObservableEventsStatics", System.StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    return obsAccess.Name switch
-    {
-        SimpleNameSyntax sn => sn.Identifier.ValueText.StartsWith("OBS_", System.StringComparison.Ordinal),
-        _ => false,
-    };
-}
-
-private static ObservableEventTargetSets CollectObservableEventTargets(
-    Compilation compilation,
-    ImmutableArray<SyntaxNode> candidates,
-    bool useWpf,
-    bool observableRoutedEvents)
-{
-    var bootstrapType = compilation.GetTypeByMetadataName(ObservableEventsConstants.BootstrapExtensionsMetadataName);
-    if (bootstrapType is null)
-    {
-        return ObservableEventTargetSets.Empty;
-    }
-
-    // Use pooled hash sets for better performance with large candidate sets
-    var events = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-    var eventHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-    var routedEvents = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-    var routedHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-    var eventsGenericConstraints = new Dictionary<string, GenericConstraintTarget>(System.StringComparer.Ordinal);
-    var eventHandlersGenericConstraints = new Dictionary<string, GenericConstraintTarget>(System.StringComparer.Ordinal);
-    var attachedRoutedEvents = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-    var attachedRoutedHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-    // Cache Avalonia detection to avoid repeated metadata lookups
-    var avaloniaRoutedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
-    var avaloniaRoutedEventTypeNonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
-    var useAvalonia = avaloniaRoutedEventType is not null
-        || avaloniaRoutedEventTypeNonGeneric is not null
-        || string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal);
-
-    foreach (var candidate in candidates)
-    {
-        if (candidate is InvocationExpressionSyntax invocation)
+        if (node is not MemberAccessExpressionSyntax ma)
         {
-            var semanticModel = compilation.GetSemanticModel(invocation.SyntaxTree);
-            if (observableRoutedEvents
-                && TryCollectRoutedTargetsFromInvocationSyntax(
-                    invocation,
-                    semanticModel,
-                    useWpf,
-                    useAvalonia,
-                    routedEvents,
-                    routedHandlers,
-                    attachedRoutedEvents,
-                    attachedRoutedHandlers))
-            {
-                continue;
-            }
+            return false;
+        }
 
-            if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
+        if (!string.Equals(ma.Name.Identifier.ValueText, ObservableEventsConstants.EventsEntryMethodName, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Exclude instance extension call shape: source.Events()
+        if (ma.Parent is InvocationExpressionSyntax inv && ReferenceEquals(inv.Expression, ma))
+        {
+            return false;
+        }
+
+        if (ma.Expression is not MemberAccessExpressionSyntax obsAccess)
+        {
+            return false;
+        }
+
+        if (obsAccess.Expression is not IdentifierNameSyntax outerId
+            || !string.Equals(outerId.Identifier.ValueText, "ObservableEventsStatics", System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return obsAccess.Name switch
+        {
+            SimpleNameSyntax sn => sn.Identifier.ValueText.StartsWith("OBS_", System.StringComparison.Ordinal),
+            _ => false,
+        };
+    }
+
+    private static ObservableEventTargetSets CollectObservableEventTargets(
+        Compilation compilation,
+        ImmutableArray<SyntaxNode> candidates,
+        bool useWpf,
+        bool observableRoutedEvents)
+    {
+        var bootstrapType = compilation.GetTypeByMetadataName(ObservableEventsConstants.BootstrapExtensionsMetadataName);
+        if (bootstrapType is null)
+        {
+            return ObservableEventTargetSets.Empty;
+        }
+
+        // Use pooled hash sets for better performance with large candidate sets
+        var events = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var eventHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var routedEvents = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var routedHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var eventsGenericConstraints = new Dictionary<string, GenericConstraintTarget>(System.StringComparer.Ordinal);
+        var eventHandlersGenericConstraints = new Dictionary<string, GenericConstraintTarget>(System.StringComparer.Ordinal);
+        var attachedRoutedEvents = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var attachedRoutedHandlers = new System.Collections.Generic.HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        // Cache Avalonia detection to avoid repeated metadata lookups
+        var avaloniaRoutedEventType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
+        var avaloniaRoutedEventTypeNonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
+        var useAvalonia = avaloniaRoutedEventType is not null
+            || avaloniaRoutedEventTypeNonGeneric is not null
+            || string.Equals(compilation.AssemblyName, "Observables.Samples.Events.Routed", System.StringComparison.Ordinal);
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate is InvocationExpressionSyntax invocation)
             {
-                if (methodSymbol.Name == ObservableEventsConstants.EventsEntryMethodName
-                    && TryGetBootstrapObservableEventsExtensionTarget(
+                var semanticModel = compilation.GetSemanticModel(invocation.SyntaxTree);
+                if (observableRoutedEvents
+                    && TryCollectRoutedTargetsFromInvocationSyntax(
                         invocation,
                         semanticModel,
-                        methodSymbol,
-                        bootstrapType,
-                        ObservableEventsConstants.EventsEntryMethodName,
-                        out var eventsTarget))
+                        useWpf,
+                        useAvalonia,
+                        routedEvents,
+                        routedHandlers,
+                        attachedRoutedEvents,
+                        attachedRoutedHandlers))
                 {
-                    if (eventsTarget.IsGenericType)
+                    continue;
+                }
+
+                if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
+                {
+                    if (methodSymbol.Name == ObservableEventsConstants.EventsEntryMethodName
+                        && TryGetBootstrapObservableEventsExtensionTarget(
+                            invocation,
+                            semanticModel,
+                            methodSymbol,
+                            bootstrapType,
+                            ObservableEventsConstants.EventsEntryMethodName,
+                            out var eventsTarget))
                     {
-                        eventsTarget = eventsTarget.OriginalDefinition;
-                    }
+                        if (eventsTarget.IsGenericType)
+                        {
+                            eventsTarget = eventsTarget.OriginalDefinition;
+                        }
 
-                    events.Add(eventsTarget);
-                }
-                else if (methodSymbol.Name == ObservableEventsConstants.EventsEntryMethodName
-                         && TryGetBootstrapGenericConstraintTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.EventsEntryMethodName,
-                             out var eventsGenericConstraintTarget))
-                {
-                    eventsGenericConstraints[eventsGenericConstraintTarget.Key] = eventsGenericConstraintTarget;
-                }
-                else if (methodSymbol.Name == ObservableEventsConstants.EventHandlersEntryMethodName
-                         && TryGetBootstrapObservableEventsExtensionTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.EventHandlersEntryMethodName,
-                             out var handlerTarget))
-                {
-                    if (handlerTarget.IsGenericType)
+                        events.Add(eventsTarget);
+                    }
+                    else if (methodSymbol.Name == ObservableEventsConstants.EventsEntryMethodName
+                             && TryGetBootstrapGenericConstraintTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.EventsEntryMethodName,
+                                 out var eventsGenericConstraintTarget))
                     {
-                        handlerTarget = handlerTarget.OriginalDefinition;
+                        eventsGenericConstraints[eventsGenericConstraintTarget.Key] = eventsGenericConstraintTarget;
                     }
-
-                    eventHandlers.Add(handlerTarget);
-                }
-                else if (methodSymbol.Name == ObservableEventsConstants.EventHandlersEntryMethodName
-                         && TryGetBootstrapGenericConstraintTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.EventHandlersEntryMethodName,
-                             out var handlerGenericConstraintTarget))
-                {
-                    eventHandlersGenericConstraints[handlerGenericConstraintTarget.Key] = handlerGenericConstraintTarget;
-                }
-                else if (observableRoutedEvents
-                         && (useWpf || useAvalonia)
-                         && methodSymbol.Name == ObservableEventsConstants.RoutedEventsEntryMethodName
-                         && TryGetBootstrapObservableEventsExtensionTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.RoutedEventsEntryMethodName,
-                             out var routedEventsTarget))
-                {
-                    if (routedEventsTarget.IsGenericType)
+                    else if (methodSymbol.Name == ObservableEventsConstants.EventHandlersEntryMethodName
+                             && TryGetBootstrapObservableEventsExtensionTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.EventHandlersEntryMethodName,
+                                 out var handlerTarget))
                     {
-                        routedEventsTarget = routedEventsTarget.OriginalDefinition;
-                    }
+                        if (handlerTarget.IsGenericType)
+                        {
+                            handlerTarget = handlerTarget.OriginalDefinition;
+                        }
 
-                    routedEvents.Add(routedEventsTarget);
-                }
-                else if (observableRoutedEvents
-                         && (useWpf || useAvalonia)
-                         && methodSymbol.Name == ObservableEventsConstants.RoutedEventHandlersEntryMethodName
-                         && TryGetBootstrapObservableEventsExtensionTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.RoutedEventHandlersEntryMethodName,
-                             out var routedHandlersTarget))
-                {
-                    if (routedHandlersTarget.IsGenericType)
+                        eventHandlers.Add(handlerTarget);
+                    }
+                    else if (methodSymbol.Name == ObservableEventsConstants.EventHandlersEntryMethodName
+                             && TryGetBootstrapGenericConstraintTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.EventHandlersEntryMethodName,
+                                 out var handlerGenericConstraintTarget))
                     {
-                        routedHandlersTarget = routedHandlersTarget.OriginalDefinition;
+                        eventHandlersGenericConstraints[handlerGenericConstraintTarget.Key] = handlerGenericConstraintTarget;
                     }
-
-                    routedHandlers.Add(routedHandlersTarget);
-                }
-                else if (observableRoutedEvents
-                         && methodSymbol.Name == ObservableEventsConstants.AttachedRoutedEventEntryMethodName
-                         && TryGetBootstrapAttachedRoutedEventTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.AttachedRoutedEventEntryMethodName,
-                             out var attachedEventsReceiver))
-                {
-                    if (attachedEventsReceiver.IsGenericType)
+                    else if (observableRoutedEvents
+                             && (useWpf || useAvalonia)
+                             && methodSymbol.Name == ObservableEventsConstants.RoutedEventsEntryMethodName
+                             && TryGetBootstrapObservableEventsExtensionTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.RoutedEventsEntryMethodName,
+                                 out var routedEventsTarget))
                     {
-                        attachedEventsReceiver = attachedEventsReceiver.OriginalDefinition;
-                    }
+                        if (routedEventsTarget.IsGenericType)
+                        {
+                            routedEventsTarget = routedEventsTarget.OriginalDefinition;
+                        }
 
-                    attachedRoutedEvents.Add(attachedEventsReceiver);
-                }
-                else if (observableRoutedEvents
-                         && methodSymbol.Name == ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName
-                         && TryGetBootstrapAttachedRoutedEventTarget(
-                             invocation,
-                             semanticModel,
-                             methodSymbol,
-                             bootstrapType,
-                             ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName,
-                             out var attachedHandlersReceiver))
-                {
-                    if (attachedHandlersReceiver.IsGenericType)
+                        routedEvents.Add(routedEventsTarget);
+                    }
+                    else if (observableRoutedEvents
+                             && (useWpf || useAvalonia)
+                             && methodSymbol.Name == ObservableEventsConstants.RoutedEventHandlersEntryMethodName
+                             && TryGetBootstrapObservableEventsExtensionTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.RoutedEventHandlersEntryMethodName,
+                                 out var routedHandlersTarget))
                     {
-                        attachedHandlersReceiver = attachedHandlersReceiver.OriginalDefinition;
+                        if (routedHandlersTarget.IsGenericType)
+                        {
+                            routedHandlersTarget = routedHandlersTarget.OriginalDefinition;
+                        }
+
+                        routedHandlers.Add(routedHandlersTarget);
                     }
+                    else if (observableRoutedEvents
+                             && methodSymbol.Name == ObservableEventsConstants.AttachedRoutedEventEntryMethodName
+                             && TryGetBootstrapAttachedRoutedEventTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.AttachedRoutedEventEntryMethodName,
+                                 out var attachedEventsReceiver))
+                    {
+                        if (attachedEventsReceiver.IsGenericType)
+                        {
+                            attachedEventsReceiver = attachedEventsReceiver.OriginalDefinition;
+                        }
 
-                    attachedRoutedHandlers.Add(attachedHandlersReceiver);
+                        attachedRoutedEvents.Add(attachedEventsReceiver);
+                    }
+                    else if (observableRoutedEvents
+                             && methodSymbol.Name == ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName
+                             && TryGetBootstrapAttachedRoutedEventTarget(
+                                 invocation,
+                                 semanticModel,
+                                 methodSymbol,
+                                 bootstrapType,
+                                 ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName,
+                                 out var attachedHandlersReceiver))
+                    {
+                        if (attachedHandlersReceiver.IsGenericType)
+                        {
+                            attachedHandlersReceiver = attachedHandlersReceiver.OriginalDefinition;
+                        }
+
+                        attachedRoutedHandlers.Add(attachedHandlersReceiver);
+                    }
                 }
-            }
 
-            continue;
-        }
-
-        if (ObservableEventsConstants.StaticObservableEventsGenerationEnabled
-            && candidate is MemberAccessExpressionSyntax staticEvents
-            && IsStaticEventsEntryMemberAccess(staticEvents))
-        {
-            var semanticModel = compilation.GetSemanticModel(staticEvents.SyntaxTree);
-            if (semanticModel.GetSymbolInfo(staticEvents).Symbol is { } staticSymbol
-                && TryGetTypeFromObservableEventsStaticsNested(staticSymbol, bootstrapType, compilation, out var staticTarget))
-            {
-                if (staticTarget.IsGenericType)
-                {
-                    staticTarget = staticTarget.OriginalDefinition;
-                }
-
-                events.Add(staticTarget);
                 continue;
             }
 
-            // Cold compile: static entry property not bound until nested type exists.
-            if (TryGetStaticObservableEventsTargetFromMemberAccess(compilation, staticEvents, out var syntaxOnlyStatic))
+            if (ObservableEventsConstants.StaticObservableEventsGenerationEnabled
+                && candidate is MemberAccessExpressionSyntax staticEvents
+                && IsStaticEventsEntryMemberAccess(staticEvents))
             {
-                if (syntaxOnlyStatic.IsGenericType)
+                var semanticModel = compilation.GetSemanticModel(staticEvents.SyntaxTree);
+                if (semanticModel.GetSymbolInfo(staticEvents).Symbol is { } staticSymbol
+                    && TryGetTypeFromObservableEventsStaticsNested(staticSymbol, bootstrapType, compilation, out var staticTarget))
                 {
-                    syntaxOnlyStatic = syntaxOnlyStatic.OriginalDefinition;
+                    if (staticTarget.IsGenericType)
+                    {
+                        staticTarget = staticTarget.OriginalDefinition;
+                    }
+
+                    events.Add(staticTarget);
+                    continue;
                 }
 
-                events.Add(syntaxOnlyStatic);
+                // Cold compile: static entry property not bound until nested type exists.
+                if (TryGetStaticObservableEventsTargetFromMemberAccess(compilation, staticEvents, out var syntaxOnlyStatic))
+                {
+                    if (syntaxOnlyStatic.IsGenericType)
+                    {
+                        syntaxOnlyStatic = syntaxOnlyStatic.OriginalDefinition;
+                    }
+
+                    events.Add(syntaxOnlyStatic);
+                }
             }
+        }
+
+        static ImmutableArray<INamedTypeSymbol> Order(System.Collections.Generic.HashSet<INamedTypeSymbol> set) =>
+            set
+                .OrderBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
+                .ToImmutableArray();
+
+        static ImmutableArray<AttachedRoutedEventTarget> OrderAttached(System.Collections.Generic.HashSet<INamedTypeSymbol> set) =>
+            set
+                .OrderBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
+                .Select(static t => new AttachedRoutedEventTarget(t))
+                .ToImmutableArray();
+
+        static ImmutableArray<GenericConstraintTarget> OrderGeneric(Dictionary<string, GenericConstraintTarget> set) =>
+            set
+                .OrderBy(static pair => pair.Key, System.StringComparer.Ordinal)
+                .Select(static pair => pair.Value)
+                .ToImmutableArray();
+
+        return new ObservableEventTargetSets(
+            Order(events),
+            Order(eventHandlers),
+            Order(routedEvents),
+            Order(routedHandlers),
+            OrderGeneric(eventsGenericConstraints),
+            OrderGeneric(eventHandlersGenericConstraints),
+            OrderAttached(attachedRoutedEvents),
+            OrderAttached(attachedRoutedHandlers));
+    }
+
+    private static bool TryCollectRoutedTargetsFromInvocationSyntax(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        bool useWpf,
+        bool useAvalonia,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> routedEvents,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> routedHandlers,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> attachedRoutedEvents,
+        System.Collections.Generic.HashSet<INamedTypeSymbol> attachedRoutedHandlers)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        var methodName = memberAccess.Name.Identifier.ValueText;
+        if (!TryGetExtensionReceiverType(memberAccess.Expression, semanticModel, out var receiverType))
+        {
+            return false;
+        }
+
+        if (receiverType.IsGenericType)
+        {
+            receiverType = receiverType.OriginalDefinition;
+        }
+
+        switch (methodName)
+        {
+            case var name when name == ObservableEventsConstants.RoutedEventsEntryMethodName
+                               && (useWpf || useAvalonia):
+                routedEvents.Add(receiverType);
+                return true;
+            case var name when name == ObservableEventsConstants.RoutedEventHandlersEntryMethodName
+                               && (useWpf || useAvalonia):
+                routedHandlers.Add(receiverType);
+                return true;
+            case var name when name == ObservableEventsConstants.AttachedRoutedEventEntryMethodName:
+                attachedRoutedEvents.Add(receiverType);
+                return true;
+            case var name when name == ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName:
+                attachedRoutedHandlers.Add(receiverType);
+                return true;
+            default:
+                return false;
         }
     }
 
-    static ImmutableArray<INamedTypeSymbol> Order(System.Collections.Generic.HashSet<INamedTypeSymbol> set) =>
-        set
-            .OrderBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
-            .ToImmutableArray();
-
-    static ImmutableArray<AttachedRoutedEventTarget> OrderAttached(System.Collections.Generic.HashSet<INamedTypeSymbol> set) =>
-        set
-            .OrderBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
-            .Select(static t => new AttachedRoutedEventTarget(t))
-            .ToImmutableArray();
-
-    static ImmutableArray<GenericConstraintTarget> OrderGeneric(Dictionary<string, GenericConstraintTarget> set) =>
-        set
-            .OrderBy(static pair => pair.Key, System.StringComparer.Ordinal)
-            .Select(static pair => pair.Value)
-            .ToImmutableArray();
-
-    return new ObservableEventTargetSets(
-        Order(events),
-        Order(eventHandlers),
-        Order(routedEvents),
-        Order(routedHandlers),
-        OrderGeneric(eventsGenericConstraints),
-        OrderGeneric(eventHandlersGenericConstraints),
-        OrderAttached(attachedRoutedEvents),
-        OrderAttached(attachedRoutedHandlers));
-}
-
-private static bool TryCollectRoutedTargetsFromInvocationSyntax(
-    InvocationExpressionSyntax invocation,
-    SemanticModel semanticModel,
-    bool useWpf,
-    bool useAvalonia,
-    System.Collections.Generic.HashSet<INamedTypeSymbol> routedEvents,
-    System.Collections.Generic.HashSet<INamedTypeSymbol> routedHandlers,
-    System.Collections.Generic.HashSet<INamedTypeSymbol> attachedRoutedEvents,
-    System.Collections.Generic.HashSet<INamedTypeSymbol> attachedRoutedHandlers)
-{
-    if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+    private static bool TryGetExtensionReceiverType(ExpressionSyntax receiverSyntax, SemanticModel semanticModel, out INamedTypeSymbol receiverType)
     {
-        return false;
-    }
-
-    var methodName = memberAccess.Name.Identifier.ValueText;
-    if (!TryGetExtensionReceiverType(memberAccess.Expression, semanticModel, out var receiverType))
-    {
-        return false;
-    }
-
-    if (receiverType.IsGenericType)
-    {
-        receiverType = receiverType.OriginalDefinition;
-    }
-
-    switch (methodName)
-    {
-        case var name when name == ObservableEventsConstants.RoutedEventsEntryMethodName
-                           && (useWpf || useAvalonia):
-            routedEvents.Add(receiverType);
-            return true;
-        case var name when name == ObservableEventsConstants.RoutedEventHandlersEntryMethodName
-                           && (useWpf || useAvalonia):
-            routedHandlers.Add(receiverType);
-            return true;
-        case var name when name == ObservableEventsConstants.AttachedRoutedEventEntryMethodName:
-            attachedRoutedEvents.Add(receiverType);
-            return true;
-        case var name when name == ObservableEventsConstants.AttachedRoutedEventHandlerEntryMethodName:
-            attachedRoutedHandlers.Add(receiverType);
-            return true;
-        default:
-            return false;
-    }
-}
-
-private static bool TryGetExtensionReceiverType(ExpressionSyntax receiverSyntax, SemanticModel semanticModel, out INamedTypeSymbol receiverType)
-{
-    receiverType = null!;
-    if (semanticModel.GetTypeInfo(receiverSyntax).Type is INamedTypeSymbol named)
-    {
-        receiverType = named;
-        return true;
-    }
-
-    return false;
-}
-
-/// <summary>
-/// When semantic binding cannot resolve the static entry property yet, recover the declaring type from
-/// <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> syntax so generation still runs.
-/// </summary>
-private static bool TryGetStaticObservableEventsTargetFromMemberAccess(
-    Compilation compilation,
-    MemberAccessExpressionSyntax eventsAccess,
-    out INamedTypeSymbol namedType)
-{
-    namedType = null!;
-    if (eventsAccess.Expression is not MemberAccessExpressionSyntax
+        receiverType = null!;
+        if (semanticModel.GetTypeInfo(receiverSyntax).Type is INamedTypeSymbol named)
         {
-            Expression: IdentifierNameSyntax { Identifier.ValueText: "ObservableEventsStatics" },
-            Name: SimpleNameSyntax staticHintNameSyntax,
-        })
-    {
+            receiverType = named;
+            return true;
+        }
+
         return false;
     }
 
-    if (!string.Equals(eventsAccess.Name.Identifier.ValueText, ObservableEventsConstants.EventsEntryMethodName, System.StringComparison.Ordinal))
+    /// <summary>
+    /// When semantic binding cannot resolve the static entry property yet, recover the declaring type from
+    /// <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> syntax so generation still runs.
+    /// </summary>
+    private static bool TryGetStaticObservableEventsTargetFromMemberAccess(
+        Compilation compilation,
+        MemberAccessExpressionSyntax eventsAccess,
+        out INamedTypeSymbol namedType)
     {
+        namedType = null!;
+        if (eventsAccess.Expression is not MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax { Identifier.ValueText: "ObservableEventsStatics" },
+                Name: SimpleNameSyntax staticHintNameSyntax,
+            })
+        {
+            return false;
+        }
+
+        if (!string.Equals(eventsAccess.Name.Identifier.ValueText, ObservableEventsConstants.EventsEntryMethodName, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var nestedId = staticHintNameSyntax.Identifier.ValueText;
+        if (!nestedId.StartsWith("OBS_", System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var hintStem = nestedId.Substring(4);
+        return TryResolveNamedTypeByStableHint(compilation, hintStem, out namedType);
+    }
+
+    private static bool TryGetBootstrapObservableEventsExtensionTarget(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol bootstrapType,
+        string entryMethodName,
+        out INamedTypeSymbol namedType)
+    {
+        namedType = null!;
+
+        if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        static INamedTypeSymbol? FindBootstrapDeclaringType(IMethodSymbol m)
+        {
+            var decl = m.ReducedFrom ?? m;
+            return decl.ContainingType?.OriginalDefinition as INamedTypeSymbol;
+        }
+
+        if (FindBootstrapDeclaringType(methodSymbol) is not { } declaring
+            || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
+        {
+            return false;
+        }
+
+        if (methodSymbol.TypeArguments.Length == 1 && methodSymbol.TypeArguments[0] is INamedTypeSymbol fromArgs)
+        {
+            namedType = fromArgs;
+            return true;
+        }
+
+        // Reduced extension inference: Events() on explicit receiver without TypeArguments surfaced on symbol.
+        if (invocation.Expression is MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
+        {
+            if (semanticModel.GetTypeInfo(receiver).Type is INamedTypeSymbol receiverNamed)
+            {
+                namedType = receiverNamed;
+                return true;
+            }
+        }
+
         return false;
     }
 
-    var nestedId = staticHintNameSyntax.Identifier.ValueText;
-    if (!nestedId.StartsWith("OBS_", System.StringComparison.Ordinal))
+    private static bool TryGetBootstrapGenericConstraintTarget(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol bootstrapType,
+        string entryMethodName,
+        out GenericConstraintTarget target)
     {
-        return false;
+        target = default;
+        if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var declaration = methodSymbol.ReducedFrom ?? methodSymbol;
+        if (declaration.ContainingType?.OriginalDefinition is not { } declaring
+            || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
+        {
+            return false;
+        }
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
+        {
+            return false;
+        }
+
+        if (semanticModel.GetTypeInfo(receiver).Type is not ITypeParameterSymbol typeParameter)
+        {
+            return false;
+        }
+
+        return TryCreateGenericConstraintTarget(typeParameter, out target);
     }
 
-    var hintStem = nestedId.Substring(4);
-    return TryResolveNamedTypeByStableHint(compilation, hintStem, out namedType);
-}
-
-private static bool TryGetBootstrapObservableEventsExtensionTarget(
-    InvocationExpressionSyntax invocation,
-    SemanticModel semanticModel,
-    IMethodSymbol methodSymbol,
-    INamedTypeSymbol bootstrapType,
-    string entryMethodName,
-    out INamedTypeSymbol namedType)
-{
-    namedType = null!;
-
-    if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
+    private static bool TryCreateGenericConstraintTarget(
+        ITypeParameterSymbol typeParameter,
+        out GenericConstraintTarget target)
     {
-        return false;
-    }
+        target = default;
+        var constraintTypes = typeParameter.ConstraintTypes
+            .OfType<INamedTypeSymbol>()
+            .Where(static t => t.TypeKind is TypeKind.Class or TypeKind.Interface)
+            .Where(static t => !ContainsTypeParameter(t))
+            .OrderBy(static t => t.TypeKind == TypeKind.Class ? 0 : 1)
+            .ThenBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
+            .ToImmutableArray();
 
-    static INamedTypeSymbol? FindBootstrapDeclaringType(IMethodSymbol m)
-    {
-        var decl = m.ReducedFrom ?? m;
-        return decl.ContainingType?.OriginalDefinition as INamedTypeSymbol;
-    }
+        if (constraintTypes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
 
-    if (FindBootstrapDeclaringType(methodSymbol) is not { } declaring
-        || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
-    {
-        return false;
-    }
+        if (!constraintTypes.SelectMany(static t => GetPublicInstanceEventsFromTypeAndBases(t)).Any())
+        {
+            return false;
+        }
 
-    if (methodSymbol.TypeArguments.Length == 1 && methodSymbol.TypeArguments[0] is INamedTypeSymbol fromArgs)
-    {
-        namedType = fromArgs;
+        target = new GenericConstraintTarget(constraintTypes);
         return true;
     }
 
-    // Reduced extension inference: Events() on explicit receiver without TypeArguments surfaced on symbol.
-    if (invocation.Expression is MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
+    private static bool ContainsTypeParameter(ITypeSymbol type)
     {
+        if (type.TypeKind == TypeKind.TypeParameter)
+        {
+            return true;
+        }
+
+        return type switch
+        {
+            INamedTypeSymbol named => named.TypeArguments.Any(static t => ContainsTypeParameter(t)),
+            IArrayTypeSymbol array => ContainsTypeParameter(array.ElementType),
+            IPointerTypeSymbol pointer => ContainsTypeParameter(pointer.PointedAtType),
+            _ => false,
+        };
+    }
+
+    private static bool TryGetBootstrapAttachedRoutedEventTarget(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        IMethodSymbol methodSymbol,
+        INamedTypeSymbol bootstrapType,
+        string entryMethodName,
+        out INamedTypeSymbol receiverType)
+    {
+        receiverType = null!;
+
+        if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var declaration = methodSymbol.ReducedFrom ?? methodSymbol;
+        if (declaration.ContainingType?.OriginalDefinition is not { } declaring
+            || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
+        {
+            return false;
+        }
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
+        {
+            return false;
+        }
+
         if (semanticModel.GetTypeInfo(receiver).Type is INamedTypeSymbol receiverNamed)
         {
-            namedType = receiverNamed;
+            receiverType = receiverNamed;
             return true;
         }
-    }
 
-    return false;
-}
-
-private static bool TryGetBootstrapGenericConstraintTarget(
-    InvocationExpressionSyntax invocation,
-    SemanticModel semanticModel,
-    IMethodSymbol methodSymbol,
-    INamedTypeSymbol bootstrapType,
-    string entryMethodName,
-    out GenericConstraintTarget target)
-{
-    target = default;
-    if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
-    {
         return false;
     }
 
-    var declaration = methodSymbol.ReducedFrom ?? methodSymbol;
-    if (declaration.ContainingType?.OriginalDefinition is not { } declaring
-        || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
+    /// <summary>
+    /// Parses <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> from semantic model (expects the static entry property on the nested partial class).
+    /// </summary>
+    private static bool TryGetTypeFromObservableEventsStaticsNested(
+        ISymbol symbol,
+        INamedTypeSymbol bootstrapType,
+        Compilation compilation,
+        out INamedTypeSymbol namedType)
     {
-        return false;
-    }
+        namedType = null!;
 
-    if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
-    {
-        return false;
-    }
-
-    if (semanticModel.GetTypeInfo(receiver).Type is not ITypeParameterSymbol typeParameter)
-    {
-        return false;
-    }
-
-    return TryCreateGenericConstraintTarget(typeParameter, out target);
-}
-
-private static bool TryCreateGenericConstraintTarget(
-    ITypeParameterSymbol typeParameter,
-    out GenericConstraintTarget target)
-{
-    target = default;
-    var constraintTypes = typeParameter.ConstraintTypes
-        .OfType<INamedTypeSymbol>()
-        .Where(static t => t.TypeKind is TypeKind.Class or TypeKind.Interface)
-        .Where(static t => !ContainsTypeParameter(t))
-        .OrderBy(static t => t.TypeKind == TypeKind.Class ? 0 : 1)
-        .ThenBy(static t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), System.StringComparer.Ordinal)
-        .ToImmutableArray();
-
-    if (constraintTypes.IsDefaultOrEmpty)
-    {
-        return false;
-    }
-
-    if (!constraintTypes.SelectMany(static t => GetPublicInstanceEventsFromTypeAndBases(t)).Any())
-    {
-        return false;
-    }
-
-    target = new GenericConstraintTarget(constraintTypes);
-    return true;
-}
-
-private static bool ContainsTypeParameter(ITypeSymbol type)
-{
-    if (type.TypeKind == TypeKind.TypeParameter)
-    {
-        return true;
-    }
-
-    return type switch
-    {
-        INamedTypeSymbol named => named.TypeArguments.Any(static t => ContainsTypeParameter(t)),
-        IArrayTypeSymbol array => ContainsTypeParameter(array.ElementType),
-        IPointerTypeSymbol pointer => ContainsTypeParameter(pointer.PointedAtType),
-        _ => false,
-    };
-}
-
-private static bool TryGetBootstrapAttachedRoutedEventTarget(
-    InvocationExpressionSyntax invocation,
-    SemanticModel semanticModel,
-    IMethodSymbol methodSymbol,
-    INamedTypeSymbol bootstrapType,
-    string entryMethodName,
-    out INamedTypeSymbol receiverType)
-{
-    receiverType = null!;
-
-    if (!string.Equals(methodSymbol.Name, entryMethodName, System.StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    var declaration = methodSymbol.ReducedFrom ?? methodSymbol;
-    if (declaration.ContainingType?.OriginalDefinition is not { } declaring
-        || !SymbolEqualityComparer.Default.Equals(declaring, bootstrapType.OriginalDefinition))
-    {
-        return false;
-    }
-
-    if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: ExpressionSyntax receiver })
-    {
-        return false;
-    }
-
-    if (semanticModel.GetTypeInfo(receiver).Type is INamedTypeSymbol receiverNamed)
-    {
-        receiverType = receiverNamed;
-        return true;
-    }
-
-    return false;
-}
-
-/// <summary>
-/// Parses <c>ObservableEventsStatics.OBS_<em>StableHint</em>.Events</c> from semantic model (expects the static entry property on the nested partial class).
-/// </summary>
-private static bool TryGetTypeFromObservableEventsStaticsNested(
-    ISymbol symbol,
-    INamedTypeSymbol bootstrapType,
-    Compilation compilation,
-    out INamedTypeSymbol namedType)
-{
-    namedType = null!;
-
-    if (symbol.Name != ObservableEventsConstants.EventsEntryMethodName)
-    {
-        return false;
-    }
-
-    if (symbol is IMethodSymbol methodSymbol)
-    {
-        if (methodSymbol.ReducedFrom is not null || methodSymbol.IsExtensionMethod)
+        if (symbol.Name != ObservableEventsConstants.EventsEntryMethodName)
         {
             return false;
         }
-    }
-    else if (symbol is not IPropertySymbol)
-    {
-        return false;
-    }
 
-    var nested = symbol.ContainingType;
-    var outer = nested?.ContainingType;
-    if (nested is null || outer is null)
-    {
-        return false;
-    }
-
-    if (!string.Equals(outer.Name, "ObservableEventsStatics", System.StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    if (!SymbolEqualityComparer.Default.Equals(outer.ContainingNamespace, bootstrapType.ContainingNamespace))
-    {
-        return false;
-    }
-
-    if (!nested.Name.StartsWith("OBS_", System.StringComparison.Ordinal))
-    {
-        return false;
-    }
-
-    var hintStem = nested.Name.Substring(4);
-    return TryResolveNamedTypeByStableHint(compilation, hintStem, out namedType);
-}
-
-/// <remarks>
-/// Must match identifiers produced via <see cref="INamedTypeSymbolExtensions.GetSafeHintName"/>.
-/// </remarks>
-private static bool TryResolveNamedTypeByStableHint(Compilation compilation, string hintStem, out INamedTypeSymbol namedType)
-{
-    namedType = null!;
-    foreach (var candidate in EnumerateNamedTypesIncludingNested(compilation.GlobalNamespace))
-    {
-        if (!string.Equals(candidate.GetSafeHintName(), hintStem, System.StringComparison.Ordinal))
+        if (symbol is IMethodSymbol methodSymbol)
         {
-            continue;
-        }
-
-        namedType = candidate;
-        return true;
-    }
-
-    return false;
-}
-
-private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypesIncludingNested(INamespaceSymbol root)
-{
-    foreach (var member in root.GetNamespaceMembers())
-    {
-        foreach (var t in EnumerateNamedTypesIncludingNested(member))
-        {
-            yield return t;
-        }
-    }
-
-    foreach (var named in root.GetTypeMembers())
-    {
-        foreach (var t in EnumerateSelfAndNestedNamedTypes(named))
-        {
-            yield return t;
-        }
-    }
-}
-
-private static IEnumerable<INamedTypeSymbol> EnumerateSelfAndNestedNamedTypes(INamedTypeSymbol type)
-{
-    yield return type;
-    foreach (var nested in type.GetTypeMembers())
-    {
-        foreach (var t in EnumerateSelfAndNestedNamedTypes(nested))
-        {
-            yield return t;
-        }
-    }
-}
-
-/// <summary>
-/// Public instance events declared on <paramref name="type"/> and its non-generic class base types (excluding <see cref="object"/>),
-/// with derived declarations taking precedence over the same event name on a base type.
-/// When <paramref name="type"/> is an interface, events declared on the interface and all its base interfaces are collected.
-/// </summary>
-private static IEnumerable<IEventSymbol> GetPublicInstanceEventsFromTypeAndBases(INamedTypeSymbol type)
-{
-    var byName = new Dictionary<string, IEventSymbol>(System.StringComparer.Ordinal);
-
-    if (type.TypeKind == TypeKind.Interface)
-    {
-        // Collect events from the interface itself and all base interfaces.
-        foreach (var iface in new[] { type }.Concat(type.AllInterfaces))
-        {
-            foreach (var evt in iface.GetMembers().OfType<IEventSymbol>()
-                         .Where(static e => !e.IsStatic))
+            if (methodSymbol.ReducedFrom is not null || methodSymbol.IsExtensionMethod)
             {
-                if (!byName.ContainsKey(evt.Name))
-                {
-                    byName[evt.Name] = evt;
-                }
+                return false;
             }
         }
-    }
-    else
-    {
-        for (var current = type; current is not null; current = current.BaseType)
+        else if (symbol is not IPropertySymbol)
         {
-            if (current.SpecialType == SpecialType.System_Object)
-            {
-                break;
-            }
+            return false;
+        }
 
-            if (current.TypeKind != TypeKind.Class)
+        var nested = symbol.ContainingType;
+        var outer = nested?.ContainingType;
+        if (nested is null || outer is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(outer.Name, "ObservableEventsStatics", System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(outer.ContainingNamespace, bootstrapType.ContainingNamespace))
+        {
+            return false;
+        }
+
+        if (!nested.Name.StartsWith("OBS_", System.StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var hintStem = nested.Name.Substring(4);
+        return TryResolveNamedTypeByStableHint(compilation, hintStem, out namedType);
+    }
+
+    /// <remarks>
+    /// Must match identifiers produced via <see cref="INamedTypeSymbolExtensions.GetSafeHintName"/>.
+    /// </remarks>
+    private static bool TryResolveNamedTypeByStableHint(Compilation compilation, string hintStem, out INamedTypeSymbol namedType)
+    {
+        namedType = null!;
+        foreach (var candidate in EnumerateNamedTypesIncludingNested(compilation.GlobalNamespace))
+        {
+            if (!string.Equals(candidate.GetSafeHintName(), hintStem, System.StringComparison.Ordinal))
             {
                 continue;
             }
 
-            foreach (var evt in current.GetMembers().OfType<IEventSymbol>()
-                         .Where(static e => e is { IsStatic: false, DeclaredAccessibility: Accessibility.Public }))
+            namedType = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypesIncludingNested(INamespaceSymbol root)
+    {
+        foreach (var member in root.GetNamespaceMembers())
+        {
+            foreach (var t in EnumerateNamedTypesIncludingNested(member))
             {
-                if (!byName.ContainsKey(evt.Name))
-                {
-                    byName[evt.Name] = evt;
-                }
+                yield return t;
+            }
+        }
+
+        foreach (var named in root.GetTypeMembers())
+        {
+            foreach (var t in EnumerateSelfAndNestedNamedTypes(named))
+            {
+                yield return t;
             }
         }
     }
 
-    return byName.Values.OrderBy(static e => e.Name, System.StringComparer.Ordinal);
-}
+    private static IEnumerable<INamedTypeSymbol> EnumerateSelfAndNestedNamedTypes(INamedTypeSymbol type)
+    {
+        yield return type;
+        foreach (var nested in type.GetTypeMembers())
+        {
+            foreach (var t in EnumerateSelfAndNestedNamedTypes(nested))
+            {
+                yield return t;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Public instance events declared on <paramref name="type"/> and its non-generic class base types (excluding <see cref="object"/>),
+    /// with derived declarations taking precedence over the same event name on a base type.
+    /// When <paramref name="type"/> is an interface, events declared on the interface and all its base interfaces are collected.
+    /// </summary>
+    private static IEnumerable<IEventSymbol> GetPublicInstanceEventsFromTypeAndBases(INamedTypeSymbol type)
+    {
+        var byName = new Dictionary<string, IEventSymbol>(System.StringComparer.Ordinal);
+
+        if (type.TypeKind == TypeKind.Interface)
+        {
+            // Collect events from the interface itself and all base interfaces.
+            foreach (var iface in new[] { type }.Concat(type.AllInterfaces))
+            {
+                foreach (var evt in iface.GetMembers().OfType<IEventSymbol>()
+                             .Where(static e => !e.IsStatic))
+                {
+                    if (!byName.ContainsKey(evt.Name))
+                    {
+                        byName[evt.Name] = evt;
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (var current = type; current is not null; current = current.BaseType)
+            {
+                if (current.SpecialType == SpecialType.System_Object)
+                {
+                    break;
+                }
+
+                if (current.TypeKind != TypeKind.Class)
+                {
+                    continue;
+                }
+
+                foreach (var evt in current.GetMembers().OfType<IEventSymbol>()
+                             .Where(static e => e is { IsStatic: false, DeclaredAccessibility: Accessibility.Public }))
+                {
+                    if (!byName.ContainsKey(evt.Name))
+                    {
+                        byName[evt.Name] = evt;
+                    }
+                }
+            }
+        }
+
+        return byName.Values.OrderBy(static e => e.Name, System.StringComparer.Ordinal);
+    }
 
 }

--- a/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.RoutedDetection.cs
+++ b/Observables.Events/Observables.Events.SourceGenerators.Shared/ObservableEventsGenerator.RoutedDetection.cs
@@ -13,144 +13,144 @@ namespace Observables.Events.Generators;
 
 public sealed partial class ObservableEventsGenerator
 {
-private static bool IsRoutedClrEvent(IEventSymbol evt, Compilation compilation, bool includeWpf)
-{
-    var fieldName = evt.Name + "Event";
-    for (var current = evt.ContainingType; current is not null; current = current.BaseType)
+    private static bool IsRoutedClrEvent(IEventSymbol evt, Compilation compilation, bool includeWpf)
     {
-        if (current.SpecialType == SpecialType.System_Object)
+        var fieldName = evt.Name + "Event";
+        for (var current = evt.ContainingType; current is not null; current = current.BaseType)
         {
-            break;
-        }
-
-        foreach (var member in current.GetMembers(fieldName))
-        {
-            if (member is not IFieldSymbol field || !field.IsStatic || field.IsImplicitlyDeclared)
+            if (current.SpecialType == SpecialType.System_Object)
             {
-                continue;
+                break;
             }
 
-            var fieldType = field.Type.WithNullableAnnotation(NullableAnnotation.None);
-            if ((includeWpf && IsWpfRoutedEventType(fieldType, compilation))
-                || IsAvaloniaRoutedEventType(fieldType, compilation))
+            foreach (var member in current.GetMembers(fieldName))
             {
-                return true;
+                if (member is not IFieldSymbol field || !field.IsStatic || field.IsImplicitlyDeclared)
+                {
+                    continue;
+                }
+
+                var fieldType = field.Type.WithNullableAnnotation(NullableAnnotation.None);
+                if ((includeWpf && IsWpfRoutedEventType(fieldType, compilation))
+                    || IsAvaloniaRoutedEventType(fieldType, compilation))
+                {
+                    return true;
+                }
             }
         }
-    }
 
-    return false;
-}
-
-private static bool HasAvaloniaRoutedClrEvents(INamedTypeSymbol type, Compilation compilation)
-{
-    return GetPublicInstanceEventsFromTypeAndBases(type)
-        .Any(evt => TryGetAvaloniaRoutedClrEventField(evt, compilation, out _, out _));
-}
-
-private static bool TryGetAvaloniaRoutedClrEventField(
-    IEventSymbol evt,
-    Compilation compilation,
-    out IFieldSymbol routedEventField,
-    out INamedTypeSymbol eventArgsType)
-{
-    routedEventField = null!;
-    eventArgsType = null!;
-
-    var routedEventGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
-    var routedEventNonGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
-    if (routedEventGenericType is null && routedEventNonGenericType is null)
-    {
         return false;
     }
 
-    var fieldName = evt.Name + "Event";
-    for (var current = evt.ContainingType; current is not null; current = current.BaseType)
+    private static bool HasAvaloniaRoutedClrEvents(INamedTypeSymbol type, Compilation compilation)
     {
-        if (current.SpecialType == SpecialType.System_Object)
+        return GetPublicInstanceEventsFromTypeAndBases(type)
+            .Any(evt => TryGetAvaloniaRoutedClrEventField(evt, compilation, out _, out _));
+    }
+
+    private static bool TryGetAvaloniaRoutedClrEventField(
+        IEventSymbol evt,
+        Compilation compilation,
+        out IFieldSymbol routedEventField,
+        out INamedTypeSymbol eventArgsType)
+    {
+        routedEventField = null!;
+        eventArgsType = null!;
+
+        var routedEventGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
+        var routedEventNonGenericType = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
+        if (routedEventGenericType is null && routedEventNonGenericType is null)
         {
-            break;
+            return false;
         }
 
-        foreach (var member in current.GetMembers(fieldName))
+        var fieldName = evt.Name + "Event";
+        for (var current = evt.ContainingType; current is not null; current = current.BaseType)
         {
-            if (member is not IFieldSymbol field
-                || !field.IsStatic
-                || field.IsImplicitlyDeclared
-                || field.Type is not INamedTypeSymbol fieldType)
+            if (current.SpecialType == SpecialType.System_Object)
             {
-                continue;
+                break;
             }
 
-            var normalizedFieldType = fieldType.WithNullableAnnotation(NullableAnnotation.None);
-
-            if (routedEventGenericType is not null
-                && SymbolEqualityComparer.Default.Equals(normalizedFieldType.OriginalDefinition, routedEventGenericType)
-                && fieldType.TypeArguments.Length == 1
-                && fieldType.TypeArguments[0] is INamedTypeSymbol genericArgsType)
+            foreach (var member in current.GetMembers(fieldName))
             {
-                routedEventField = field;
-                eventArgsType = genericArgsType;
-                return true;
-            }
+                if (member is not IFieldSymbol field
+                    || !field.IsStatic
+                    || field.IsImplicitlyDeclared
+                    || field.Type is not INamedTypeSymbol fieldType)
+                {
+                    continue;
+                }
 
-            if (routedEventNonGenericType is not null
-                && SymbolEqualityComparer.Default.Equals(normalizedFieldType, routedEventNonGenericType)
-                && TryGetAvaloniaRoutedEventArgsType(evt, compilation, out INamedTypeSymbol nonGenericArgsType))
-            {
-                routedEventField = field;
-                eventArgsType = nonGenericArgsType;
-                return true;
+                var normalizedFieldType = fieldType.WithNullableAnnotation(NullableAnnotation.None);
+
+                if (routedEventGenericType is not null
+                    && SymbolEqualityComparer.Default.Equals(normalizedFieldType.OriginalDefinition, routedEventGenericType)
+                    && fieldType.TypeArguments.Length == 1
+                    && fieldType.TypeArguments[0] is INamedTypeSymbol genericArgsType)
+                {
+                    routedEventField = field;
+                    eventArgsType = genericArgsType;
+                    return true;
+                }
+
+                if (routedEventNonGenericType is not null
+                    && SymbolEqualityComparer.Default.Equals(normalizedFieldType, routedEventNonGenericType)
+                    && TryGetAvaloniaRoutedEventArgsType(evt, compilation, out INamedTypeSymbol nonGenericArgsType))
+                {
+                    routedEventField = field;
+                    eventArgsType = nonGenericArgsType;
+                    return true;
+                }
             }
         }
+
+        return false;
     }
 
-    return false;
-}
-
-private static bool TryGetAvaloniaRoutedEventArgsType(
-    IEventSymbol evt,
-    Compilation compilation,
-    out INamedTypeSymbol eventArgsType)
-{
-    eventArgsType = null!;
-
-    var routedEventArgs = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEventArgs");
-    if (evt.Type is INamedTypeSymbol { TypeArguments.Length: 1 } handlerType
-        && handlerType.TypeArguments[0] is INamedTypeSymbol argsFromHandler)
+    private static bool TryGetAvaloniaRoutedEventArgsType(
+        IEventSymbol evt,
+        Compilation compilation,
+        out INamedTypeSymbol eventArgsType)
     {
-        eventArgsType = argsFromHandler;
-        return true;
+        eventArgsType = null!;
+
+        var routedEventArgs = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEventArgs");
+        if (evt.Type is INamedTypeSymbol { TypeArguments.Length: 1 } handlerType
+            && handlerType.TypeArguments[0] is INamedTypeSymbol argsFromHandler)
+        {
+            eventArgsType = argsFromHandler;
+            return true;
+        }
+
+        if (routedEventArgs is not null)
+        {
+            eventArgsType = routedEventArgs;
+            return true;
+        }
+
+        return false;
     }
 
-    if (routedEventArgs is not null)
+    private static bool IsWpfRoutedEventType(ITypeSymbol type, Compilation compilation)
     {
-        eventArgsType = routedEventArgs;
-        return true;
+        var routedEventType = compilation.GetTypeByMetadataName("System.Windows.RoutedEvent");
+        return routedEventType is not null
+            && SymbolEqualityComparer.Default.Equals(type.WithNullableAnnotation(NullableAnnotation.None), routedEventType);
     }
 
-    return false;
-}
-
-private static bool IsWpfRoutedEventType(ITypeSymbol type, Compilation compilation)
-{
-    var routedEventType = compilation.GetTypeByMetadataName("System.Windows.RoutedEvent");
-    return routedEventType is not null
-        && SymbolEqualityComparer.Default.Equals(type.WithNullableAnnotation(NullableAnnotation.None), routedEventType);
-}
-
-private static bool IsAvaloniaRoutedEventType(ITypeSymbol type, Compilation compilation)
-{
-    var nonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
-    if (nonGeneric is not null
-        && SymbolEqualityComparer.Default.Equals(type.WithNullableAnnotation(NullableAnnotation.None), nonGeneric))
+    private static bool IsAvaloniaRoutedEventType(ITypeSymbol type, Compilation compilation)
     {
-        return true;
-    }
+        var nonGeneric = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent");
+        if (nonGeneric is not null
+            && SymbolEqualityComparer.Default.Equals(type.WithNullableAnnotation(NullableAnnotation.None), nonGeneric))
+        {
+            return true;
+        }
 
-    var generic = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
-    return generic is not null
-        && type is INamedTypeSymbol named
-        && SymbolEqualityComparer.Default.Equals(named.OriginalDefinition, generic);
-}
+        var generic = compilation.GetTypeByMetadataName("Avalonia.Interactivity.RoutedEvent`1");
+        return generic is not null
+            && type is INamedTypeSymbol named
+            && SymbolEqualityComparer.Default.Equals(named.OriginalDefinition, generic);
+    }
 }

--- a/Observables.SourceGenerators.props
+++ b/Observables.SourceGenerators.props
@@ -22,4 +22,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <ObservablesEnableBannedApiAnalyzers>true</ObservablesEnableBannedApiAnalyzers>
+  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)eng\Observables.BannedApi.props" />
+
 </Project>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -316,6 +316,16 @@ sealed class Build : NukeBuild
             }
         });
 
+    Target FormatWhitespace => _ => _
+        .DependsOn(Restore)
+        .Executes(() =>
+        {
+            // Whitespace-only (EOL / trailing). Style/analyzer format is deferred:
+            // RestAPI still uses block namespaces (IDE0161) from Refit-era sources.
+            // Prefer running on LF checkouts (CI ubuntu); Windows CRLF working trees may fail.
+            DotNet($"format whitespace {SolutionFile} --verify-no-changes --no-restore");
+        });
+
     Target Ci => _ => _
         .DependsOn(UnitTest);
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -214,7 +214,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 |---|--------|--------|------|
 | E11 | 架构总览文档 + 贡献者指南 | M | **已完成**：[`architecture.md`](design/architecture.md)、[`contributor.md`](design/contributor.md)；文档体系见 [`DOCUMENTATION.md`](DOCUMENTATION.md) |
 | ~~E12~~ | ~~真实应用 Showcase（GitPulse）~~ | ~~M~~ | **已完成（Showcase）**：[`GitPulse`](https://github.com/Skymly/GitPulse) 作为日常可用的 .NET MAUI GitHub 客户端，消费 `Observables.RestAPI.R3` + `Observables.Events.R3`。**Samples**：多数 IO 域已有进程内 LiveDemo（CI 跑）；NATS 默认 RegistrationDemo、`--live` 才真 I/O。更深端到端示例不作为 E12 验收门槛（见搁置 D8） |
-| E13 | BannedApiAnalyzers + CI `dotnet format --verify` | S | 防止生成器代码误用反射等不安全 API；CI 格式校验（与 D5 合并处理） |
+| ~~E13~~ | ~~BannedApiAnalyzers + CI `dotnet format whitespace --verify`~~ | ~~S~~ | **已完成**：生成器 / Analyzers / CodeFixes 启用 `Microsoft.CodeAnalysis.BannedApiAnalyzers`（`eng/BannedSymbols.Roslyn.txt`）；CI Ubuntu job `Format whitespace verify`（与 D5 合并）。全量 `dotnet format style` 因 RestAPI 等 block namespace（IDE0161）暂缓 |
 
 ### 搁置（等用户反馈或维护者有额外精力）
 
@@ -224,7 +224,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | D2 | 代码签名 | EV 证书成本高，个人项目收益低 |
 | ~~D3~~ | ~~增量生成器缓存命中测试~~ | **已完成（全量覆盖）**：8 域 × R3 + Reactive = 15 个测试项目，45 个缓存测试全部通过；`ForAttributeWithMetadataName` 域（SignalR/Mqtt/WebSocket/Grpc/Sse/Nats）无关编辑→Cached，`CreateSyntaxProvider` 域（RestAPI/Events）无关编辑可能 Modified（预期行为） |
 | D4 | 异常处理统一（非 RestAPI 域补自定义异常） | 各域策略可能有意为之，强行统一风险高 |
-| D5 | CI 添加 `dotnet format --verify` | 本地 editorconfig 已控制，CI 增加价值有限 |
+| ~~D5~~ | ~~CI 添加 `dotnet format whitespace --verify`~~ | **已完成（并入 E13）**：Ubuntu CI job 校验 LF / trailing whitespace；全量 style format 仍暂缓 |
 | D6 | SignalR/Nats/Mqtt 桥接释放/竞态细节修复 | 低风险，等用户反馈 |
 | D7 | NuGet 徽章更新、Events 硬编码 AssemblyName | 功能正确，重构风险 > 收益 |
 | D8 | 6 域 Samples 更深端到端示例（超出当前进程内 LiveDemo） | Events/RestAPI Samples + GitPulse 已覆盖真实消费；SignalR/Mqtt/Grpc/WebSocket/Sse 已有 loopback/embedded LiveDemo，NATS 有 `--live`；再加深按需 |

--- a/eng/BannedSymbols.Roslyn.txt
+++ b/eng/BannedSymbols.Roslyn.txt
@@ -1,0 +1,14 @@
+// Banned APIs for Observables Roslyn components (generators, analyzers, code fixes).
+// Prefer Roslyn symbols / emitted source over System.Reflection runtime APIs.
+
+T:System.Activator; Source generators and analyzers must not use Activator; emit code or use Roslyn APIs instead
+M:System.Reflection.Assembly.Load(System.String); Do not load assemblies dynamically in generators/analyzers
+M:System.Reflection.Assembly.Load(System.Reflection.AssemblyName); Do not load assemblies dynamically in generators/analyzers
+M:System.Reflection.Assembly.Load(System.Byte[]); Do not load assemblies dynamically in generators/analyzers
+M:System.Reflection.Assembly.LoadFrom(System.String); Do not load assemblies dynamically in generators/analyzers
+M:System.Reflection.Assembly.LoadFile(System.String); Do not load assemblies dynamically in generators/analyzers
+M:System.Type.GetType(System.String); Prefer Roslyn ITypeSymbol over Type.GetType
+M:System.Type.GetType(System.String,System.Boolean); Prefer Roslyn ITypeSymbol over Type.GetType
+M:System.Type.GetType(System.String,System.Boolean,System.Boolean); Prefer Roslyn ITypeSymbol over Type.GetType
+M:System.Reflection.MethodBase.Invoke(System.Object,System.Object[]); Do not invoke members via reflection in generators/analyzers
+M:System.Reflection.MethodBase.Invoke(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo); Do not invoke members via reflection in generators/analyzers

--- a/eng/Observables.BannedApi.props
+++ b/eng/Observables.BannedApi.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    BannedApiAnalyzers for Roslyn components (generators / analyzers / code fixes).
+    Imported from Observables.SourceGenerators.props and Directory.Build.props (shared analyzers).
+  -->
+
+  <ItemGroup Condition="'$(ObservablesEnableBannedApiAnalyzers)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.Roslyn.txt" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Enable `Microsoft.CodeAnalysis.BannedApiAnalyzers` for generators, Analyzers, and CodeFixes (`eng/BannedSymbols.Roslyn.txt`)
- Add Ubuntu CI job `Format whitespace verify` (`dotnet format whitespace --verify-no-changes`); merges ROADMAP D5
- Normalize `ci.yml` to LF (was CRLF in the index)
- Mark E13/D5 complete; defer full `dotnet format style` (RestAPI block namespaces / IDE0161)

## Test plan
- [x] Build RestAPI R3 SourceGenerators + Analyzers (Release)
- [ ] CI green (especially Format whitespace verify + Full CI)
- [ ] Bugbot review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are build/CI and analyzer guardrails only; the possible `ci.yml` YAML typo on the `changes` job could break domain-detection jobs if left unfixed.
> 
> **Overview**
> **Banned API enforcement** for source generators, `Observables.Analyzers`, and `Observables.CodeFixes`: central package `Microsoft.CodeAnalysis.BannedApiAnalyzers`, shared `eng/Observables.BannedApi.props`, and `eng/BannedSymbols.Roslyn.txt` (blocks `Activator`, dynamic `Assembly.Load*`, `Type.GetType`, and `MethodBase.Invoke`).
> 
> **CI** gains an Ubuntu `format-whitespace` job running `dotnet format whitespace Observables.slnx --verify-no-changes`. **Nuke** adds `FormatWhitespace` with the same verify command (style format still deferred per ROADMAP). `ci.yml` is re-normalized to LF.
> 
> **Docs**: `ROADMAP.md` marks E13 and D5 complete and notes full `dotnet format style` is still blocked on RestAPI block namespaces (IDE0161).
> 
> **Watch**: the `changes` job header appears merged onto one line (`changes:    name:`), which may break YAML parsing if not fixed before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08571fb3b06c01be2cf0aa8707a3144cc9d65423. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->