### PR TITLE
Scaffold Observables.Postgres with B-tier peer host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ Observables/
 | **Grpc** | `Observables.Grpc` | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Grpc.Tests` / `Grpc.Reactive.Tests`，进程内 `TestServer`） |
 | **Sse** | `Observables.Sse` | `Sse.R3.SourceGenerators` | `Sse.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Sse.Tests` / `Sse.Reactive.Tests`，内嵌 HTTP server） |
 | **Nats** | `Observables.Nats` | `Nats.R3.SourceGenerators` | `Nats.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Nats.Tests` / `Nats.Reactive.Tests`，进程内 nats-server） |
+| **Postgres** | `Observables.Postgres`（脚手架） | `Postgres.R3.SourceGenerators`（stub） | `Postgres.Reactive.SourceGenerators`（stub） | B-tier peer + raw Npgsql LISTEN/NOTIFY（`Postgres.Tests`）；生成代理 / Package 待后续票 |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 
@@ -221,6 +222,7 @@ Observables/
     | `OBS7xxx` | Grpc |
     | `OBS8xxx` | Sse |
     | `OBS9xxx` | Nats |
+    | `OBS10xxx` | Postgres |
 
   - 新增诊断落入对应段，**不复用、不跨段**。
   - 新增诊断写入对应项目的 `AnalyzerReleases.Unshipped.md`；发版时移入 `Shipped.md`（**已启用**，勿再 `#pragma warning disable RS2008`）。
@@ -368,7 +370,7 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | **Shared** | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.Analyzers`、`Observables.CodeFixes` |
 | **Events** | `/Events/`（含 `Observables.Events/targets`、Shared 诊断 `OBS2001`–`OBS2005`） |
 | **RestAPI** | `/RestAPI/`（含 `SourceGenerators.Shared`、Tests） |
-| **SignalR** / **WebSocket** / **Mqtt** / **Grpc** / **Sse** / **Nats** | 各对应文件夹 |
+| **SignalR** / **WebSocket** / **Mqtt** / **Grpc** / **Sse** / **Nats** / **Postgres** | 各对应文件夹 |
 | **Docs** | 本仓 `docs/`（维护者/中文）；用户文档站 [Observables.Docs](https://github.com/Skymly/Observables.Docs)（VitePress，**分 PR**） |
 | **Repository (root README)** | 根 `README.md`、`CONTRIBUTING.md` |
 | **Solution Items** | 根 `AGENTS.md`、`Observables.slnx`、`Directory.Build.props`、`Directory.Packages.props`（CPM）、公共 props、`eng/`、`build/`（Nuke）、`.github/` |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="MQTTnet" Version="4.3.7.1207" />
     <PackageVersion Include="NATS.Client.Core" Version="2.8.1" />
     <PackageVersion Include="NATS.Client.Serializers.Json" Version="2.8.1" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />

--- a/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/Observables.Postgres.R3.SourceGenerators.csproj
+++ b/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/Observables.Postgres.R3.SourceGenerators.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\Observables.SourceGenerators.R3.props" />
+
+  <PropertyGroup>
+    <Description>Source generator for PostgreSQL LISTEN/NOTIFY proxies → R3 Observable (scaffold stub).</Description>
+    <DefineConstants>$(DefineConstants);ROSLYN_4;POSTGRES_R3</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="R3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <Import Project="..\Observables.Postgres.SourceGenerators.Shared\Observables.Postgres.SourceGenerators.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/PostgresInterfaceStubGenerator.cs
+++ b/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/PostgresInterfaceStubGenerator.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.Postgres.R3.SourceGenerators;
+
+/// <summary>Scaffold stub — Listen/Notify emit lands in follow-up tickets.</summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class PostgresInterfaceStubGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+    }
+}

--- a/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/Observables.Postgres.Reactive.SourceGenerators.csproj
+++ b/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/Observables.Postgres.Reactive.SourceGenerators.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\Observables.SourceGenerators.props" />
+
+  <PropertyGroup>
+    <Description>Source generator for PostgreSQL LISTEN/NOTIFY proxies → System.Reactive IObservable (scaffold stub).</Description>
+    <DefineConstants>$(DefineConstants);ROSLYN_4;POSTGRES_REACTIVE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" PrivateAssets="all" />
+  </ItemGroup>
+
+  <Import Project="..\Observables.Postgres.SourceGenerators.Shared\Observables.Postgres.SourceGenerators.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/PostgresInterfaceStubGenerator.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/PostgresInterfaceStubGenerator.cs
@@ -1,0 +1,12 @@
+using Microsoft.CodeAnalysis;
+
+namespace Observables.Postgres.Reactive.SourceGenerators;
+
+/// <summary>Scaffold stub — Listen/Notify emit lands in follow-up tickets.</summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class PostgresInterfaceStubGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+    }
+}

--- a/Observables.Postgres/Observables.Postgres.Reactive/Observables.Postgres.Reactive.csproj
+++ b/Observables.Postgres/Observables.Postgres.Reactive/Observables.Postgres.Reactive.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Observables.Postgres.Reactive</RootNamespace>
+    <AssemblyName>Observables.Postgres.Reactive</AssemblyName>
+    <Description>System.Reactive bridges for Observables.Postgres (scaffolding).</Description>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Postgres\Observables.Postgres.csproj" />
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Reactive/PostgresReactiveFeature.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PostgresReactiveFeature.cs
@@ -1,0 +1,6 @@
+namespace Observables.Postgres.Reactive;
+
+/// <summary>
+/// Assembly marker for the Observables.Postgres.Reactive bridge scaffold.
+/// </summary>
+internal static class PostgresReactiveFeature;

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/AnalyzerReleases.Shipped.md
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+; Unshipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/DiagnosticDescriptors.cs
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/DiagnosticDescriptors.cs
@@ -1,0 +1,10 @@
+namespace Observables.Postgres.Generators;
+
+/// <summary>
+/// Postgres diagnostics use the <c>OBS10xxx</c> segment (reserved in AGENTS.md).
+/// Concrete descriptors land with the Listen/Notify generator golden path.
+/// </summary>
+internal static class DiagnosticDescriptors
+{
+    // OBS10xxx — reserved for Observables.Postgres (no shipped rules yet).
+}

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.projitems
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.projitems
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>b0f3c4d5-6e7f-4081-9b02-4d5e6f708192</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Observables.Postgres.Generators</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)AnalyzerReleases.Unshipped.md" />
+    <Compile Include="$(MSBuildThisFileDirectory)DiagnosticDescriptors.cs" />
+  </ItemGroup>
+</Project>

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.shproj
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b0f3c4d5-6e7f-4081-9b02-4d5e6f708192</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Observables.Postgres.SourceGenerators.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Tests/Infrastructure/PostgresTestServer.cs
+++ b/Observables.Postgres/Observables.Postgres.Tests/Infrastructure/PostgresTestServer.cs
@@ -1,0 +1,366 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Observables.Postgres.Tests.Infrastructure;
+
+/// <summary>
+/// B-tier portable PostgreSQL peer for E2E tests (downloads zonky minimal binaries when missing).
+/// <para>
+/// Binary cache: <c>{TempPath}/observables-postgres-test/{version}/{platform}/</c>
+/// (Maven Central jar → nested <c>.txz</c> extract). Download/extract is gated by a process-wide
+/// <see cref="SemaphoreSlim"/> so parallel assemblies do not corrupt the cache.
+/// </para>
+/// <para>
+/// Test execution: use <see cref="PostgresTestServerCollection"/> with
+/// <c>DisableParallelization = true</c> so one peer is shared serially within the assembly
+/// (same pattern as Nats). Windows and Linux amd64 only; macOS is not supported.
+/// </para>
+/// </summary>
+public sealed class PostgresTestServer : IAsyncDisposable
+{
+    /// <summary>Pinned zonky embedded-postgres-binaries version (PostgreSQL 17.4).</summary>
+    public const string PostgresBinariesVersion = "17.4.0";
+
+    static readonly SemaphoreSlim ServerBinaryGate = new(1, 1);
+
+    readonly string dataDirectory;
+    readonly string binDirectory;
+    readonly int port;
+    readonly string connectionString;
+    bool stopped;
+
+    PostgresTestServer(string dataDirectory, string binDirectory, int port, string connectionString)
+    {
+        this.dataDirectory = dataDirectory;
+        this.binDirectory = binDirectory;
+        this.port = port;
+        this.connectionString = connectionString;
+    }
+
+    /// <summary>Npgsql connection string for the loopback peer (trust auth, database postgres).</summary>
+    public string ConnectionString => connectionString;
+
+    public int Port => port;
+
+    public static async Task<PostgresTestServer> StartAsync(CancellationToken cancellationToken = default)
+    {
+        var port = ReserveFreeTcpPort();
+        var binDirectory = await EnsurePostgresBinDirectoryAsync(cancellationToken).ConfigureAwait(false);
+        var instanceRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"observables-postgres-{port}-{Guid.NewGuid():N}");
+        var dataDirectory = Path.Combine(instanceRoot, "data");
+        Directory.CreateDirectory(instanceRoot);
+
+        await RunPostgresToolAsync(
+            binDirectory,
+            "initdb",
+            [
+                "-D", dataDirectory,
+                "-U", "postgres",
+                "--auth=trust",
+                "--no-locale",
+                "-E", "UTF8",
+            ],
+            cancellationToken).ConfigureAwait(false);
+
+        var logPath = Path.Combine(instanceRoot, "postgres.log");
+        // Do not use pg_ctl -w with redirected stdio — on Windows the waiter can hang
+        // after the server is already accepting connections. Port polling is the readiness gate.
+        StartPostgresDetached(
+            binDirectory,
+            [
+                "-D", dataDirectory,
+                "-l", logPath,
+                "-o", $"-p {port} -h 127.0.0.1",
+                "start",
+            ]);
+
+        await WaitForPortAsync(port, cancellationToken).ConfigureAwait(false);
+
+        var connectionString =
+            $"Host=127.0.0.1;Port={port};Username=postgres;Database=postgres;Pooling=false;SSL Mode=Disable";
+        return new PostgresTestServer(dataDirectory, binDirectory, port, connectionString);
+    }
+
+    static async Task<string> EnsurePostgresBinDirectoryAsync(CancellationToken cancellationToken)
+    {
+        await ServerBinaryGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await EnsurePostgresBinDirectoryCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            ServerBinaryGate.Release();
+        }
+    }
+
+    static async Task<string> EnsurePostgresBinDirectoryCoreAsync(CancellationToken cancellationToken)
+    {
+        var platform = OperatingSystem.IsWindows()
+            ? "windows-amd64"
+            : OperatingSystem.IsLinux()
+                ? "linux-amd64"
+                : throw new PlatformNotSupportedException(
+                    "E2E PostgreSQL tests require Windows or Linux amd64 CI agents.");
+
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "observables-postgres-test",
+            PostgresBinariesVersion,
+            platform);
+        var binDirectory = Path.Combine(root, "bin");
+        var initdbName = OperatingSystem.IsWindows() ? "initdb.exe" : "initdb";
+        var initdbPath = Path.Combine(binDirectory, initdbName);
+        if (File.Exists(initdbPath))
+        {
+            EnsureUnixExecutables(binDirectory);
+            return binDirectory;
+        }
+
+        Directory.CreateDirectory(root);
+        var artifactId = $"embedded-postgres-binaries-{platform}";
+        var jarName = $"{artifactId}-{PostgresBinariesVersion}.jar";
+        var jarPath = Path.Combine(root, jarName);
+        if (!File.Exists(jarPath))
+        {
+            var downloadUrl =
+                $"https://repo1.maven.org/maven2/io/zonky/test/postgres/{artifactId}/{PostgresBinariesVersion}/{jarName}";
+            using var client = new HttpClient();
+            await using var stream = await client
+                .GetStreamAsync(downloadUrl, cancellationToken)
+                .ConfigureAwait(false);
+            await using var file = File.Create(jarPath);
+            await stream.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+        }
+
+        var txzName = OperatingSystem.IsWindows()
+            ? "postgres-windows-x86_64.txz"
+            : "postgres-linux-x86_64.txz";
+        var txzPath = Path.Combine(root, txzName);
+        if (!File.Exists(txzPath))
+        {
+            ZipFile.ExtractToDirectory(jarPath, root, overwriteFiles: true);
+        }
+
+        if (!File.Exists(txzPath))
+        {
+            throw new FileNotFoundException(
+                $"PostgreSQL archive '{txzName}' not found after extracting zonky jar.",
+                txzPath);
+        }
+
+        using (var extraction = Process.Start(
+                   new ProcessStartInfo
+                   {
+                       FileName = "tar",
+                       UseShellExecute = false,
+                       CreateNoWindow = true,
+                       RedirectStandardOutput = true,
+                       RedirectStandardError = true,
+                       ArgumentList =
+                       {
+                           "-xJf",
+                           txzPath,
+                           "-C",
+                           root,
+                       },
+                   }) ?? throw new InvalidOperationException("Failed to start tar for PostgreSQL extraction."))
+        {
+            await extraction.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            if (extraction.ExitCode != 0)
+            {
+                var stderr = await extraction.StandardError.ReadToEndAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                throw new InvalidOperationException(
+                    $"tar failed to extract PostgreSQL archive with exit code {extraction.ExitCode}: {stderr}");
+            }
+        }
+
+        if (!File.Exists(initdbPath))
+        {
+            throw new FileNotFoundException(
+                "PostgreSQL initdb executable not found after extract.",
+                initdbPath);
+        }
+
+        EnsureUnixExecutables(binDirectory);
+        return binDirectory;
+    }
+
+    static void EnsureUnixExecutables(string binDirectory)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        foreach (var name in new[] { "initdb", "pg_ctl", "postgres", "psql" })
+        {
+            var path = Path.Combine(binDirectory, name);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            var mode = File.GetUnixFileMode(path);
+            File.SetUnixFileMode(
+                path,
+                mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+        }
+    }
+
+    static void StartPostgresDetached(string binDirectory, IReadOnlyList<string> arguments)
+    {
+        var exeName = OperatingSystem.IsWindows() ? "pg_ctl.exe" : "pg_ctl";
+        var startInfo = CreatePostgresStartInfo(binDirectory, exeName, arguments, redirect: false);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start pg_ctl.");
+        // Without -w, pg_ctl exits after spawning postgres; do not redirect stdio (Windows hang).
+        if (!process.WaitForExit(30_000))
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // ignored
+            }
+
+            throw new TimeoutException("pg_ctl start did not exit within 30 seconds.");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"pg_ctl start exited with code {process.ExitCode}.");
+        }
+    }
+
+    static async Task RunPostgresToolAsync(
+        string binDirectory,
+        string toolName,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        var exeName = OperatingSystem.IsWindows() ? $"{toolName}.exe" : toolName;
+        var startInfo = CreatePostgresStartInfo(binDirectory, exeName, arguments, redirect: true);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start {toolName}.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"{toolName} exited with code {process.ExitCode}. stdout: {stdout} stderr: {stderr}");
+        }
+    }
+
+    static ProcessStartInfo CreatePostgresStartInfo(
+        string binDirectory,
+        string exeName,
+        IReadOnlyList<string> arguments,
+        bool redirect)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Path.Combine(binDirectory, exeName),
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = redirect,
+            RedirectStandardError = redirect,
+            WorkingDirectory = binDirectory,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        // Windows builds need sibling DLLs on PATH.
+        var pathEnv = startInfo.Environment["PATH"] ?? string.Empty;
+        startInfo.Environment["PATH"] = string.IsNullOrEmpty(pathEnv)
+            ? binDirectory
+            : binDirectory + Path.PathSeparator + pathEnv;
+        return startInfo;
+    }
+
+    static int ReserveFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    static async Task WaitForPortAsync(int port, CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using var client = new TcpClient();
+                await client.ConnectAsync(IPAddress.Loopback, port, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch
+            {
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new TimeoutException($"PostgreSQL did not listen on port {port}.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (stopped)
+        {
+            return;
+        }
+
+        stopped = true;
+        try
+        {
+            var startInfo = CreatePostgresStartInfo(
+                binDirectory,
+                OperatingSystem.IsWindows() ? "pg_ctl.exe" : "pg_ctl",
+                ["-D", dataDirectory, "-m", "fast", "-w", "stop"],
+                redirect: false);
+            using var process = Process.Start(startInfo);
+            if (process is not null)
+            {
+                await process.WaitForExitAsync().ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // ignored — best-effort shutdown
+        }
+
+        var instanceRoot = Path.GetDirectoryName(dataDirectory);
+        if (instanceRoot is not null)
+        {
+            try
+            {
+                Directory.Delete(instanceRoot, recursive: true);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/Observables.Postgres/Observables.Postgres.Tests/Infrastructure/PostgresTestServerFixture.cs
+++ b/Observables.Postgres/Observables.Postgres.Tests/Infrastructure/PostgresTestServerFixture.cs
@@ -1,0 +1,18 @@
+namespace Observables.Postgres.Tests.Infrastructure;
+
+public sealed class PostgresTestServerFixture : IAsyncLifetime, IAsyncDisposable
+{
+    public PostgresTestServer Server { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync() =>
+        Server = await PostgresTestServer.StartAsync().ConfigureAwait(false);
+
+    public async ValueTask DisposeAsync() => await Server.DisposeAsync().ConfigureAwait(false);
+}
+
+/// <summary>
+/// Shares one B-tier PostgreSQL peer; disables parallelization so concurrent tests do not
+/// contend on LISTEN/NOTIFY sessions or the download gate.
+/// </summary>
+[CollectionDefinition(nameof(PostgresTestServerCollection), DisableParallelization = true)]
+public sealed class PostgresTestServerCollection : ICollectionFixture<PostgresTestServerFixture>;

--- a/Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj
+++ b/Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Observables.Postgres.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Observables.Postgres\Observables.Postgres.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Tests/PostgresListenNotifyPeerTests.cs
+++ b/Observables.Postgres/Observables.Postgres.Tests/PostgresListenNotifyPeerTests.cs
@@ -1,0 +1,49 @@
+using Npgsql;
+using Observables.Postgres.Tests.Infrastructure;
+
+namespace Observables.Postgres.Tests;
+
+[Collection(nameof(PostgresTestServerCollection))]
+public sealed class PostgresListenNotifyPeerTests(PostgresTestServerFixture fixture)
+{
+    [Fact]
+    public async Task Listen_receives_Notify_across_two_connections()
+    {
+        const string channel = "observables_peer";
+        const string payload = "hello-from-notify";
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var listener = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await listener.OpenAsync(cancellation);
+
+        var notification = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        listener.Notification += (_, args) =>
+        {
+            if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
+            {
+                notification.TrySetResult(args.Payload);
+            }
+        };
+
+        await using (var listenCommand = new NpgsqlCommand($"LISTEN {channel};", listener))
+        {
+            await listenCommand.ExecuteNonQueryAsync(cancellation);
+        }
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+        var waitTask = listener.WaitAsync(timeout.Token);
+
+        await using var notifier = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await notifier.OpenAsync(cancellation);
+        await using (var notifyCommand = new NpgsqlCommand($"NOTIFY {channel}, '{payload}';", notifier))
+        {
+            await notifyCommand.ExecuteNonQueryAsync(cancellation);
+        }
+
+        var received = await notification.Task.WaitAsync(timeout.Token);
+        await waitTask;
+
+        Assert.Equal(payload, received);
+    }
+}

--- a/Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj
+++ b/Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Observables.Postgres</RootNamespace>
+    <AssemblyName>Observables.Postgres</AssemblyName>
+    <Description>PostgreSQL LISTEN/NOTIFY runtime and R3 stream bridges (scaffolding).</Description>
+    <!-- Npgsql 9+ dropped netstandard2.0; Postgres domain targets modern TFMs only. -->
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres/PostgresFeature.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresFeature.cs
@@ -1,0 +1,7 @@
+namespace Observables.Postgres;
+
+/// <summary>
+/// Assembly marker for the Observables.Postgres Feature scaffold.
+/// Public API (attributes, <c>PostgresService.For&lt;T&gt;</c>) lands in follow-up tickets.
+/// </summary>
+internal static class PostgresFeature;

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.Postgres/Observables.Postgres/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/Observables.Postgres/Observables.Postgres/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -257,5 +257,25 @@
 
   </Folder>
 
+  <Folder Name="/Postgres/">
+
+    <Project Path="Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.shproj" Id="b0f3c4d5-6e7f-4081-9b02-4d5e6f708192" />
+
+    <Project Path="Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj" />
+
+    <Project Path="Observables.Postgres/Observables.Postgres.Reactive/Observables.Postgres.Reactive.csproj" />
+
+    <Project Path="Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/Observables.Postgres.Reactive.SourceGenerators.csproj" />
+
+    <Project Path="Observables.Postgres/Observables.Postgres.R3.SourceGenerators/Observables.Postgres.R3.SourceGenerators.csproj" />
+
+    <Folder Name="/Tests/">
+
+      <Project Path="Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj" />
+
+    </Folder>
+
+  </Folder>
+
 </Solution>
 

--- a/docs/design/contributor.md
+++ b/docs/design/contributor.md
@@ -75,7 +75,7 @@ Skymly/Observables/
 4. [ ] 建立 `*.R3.SourceGenerators` 与 `*.Reactive.SourceGenerators`
 5. [ ] 建立 `*.Package`，产出两个 NuGet 包
 6. [ ] 在 `eng/Observables.BuildManifest.json` 登记 pack / test / smoke
-7. [ ] 分配诊断段（如 `OBS10xxx` 须先扩展 `AGENTS.md` 段表并记 ADR）
+7. [ ] 分配诊断段（Postgres 已占用 `OBS10xxx`；再增段须先扩展 `AGENTS.md` 段表并记 ADR）
 8. [ ] 各域 `AnalyzerReleases.Unshipped.md` 登记新诊断
 9. [ ] 生成器测试（Verify）+ 运行时 E2E + `eng/nuget-smoke` 消费者
 10. [ ] 三仓文档：主仓 `docs/design/`、Observables.Docs 域页 + `diagnostics.md`、Samples 示例项目

--- a/eng/Observables.BuildManifest.json
+++ b/eng/Observables.BuildManifest.json
@@ -97,6 +97,7 @@
     "Observables.Nats/Observables.Nats.Reactive.SourceGenerators.Tests/Observables.Nats.Reactive.SourceGenerators.Tests.csproj",
     "Observables.Nats/Observables.Nats.Tests/Observables.Nats.Tests.csproj",
     "Observables.Nats/Observables.Nats.Reactive.Tests/Observables.Nats.Reactive.Tests.csproj",
+    "Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj",
     "Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj",
     "Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj",
     "Observables.Shared/Observables.TrimTests/Observables.TrimTests.csproj"

--- a/eng/Observables.ProjectDefaults.props
+++ b/eng/Observables.ProjectDefaults.props
@@ -33,6 +33,7 @@
     <_ObsIsDomainFolder Condition="$(_ObsProjectDir.Contains('/Observables.Grpc/'))">true</_ObsIsDomainFolder>
     <_ObsIsDomainFolder Condition="$(_ObsProjectDir.Contains('/Observables.Sse/'))">true</_ObsIsDomainFolder>
     <_ObsIsDomainFolder Condition="$(_ObsProjectDir.Contains('/Observables.Nats/'))">true</_ObsIsDomainFolder>
+    <_ObsIsDomainFolder Condition="$(_ObsProjectDir.Contains('/Observables.Postgres/'))">true</_ObsIsDomainFolder>
     <_ObsIsEventsPackProject>false</_ObsIsEventsPackProject>
     <_ObsIsEventsPackProject Condition="$(_ObsProjectDir.Contains('/Observables.Events.Package')) and '$(_ObsIsGeneratorProject)' != 'true'">true</_ObsIsEventsPackProject>
     <_ObsIsSharedProject>false</_ObsIsSharedProject>


### PR DESCRIPTION
## Summary
- Stand up the `Observables.Postgres` Feature project graph under `/Postgres/` (runtime, Reactive, dual generator stubs, Shared, tests).
- Add a Nats-style B-tier portable PostgreSQL peer (zonky binaries) and prove raw Npgsql LISTEN receives NOTIFY across two connections.
- Reserve the `OBS10xxx` diagnostic segment in AGENTS/contributor governance docs.

Closes #155

## Test plan
- [ ] `dotnet test Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj -c Release --framework net8.0`
- [ ] Confirm solution loads `/Postgres/` projects from `Observables.slnx`
- [ ] Confirm peer cache path `%TEMP%/observables-postgres-test/` and collection `DisableParallelization` behave on first-run download

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding and test-only infrastructure; no shipped public API, NuGet packages, or production runtime behavior yet.
> 
> **Overview**
> Introduces the **Observables.Postgres** feature slice under `/Postgres/`: runtime and Reactive bridge projects (assembly markers + Public API baselines), a shared generator `shproj`, and **no-op** R3/Reactive `PostgresInterfaceStubGenerator` stubs wired to the usual props.
> 
> Adds **Npgsql 10.0.3** to central package management and registers the domain in **`Observables.slnx`**, **`eng/Observables.BuildManifest.json`** (`testProjects` only—no `.Package` or smoke consumers yet), **`eng/Observables.ProjectDefaults.props`**, and contributor/AGENTS docs. Reserves the **`OBS10xxx`** diagnostic segment with empty `DiagnosticDescriptors` and analyzer release files.
> 
> Ships a **Nats-style B-tier** `PostgresTestServer` (zonky embedded binaries, Maven download cache, Windows/Linux amd64) plus a serial xUnit collection and an E2E test that proves raw **LISTEN/NOTIFY** over two Npgsql connections. Runtime public API and generator emit remain follow-up work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c66441b2a7e64cd01ba70a36e5b5e751d398cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->