### PR TITLE
Postgres: Pack, PackVerify, nuget-smoke, and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       grpc: ${{ steps.filter.outputs.grpc }}
       sse: ${{ steps.filter.outputs.sse }}
       nats: ${{ steps.filter.outputs.nats }}
+      postgres: ${{ steps.filter.outputs.postgres }}
       shared: ${{ steps.filter.outputs.shared }}
       any: ${{ steps.filter.outputs.any }}
     steps:
@@ -148,6 +149,9 @@ jobs:
               - 'Observables.slnx'
             nats:
               - 'Observables.Nats/**'
+              - 'Observables.slnx'
+            postgres:
+              - 'Observables.Postgres/**'
               - 'Observables.slnx'
             shared:
               - 'Observables.Shared/**'
@@ -219,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres]
     steps:
       - name: Skip if domain not changed and not shared
         if: |
@@ -279,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres]
     steps:
       - name: Skip if domain not changed, push event skipped, or PR missing pack label
         if: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.6`（**16 包**）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 16 包
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.6`（**16 包**）；本地 manifest / PackVerify 已含 Postgres（**18 包**，待发版）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
 - **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，0.1.6 稳定版已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
 - **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.6 稳定版已发）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
@@ -158,7 +158,7 @@ Observables/
 | **Grpc** | `Observables.Grpc` | `Grpc.R3.SourceGenerators` | `Grpc.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Grpc.Tests` / `Grpc.Reactive.Tests`，进程内 `TestServer`） |
 | **Sse** | `Observables.Sse` | `Sse.R3.SourceGenerators` | `Sse.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Sse.Tests` / `Sse.Reactive.Tests`，内嵌 HTTP server） |
 | **Nats** | `Observables.Nats` | `Nats.R3.SourceGenerators` | `Nats.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Nats.Tests` / `Nats.Reactive.Tests`，进程内 nats-server） |
-| **Postgres** | `Observables.Postgres`（脚手架） | `Postgres.R3.SourceGenerators`（stub） | `Postgres.Reactive.SourceGenerators`（stub） | B-tier peer + raw Npgsql LISTEN/NOTIFY（`Postgres.Tests`）；生成代理 / Package 待后续票 |
+| **Postgres** | `Observables.Postgres` | `Postgres.R3.SourceGenerators` | `Postgres.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Postgres.Tests` / `Postgres.Reactive.Tests`，B-tier portable peer）；`Postgres.Package` + PackVerify + nuget-smoke |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 
@@ -345,13 +345,13 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | **Test** | 同 `Ci`（`Compile` + `UnitTest`）；可附加 `--test-domains <逗号分隔>` 过滤测试项目（例如 `--test-domains mqtt,shared`） |
 | **Pack** | 打包 pack 子项目 → `artifacts/package/`（**不**依赖 UnitTest）；可附加 `--pack-domains <逗号分隔>` 过滤包（按 `PackageId` 前缀 `Observables.<d>.` 匹配） |
 | **PackOnly** | `Pack` + `PackVerify`（**不**跑 UnitTest） |
-| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats `lib/`（manifest 当前 **16 包**） |
+| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats/Postgres `lib/`（manifest 当前 **18 包**） |
 | **CiPack** | CI 完整流水线：`Test` + `PackOnly` + `NuGetConsumerSmoke`（本地包）；保留供本地或 release.yml 全链路调试 |
 | **Publish** | 推送到 nuget.org（`NUGET_API_KEY`）与 GitHub Packages（`GITHUB_TOKEN`，`packages:write`）；`DependsOn(Test, PackVerify)` 确保发版前测试已通过 |
 
 | Workflow | 触发 | 作用 |
 |----------|------|------|
-| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 6 个 `test-domain` 矩阵（**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 6 个 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
+| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
 | [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 actor；内部 `Test` → `PackVerify` → push） |
 
 ## 工作约定

--- a/Observables.Postgres/Observables.Postgres.Package/Directory.Build.props
+++ b/Observables.Postgres/Observables.Postgres.Package/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <OutputPath>bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Package.csproj
+++ b/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Package.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.82">
+
+  <PropertyGroup>
+    <Description>Traversal root for Observables.Postgres.R3 and Observables.Postgres.Reactive NuGet packages.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="Observables.Postgres.R3.csproj" />
+    <ProjectReference Include="Observables.Postgres.Reactive.Pack.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.R3.csproj
+++ b/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.R3.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+  <Import Project="..\..\eng\PackReferencedProjects.targets" />
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <!-- Npgsql 9+ dropped netstandard2.0; pack TFMs must match Observables.Postgres runtime. -->
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>Observables.Postgres.R3</PackageId>
+    <Description>Declarative PostgreSQL LISTEN/NOTIFY proxies with Roslyn source generators — annotate interfaces with [Listen]/[Notify] to generate R3 Observable&lt;T&gt; proxies for Postgres notification channels.</Description>
+    <PackageTags>observables;postgres;postgresql;listen;notify;pubsub;reactive;rx;reactive-extensions;iobservable;r3;declarative;roslyn;source-generator;csharp;dotnet;npgsql</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.Postgres.R3.SourceGenerators\Observables.Postgres.R3.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.Postgres.R3.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Postgres.R3.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Postgres.R3.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObservablesPackLibProjectReference Include="..\Observables.Postgres\Observables.Postgres.csproj" />
+    <PackageReference Include="R3" />
+    <PackageReference Include="Npgsql" />
+    <None Include="README.Postgres.R3.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Reactive.Pack.csproj
+++ b/Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Reactive.Pack.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\eng\Observables.Package.props" />
+  <Import Project="..\..\eng\PackRoslynAnalyzer.targets" />
+  <Import Project="..\..\eng\PackReferencedProjects.targets" />
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>false</DevelopmentDependency>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+    <!-- Npgsql 9+ dropped netstandard2.0; pack TFMs must match Observables.Postgres runtime. -->
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>Observables.Postgres.Reactive</PackageId>
+    <Description>Declarative PostgreSQL LISTEN/NOTIFY proxies with Roslyn source generators — annotate interfaces with [Listen]/[Notify] to generate System.Reactive IObservable&lt;T&gt; proxies for Postgres notification channels.</Description>
+    <PackageTags>observables;postgres;postgresql;listen;notify;pubsub;reactive;rx;reactive-extensions;iobservable;system.reactive;declarative;roslyn;source-generator;csharp;dotnet;npgsql</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ObservablesPackGeneratorProject>..\Observables.Postgres.Reactive.SourceGenerators\Observables.Postgres.Reactive.SourceGenerators.csproj</ObservablesPackGeneratorProject>
+    <ObservablesPackGeneratorAssemblyName>Observables.Postgres.Reactive.SourceGenerators.dll</ObservablesPackGeneratorAssemblyName>
+    <ObservablesPackGeneratorOutputDir>$(MSBuildProjectDirectory)\..\Observables.Postgres.Reactive.SourceGenerators\bin\$(Configuration)\netstandard2.0\</ObservablesPackGeneratorOutputDir>
+    <ObservablesPackPackagePropsFile>$(MSBuildProjectDirectory)\build\Observables.Postgres.Reactive.props</ObservablesPackPackagePropsFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObservablesPackLibProjectReference Include="..\Observables.Postgres\Observables.Postgres.csproj" />
+    <ObservablesPackLibProjectReference Include="..\Observables.Postgres.Reactive\Observables.Postgres.Reactive.csproj" />
+    <PackageReference Include="System.Reactive" />
+    <PackageReference Include="Npgsql" />
+    <None Include="README.Postgres.Reactive.pack.md" Pack="true" PackagePath="README.md" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Package/README.Postgres.R3.pack.md
+++ b/Observables.Postgres/Observables.Postgres.Package/README.Postgres.R3.pack.md
@@ -1,0 +1,41 @@
+# Observables.Postgres.R3
+
+Declarative PostgreSQL LISTEN/NOTIFY proxies with Roslyn source generators — annotate interfaces with `[Listen]`/`[Notify]` to generate [R3](https://github.com/Cysharp/R3) `Observable<T>` proxies for Postgres notification channels.
+
+## Install
+
+```xml
+<PackageReference Include="Observables.Postgres.R3" Version="0.1.6" />
+<PackageReference Include="Npgsql" Version="10.0.3" />
+<PackageReference Include="R3" Version="1.3.0" />
+```
+
+## Usage
+
+```csharp
+using Npgsql;
+using Observables.Postgres;
+using R3;
+
+[Postgres]
+public interface IOrderHub
+{
+    [Listen("orders")]
+    Observable<string> Orders { get; }
+
+    [Notify("orders")]
+    Observable<Unit> PublishOrder(string payload);
+}
+
+await using var connection = new NpgsqlConnection(connectionString);
+await connection.OpenAsync();
+var hub = PostgresService.For<IOrderHub>(connection);
+```
+
+## Diagnostics
+
+`OBS10001`–`OBS10007` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/Observables.Postgres/Observables.Postgres.Package/README.Postgres.Reactive.pack.md
+++ b/Observables.Postgres/Observables.Postgres.Package/README.Postgres.Reactive.pack.md
@@ -1,0 +1,23 @@
+# Observables.Postgres.Reactive
+
+Declarative PostgreSQL LISTEN/NOTIFY proxies with Roslyn source generators — annotate interfaces with `[Listen]`/`[Notify]` to generate [System.Reactive](https://github.com/dotnet/reactive) `IObservable<T>` proxies for Postgres notification channels.
+
+## Install
+
+```xml
+<PackageReference Include="Observables.Postgres.Reactive" Version="0.1.6" />
+<PackageReference Include="Npgsql" Version="10.0.3" />
+<PackageReference Include="System.Reactive" Version="6.0.1" />
+```
+
+## Usage
+
+Same `[Postgres]` attributes as the R3 package; use `IObservable<T>` return types and `PostgresService.For<T>(connection)`.
+
+## Diagnostics
+
+`OBS10001`–`OBS10007` — see [Observables](https://github.com/Skymly/Observables).
+
+## License
+
+MIT

--- a/Observables.Postgres/Observables.Postgres.Package/build/Observables.Postgres.R3.props
+++ b/Observables.Postgres/Observables.Postgres.Package/build/Observables.Postgres.R3.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Marker props for Observables.Postgres.R3 (runtime + analyzer). -->
+</Project>

--- a/Observables.Postgres/Observables.Postgres.Package/build/Observables.Postgres.Reactive.props
+++ b/Observables.Postgres/Observables.Postgres.Package/build/Observables.Postgres.Reactive.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Marker props for Observables.Postgres.Reactive (runtime + analyzer). -->
+</Project>

--- a/Observables.slnx
+++ b/Observables.slnx
@@ -261,6 +261,8 @@
 
     <Project Path="Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Observables.Postgres.SourceGenerators.Shared.shproj" Id="b0f3c4d5-6e7f-4081-9b02-4d5e6f708192" />
 
+    <Project Path="Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Package.csproj" />
+
     <Project Path="Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj" />
 
     <Project Path="Observables.Postgres/Observables.Postgres.Reactive/Observables.Postgres.Reactive.csproj" />

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -222,7 +222,8 @@ sealed class Build : NukeBuild
                     || packageId.StartsWith("Observables.WebSocket.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Grpc.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Sse.", StringComparison.Ordinal)
-                    || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal))
+                    || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal))
                 {
                     Assert.True(
                         entries.Contains("analyzers/dotnet/roslyn4.12/cs/Observables.CodeFixes.dll"),
@@ -245,7 +246,8 @@ sealed class Build : NukeBuild
                     || packageId.StartsWith("Observables.WebSocket.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Grpc.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Sse.", StringComparison.Ordinal)
-                    || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal))
+                    || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal))
                 {
                     bool hasLib = entries.Any(e => e.StartsWith("lib/", StringComparison.OrdinalIgnoreCase)
                         && e.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));

--- a/eng/Observables.BuildManifest.json
+++ b/eng/Observables.BuildManifest.json
@@ -63,6 +63,14 @@
     {
       "packProject": "Observables.Nats/Observables.Nats.Package/Observables.Nats.Reactive.Pack.csproj",
       "packageId": "Observables.Nats.Reactive"
+    },
+    {
+      "packProject": "Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.R3.csproj",
+      "packageId": "Observables.Postgres.R3"
+    },
+    {
+      "packProject": "Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Reactive.Pack.csproj",
+      "packageId": "Observables.Postgres.Reactive"
     }
   ],
   "testProjects": [
@@ -121,6 +129,8 @@
     "eng/nuget-smoke/Sse.R3.Consumer/Sse.R3.Consumer.csproj",
     "eng/nuget-smoke/Sse.Reactive.Consumer/Sse.Reactive.Consumer.csproj",
     "eng/nuget-smoke/Nats.R3.Consumer/Nats.R3.Consumer.csproj",
-    "eng/nuget-smoke/Nats.Reactive.Consumer/Nats.Reactive.Consumer.csproj"
+    "eng/nuget-smoke/Nats.Reactive.Consumer/Nats.Reactive.Consumer.csproj",
+    "eng/nuget-smoke/Postgres.R3.Consumer/Postgres.R3.Consumer.csproj",
+    "eng/nuget-smoke/Postgres.Reactive.Consumer/Postgres.Reactive.Consumer.csproj"
   ]
 }

--- a/eng/nuget-smoke/Postgres.R3.Consumer/Postgres.R3.Consumer.csproj
+++ b/eng/nuget-smoke/Postgres.R3.Consumer/Postgres.R3.Consumer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Observables.Postgres.R3" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/eng/nuget-smoke/Postgres.R3.Consumer/Program.cs
+++ b/eng/nuget-smoke/Postgres.R3.Consumer/Program.cs
@@ -1,0 +1,19 @@
+using Observables.Postgres;
+using R3;
+
+namespace Observables.NuGetSmoke.Postgres.R3;
+
+[Postgres]
+public interface ISmokeChannels
+{
+    [Listen("ping")]
+    Observable<string> Ping { get; }
+
+    [Notify("ping")]
+    Observable<Unit> PublishPing(string payload);
+}
+
+public static class Program
+{
+    public static void Main() => Console.WriteLine("Observables.Postgres.R3 consumer smoke OK");
+}

--- a/eng/nuget-smoke/Postgres.Reactive.Consumer/Postgres.Reactive.Consumer.csproj
+++ b/eng/nuget-smoke/Postgres.Reactive.Consumer/Postgres.Reactive.Consumer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Observables.Postgres.Reactive" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/eng/nuget-smoke/Postgres.Reactive.Consumer/Program.cs
+++ b/eng/nuget-smoke/Postgres.Reactive.Consumer/Program.cs
@@ -1,0 +1,15 @@
+using Observables.Postgres;
+
+namespace Observables.NuGetSmoke.Postgres.Reactive;
+
+[Postgres]
+public interface ISmokeChannels
+{
+    [Listen("ping")]
+    IObservable<string> Ping { get; }
+}
+
+public static class Program
+{
+    public static void Main() => Console.WriteLine("Observables.Postgres.Reactive consumer smoke OK");
+}


### PR DESCRIPTION
## Summary
- Add `Observables.Postgres.Package` producing `Observables.Postgres.R3` / `.Reactive` (lib/ + analyzers/codefixes; TFMs net8/9/10 for Npgsql).
- Register packages and smoke consumers in BuildManifest; extend PackVerify for Postgres `lib/` + analyzer layout.
- Add `eng/nuget-smoke` Postgres R3/Reactive consumers; wire CI paths-filter and test/pack domain matrices for `postgres`.

Closes #159.

## Test plan
- [x] `dotnet run --project build/_build.csproj -- --target PackOnly --configuration Release --pack-domains postgres`
- [x] Local nuget-smoke Postgres R3/Reactive build + run against artifacts
- [x] Postgres generator tests + E2E on net8/net10
- [ ] CI: test-domain postgres + pack-domain postgres + smoke (needs `pack` label)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI changes mirror established domain patterns; no runtime behavior or security-sensitive logic is modified in this diff.
> 
> **Overview**
> Adds **Postgres NuGet publishing** alongside the existing runtime/generators: a new `Observables.Postgres.Package` traversal produces **`Observables.Postgres.R3`** and **`Observables.Postgres.Reactive`** with runtime `lib/`, Roslyn analyzers/codefixes, and pack READMEs. Pack TFMs are **net8.0–net10.0** (aligned with Npgsql dropping netstandard2.0).
> 
> **Build & release wiring** registers both packages and two `eng/nuget-smoke` consumers in `Observables.BuildManifest.json`, extends **PackVerify** in `build/Program.cs` to assert Postgres packages match the same analyzer/`lib/` layout as other IO domains, and adds the package project to the solution.
> 
> **CI** gains a `postgres` paths-filter output and includes `postgres` in the parallel **test-domain** and **pack-domain** matrices so Postgres-only changes run targeted Nuke test/pack jobs like other features.
> 
> `AGENTS.md` is updated to describe Postgres as fully packaged (18 packages in manifest) rather than stub/scaffold status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84ab2b642b9b97c25faa79a6c63c1ac4d989c0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->