### PR TITLE
Document Postgres as ninth maintainer-facing domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Release notes: update the version table in this file and [docs/ROADMAP.md](docs/
 ### PR conventions
 
 - **Titles and descriptions**: English.
-- **Scope**: Prefer one solution-folder module per PR (Shared, Events, RestAPI, SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, or Solution Items for root props / `eng/` / `build/` / `.github/`).
+- **Scope**: Prefer one solution-folder module per PR (Shared, Events, RestAPI, SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, or Solution Items for root props / `eng/` / `build/` / `.github/`).
 - **Commits**: English; do not mention AI or agent tools in commit messages.
 - **Do not** change `eng/Observables.Package.props` version or create tags unless the task explicitly requests a release.
 
@@ -69,7 +69,9 @@ Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with
 
 ### Package set
 
-Sixteen NuGet packages — eight domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`:
+**nuget.org (`0.1.6`)**: sixteen packages — eight domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
+
+**Local tree / PackVerify**: eighteen packages — nine domains (adds Postgres). Postgres ships on the next maintainer-approved release; until then Package IDs exist in-repo and in `eng/Observables.BuildManifest.json` but are not yet on nuget.org.
 
 | Package ID | Domain |
 |------------|--------|
@@ -81,6 +83,7 @@ Sixteen NuGet packages — eight domains, each as `Observables.<Feature>.R3` and
 | `Observables.Grpc.R3` / `.Reactive` | gRPC `CallInvoker` proxy |
 | `Observables.Sse.R3` / `.Reactive` | Server-Sent Events (`text/event-stream`) |
 | `Observables.Nats.R3` / `.Reactive` | Core NATS subject proxy |
+| `Observables.Postgres.R3` / `.Reactive` | PostgreSQL LISTEN/NOTIFY channel proxy (in-repo; pending nuget.org) |
 
 Version source of truth: `eng/Observables.Package.props` (`PackageVersion` / `Version`).
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Observables
 
-> **Roslyn source generators bridging events & IO boundaries to R3 / System.Reactive.** Declarative interface-driven proxies for HTTP, SignalR, MQTT, WebSocket, gRPC, SSE, and NATS — write the interface, get the `Observable<T>`.
+> **Roslyn source generators bridging events & IO boundaries to R3 / System.Reactive.** Declarative interface-driven proxies for HTTP, SignalR, MQTT, WebSocket, gRPC, SSE, NATS, and PostgreSQL LISTEN/NOTIFY — write the interface, get the `Observable<T>`.
 
 [![NuGet](https://img.shields.io/nuget/v/Observables.Events.R3.svg?label=NuGet&logo=nuget)](https://www.nuget.org/profiles/Skymly)
 [![CI](https://img.shields.io/github/actions/workflow/status/Skymly/Observables/ci.yml?branch=main&label=CI&logo=github)](https://github.com/Skymly/Observables/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/Skymly/Observables.svg?label=License&logo=opensourcehardware)](LICENSE)
 
-面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件：用声明式接口把 .NET 事件、HTTP、SignalR、MQTT、WebSocket、gRPC、SSE、NATS 等边界桥接到 **R3** 或 **System.Reactive**。
+面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件：用声明式接口把 .NET 事件、HTTP、SignalR、MQTT、WebSocket、gRPC、SSE、NATS、PostgreSQL LISTEN/NOTIFY 等边界桥接到 **R3** 或 **System.Reactive**。
 
 | 资源 | 链接 |
 |------|------|
@@ -43,7 +43,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 
 ## 功能域
 
-八域均已提供运行时（按需）、双路源生成器、测试与 NuGet 包；共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
+九域均已在主仓提供运行时（按需）、双路源生成器与测试；前八域已发 nuget.org（`0.1.6`，16 包），**Postgres** 已落地并纳入本地 PackVerify（18 包，待发版）。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
 
 | 域 | 说明 |
 |----|------|
@@ -55,6 +55,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 | **Grpc** | `CallInvoker` 代理 |
 | **Sse** | `text/event-stream` 事件流 |
 | **Nats** | Core NATS subject 代理（v1 不含 JetStream） |
+| **Postgres** | PostgreSQL LISTEN/NOTIFY 通道代理（专用非池化连接；推荐 keepalive） |
 
 设计稿见 [`docs/`](docs/README.md)（文档体系见 [`docs/DOCUMENTATION.md`](docs/DOCUMENTATION.md)）。路由事件生成默认关闭；在消费者项目中设置 `<ObservableRoutedEvents>true</ObservableRoutedEvents>`（见 `Observables.Events/Observables.Events/targets/observables.events.props`）。
 
@@ -292,6 +293,29 @@ var hub = NatsService.For<IOrderHub>(nats);
 ```
 
 依赖 [NATS.Client.Core](https://www.nuget.org/packages/NATS.Client.Core)。
+
+## Postgres（LISTEN/NOTIFY）
+
+在 `[Postgres]` 接口上用 `[Listen]` / `[Notify]` 标注成员，生成器产出 LISTEN 热流与 NOTIFY 冷流。`PostgresService.For<T>` 接受**专用、非池化**的 `NpgsqlConnection`（勿从连接池借连接做长生命周期 `Wait`）；Listen 连接建议 `Pooling=false` 并设置 Npgsql **`Keepalive`**。
+
+```csharp
+[Postgres]
+public interface IOrderHub
+{
+    [Listen("orders")]
+    Observable<string> Orders { get; }
+
+    [Notify("orders")]
+    Observable<Unit> PublishOrder(string payload, CancellationToken cancellationToken = default);
+}
+
+await using var connection = new NpgsqlConnection(
+    "Host=localhost;Database=app;Username=app;Password=…;Pooling=false;Keepalive=30");
+await connection.OpenAsync();
+var hub = PostgresService.For<IOrderHub>(connection);
+```
+
+依赖 [Npgsql](https://www.nuget.org/packages/Npgsql)。维护者设计说明见 [`docs/design/postgres.md`](docs/design/postgres.md)。
 
 ## 构建
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,10 +8,10 @@
 
 | 维度 | 现状 |
 |------|------|
-| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**（运行时 + 双路生成器 + 测试） |
+| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**（运行时 + 双路生成器 + 测试；Postgres 待 nuget.org 发版） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
 | nuget.org 已发 | **`0.1.0-preview6`** — **12 包**；**`0.1.0-preview7`** — **14 包**（+ Sse）；**`0.1.0-preview8`** — **16 包**（+ Nats）；**`0.1.0`** — **16 包**（稳定版）；**`0.1.1-preview1`** — 本地化 IntelliSense 预览；**`0.1.1`** — **16 包**（稳定版，`v0.1.1` tag + GitHub Release）；**`0.1.2`** — **16 包**（稳定版，`v0.1.2` tag + GitHub Release，含 Events 增量缓存 + 诊断描述符收敛）；**`0.1.3`** — 未发布（空 snupkg 被 nuget.org 拒绝）；**`0.1.4`** — **16 包** + **16 snupkg**（稳定版，`v0.1.4` tag，含符号包修复 + CI smoke job + RestAPI 常量统一 + E2E 端口修复 + RestAPI.Reactive 对齐 + Events Reactive 前缀统一） |
-| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（**16** 消费者） |
+| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（本地 manifest **18** 包 / 消费者，含 Postgres；nuget.org 仍为 **16**） |
 | 示例仓 CI | `Observables.Samples` Nuke `Ci`（NuGet `0.1.1`，已同步） |
 
 ### 已知工程债（详见 AGENTS.md「工程治理」）
@@ -42,8 +42,9 @@
 | `OBS7001`–`OBS7999` | Grpc | 使用中（7001–7008；7008 为内部 fail-safe） |
 | `OBS8001`–`OBS8999` | SSE | 使用中（8001–8007；8006 为内部 fail-safe） |
 | `OBS9001`–`OBS9999` | NATS | 使用中（9001–9008；9008 为内部 fail-safe） |
+| `OBS10001`–`OBS10999` | Postgres | 使用中（10001–10008；10008 为内部 fail-safe；10007 为空接口，Shared Analyzer） |
 
-当前共 **60** 个唯一诊断：**52** 个用户可行动诊断与 **8** 个内部 fail-safe 诊断。新增诊断须落入对应段并在 `AnalyzerReleases.Unshipped.md` 登记（见 AGENTS.md）。
+当前共 **68** 个唯一诊断（含 Postgres OBS10xxx）：前八域 **60** 个 + Postgres **8** 个。新增诊断须落入对应段并在 `AnalyzerReleases.Unshipped.md` 登记（见 AGENTS.md）。
 
 ## 里程碑
 
@@ -167,6 +168,14 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 ## Post-1.0 Follow-up（按需，不绑定版本）
 
 以下为 0.1.0 稳定版后的工程改进项，按优先级分组。不阻断发版，维护者有精力时按需处理。
+
+### P1 — 第九域 Postgres（ADR-002）
+
+| # | 行动项 | 状态 | 说明 |
+|---|--------|------|------|
+| P1-PG | Postgres LISTEN/NOTIFY Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + E2E（B-tier peer）+ PackVerify / nuget-smoke；设计文档 [`docs/design/postgres.md`](design/postgres.md)；README / CONTRIBUTING / ROADMAP 已同步 |
+| P1-PG-nuget | nuget.org 发第九域（+2 包 → 18） | 待维护者批准 | 勿擅自改 `PackageVersion` / tag；发版后 ADR-002 §6 mid-trigger 复审剩余 top-5 |
+| P1-PG-docs | Observables.Docs / Samples | 跨仓待办 | 用户站与 Samples 不在本仓本票范围 |
 
 ### P2 — 中期处理
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,7 @@
 | Grpc | [grpc.md](grpc.md) |
 | Sse | [sse.md](sse.md) |
 | Nats | [nats.md](nats.md) |
+| Postgres | [postgres.md](postgres.md) |
 
 ## 横切工程文档
 

--- a/docs/design/postgres.md
+++ b/docs/design/postgres.md
@@ -1,0 +1,146 @@
+# 设计：Postgres 域
+
+> 状态：主仓已实现（运行时 + 双路生成器 + Package + 三层测试）；**nuget.org 尚未发**第九域（本地 PackVerify / manifest 为 **18 包**，当前稳定版 `0.1.6` 仍为 **16 包**）。关联 Issue [#154](https://github.com/Skymly/Observables/issues/154) / [#160](https://github.com/Skymly/Observables/issues/160)。面向用户文档见 Observables.Docs（跨仓，未含在本票）。
+
+## 1. 动机与定位
+
+`Observables.Postgres` 将 **PostgreSQL LISTEN/NOTIFY**（[Npgsql](https://www.nuget.org/packages/Npgsql)）桥接为 interface-proxy IO 边界：
+
+| 边界 | 方向 | PostgreSQL | 反应式映射 |
+|------|------|------------|------------|
+| **Listen** | server → client（流） | `LISTEN` + `Wait`/`Notification` | 热流 `Observable<T>` / `IObservable<T>` 属性 |
+| **Notify** | client → server | `NOTIFY` / `pg_notify` | 冷流 `Observable<Unit>` / `IObservable<Unit>` 方法 |
+
+工程骨架以 **Nats / Mqtt** 为模板（`[Postgres]` → `*GeneratedProxy` + `ModuleInitializer` → `PostgresService.For<T>`）。排名依据 [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)（LISTEN/NOTIFY 白名单 #1）。
+
+## 2. 公共面
+
+### 属性
+
+| 属性 | 目标 | 说明 |
+|------|------|------|
+| `[Postgres]` | `interface` | 标记 LISTEN/NOTIFY 代理接口 |
+| `[Listen(string? channel = null)]` | `property` | LISTEN 通道；热通知流；未指定时回退成员名 |
+| `[Notify(string? channel = null)]` | `method` | NOTIFY 通道；冷发送流；未指定时回退成员名 |
+
+通道名须为 **编译期字面量**（或成员名回退）；须匹配 PostgreSQL 标识符规则 `[A-Za-z_][A-Za-z0-9_]*`（最长 63）。**禁止** `{param}` 占位符与非法标识符（OBS10001 / OBS10006）。
+
+### 运行时入口
+
+```csharp
+namespace Observables.Postgres;
+
+public static class PostgresService
+{
+    public static T For<T>(NpgsqlConnection connection);
+}
+```
+
+`For<T>` 接受已打开的 **专用** `NpgsqlConnection`。代理**不**释放该连接；连接生命周期应与 Listen 订阅 / `Wait` 循环对齐。
+
+### 消费者示例
+
+```csharp
+[Postgres]
+public interface IOrderHub
+{
+    [Listen("orders")]
+    Observable<string> Orders { get; }
+
+    [Notify("orders")]
+    Observable<Unit> PublishOrder(string payload, CancellationToken cancellationToken = default);
+}
+
+// Dedicated Listen connection: Pooling=false + keepalive (see §4)
+await using var connection = new NpgsqlConnection(
+    "Host=…;Database=…;Username=…;Password=…;Pooling=false;Keepalive=30");
+await connection.OpenAsync();
+var hub = PostgresService.For<IOrderHub>(connection);
+```
+
+Reactive 路径：成员返回 `IObservable<T>`，引用 `Observables.Postgres.Reactive`；桥接为 `SystemReactivePostgresAdapter`。
+
+## 3. 生成映射
+
+- Listen 属性 → `PostgresObservable.FromListen` / `FromListen<T>`（或 Reactive 适配器同名方法）
+- Notify 方法 → `PostgresObservable.FromNotify` / `FromNotify<T>`（空载荷、`string`、或序列化后的 `T`）
+
+## 4. 不变量：专用连接与 keepalive
+
+LISTEN 在会话上注册通道并占用连接上的 `Wait`/`WaitAsync` 循环，因此：
+
+1. **专用、非池化连接**：不要把从 `NpgsqlDataSource` / 连接池借来的连接用于长生命周期 Listen。优先 `Pooling=false`（或显式工厂打开专用连接）。
+2. **生命周期 = 订阅**：连接由调用方拥有；代理不 `Dispose` 连接。Listen 订阅结束时应 `UNLISTEN`（运行时尽力清理）并关闭/释放连接。
+3. **勿与并发命令共享**：同一连接上不要与 Listen 的 `Wait` 循环并行跑其它查询。
+4. **Keepalive（推荐）**：在专用 Listen 连接字符串上设置 Npgsql **`Keepalive`**（秒，例如 `Keepalive=30`），避免空闲 LISTEN 会话被中间设备或服务器超时断开。Notify 可用短生命周期连接或另一会话；不必与 Listen 共用同一连接。
+
+`PostgresService.For` 的 XML 注释与本设计文档均陈述上述不变量。
+
+## 5. Payload
+
+| 类型 | 行为 |
+|------|------|
+| `string` | 通知载荷原文透传 |
+| 其它 `T` | 默认 `System.Text.Json`（`JsonPostgresPayloadSerializer` / `PostgresPayload`） |
+| 自定义 | `PostgresPayloadSerializers.Register<T>(…)`（委托、`IPostgresPayloadSerializer` / `IPostgresPayloadSerializer<T>`） |
+
+原始原语路径见 `PrimitivePostgresPayloadSerializer`；trim/AOT 对 JSON 反射路径带 `RequiresUnreferencedCode` / `RequiresDynamicCode`。
+
+## 6. 诊断（OBS10xxx）
+
+| ID | 严重性 | 触发 |
+|----|--------|------|
+| OBS10001 | Warning | 缺少边界特性或 channel 非字面量 |
+| OBS10002 | Error | 未引用 `Observables.Postgres` |
+| OBS10003 | Error | 不支持的返回类型 |
+| OBS10004 | Error | 成员形态与特性不匹配（如 `[Listen]` 在方法上） |
+| OBS10005 | Error | `IObservable<T>` 需 `Observables.Postgres.Reactive` |
+| OBS10006 | Error | 非法 channel / 占位符 / Notify 参数形态 |
+| OBS10007 | Warning | 空 `[Postgres]` 接口（`EmptyProxyInterfaceAnalyzer`） |
+| OBS10008 | Error | 生成器内部 fail-safe |
+
+段分配权威见 `AGENTS.md` / `docs/ROADMAP.md`。OBS10007 在 Shared 分析器登记；其余在域 `DiagnosticDescriptors.cs`。
+
+## 7. 项目组成
+
+```
+Observables.Postgres/
+├── Observables.Postgres/
+├── Observables.Postgres.Reactive/
+├── Observables.Postgres.SourceGenerators.Shared/
+├── Observables.Postgres.R3.SourceGenerators/
+├── Observables.Postgres.Reactive.SourceGenerators/
+├── Observables.Postgres.Package/
+├── Observables.Postgres.R3.SourceGenerators.Tests/
+├── Observables.Postgres.Reactive.SourceGenerators.Tests/
+├── Observables.Postgres.Tests/
+└── Observables.Postgres.Reactive.Tests/
+```
+
+登记：`Observables.slnx` `/Postgres/`、`eng/Observables.BuildManifest.json`（本地 **18** 包）、`ProxyDomainCatalog`、`ci.yml` postgres 矩阵、`eng/nuget-smoke`。
+
+## 8. 测试
+
+- 生成器 Verify + OBS10xxx 诊断断言（R3 + Reactive）
+- E2E：B-tier 可移植 PostgreSQL 子进程（非 Docker 默认）；Listen 收跨会话 NOTIFY、Notify 被第二 LISTEN 观察到；typed JSON / 自定义序列化器往返
+- nuget-smoke：`Postgres.{R3,Reactive}.Consumer`
+
+## 9. 非目标（v1 显式排除）
+
+- **逻辑复制**（logical replication）、replication slot、LSN、output plugin
+- **结算类 API**：ack / offset / checkpoint / lease（ADR-002 白名单外）
+- Request/Reply 模拟、第三反应式后端
+- Redis / Diagnostic Source / RabbitMQ / AMQP 1.0（ADR-002 后续排名，另开 epic）
+- Docker/Testcontainers 作为本域默认 E2E 依赖
+
+## 10. Follow-up
+
+- nuget.org 发第九域（版本须维护者批准；发版后触发 ADR-002 §6 mid-trigger 复审剩余 top-5）
+- Observables.Docs `postgres.md` + `diagnostics.md` OBS10xxx；Observables.Samples.Postgres（跨仓）
+- JSON sourcegen / 更严格 AOT 友好载荷路径
+
+## 11. 参考
+
+- 仓库内范本：**Nats**、**Mqtt**
+- [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)
+- [Npgsql — Notifications](https://www.npgsql.org/doc/notification.html)


### PR DESCRIPTION
## Summary
- Add maintainer design doc `docs/design/postgres.md` covering Listen/Notify API, dedicated-connection + keepalive invariants, OBS10xxx diagnostics, and explicit non-goals (logical replication / settlement APIs).
- Sync root README, CONTRIBUTING, and ROADMAP so the ninth Postgres Feature is visible alongside other domains (nuget.org still 16 packages; local PackVerify 18).
- Closes #160.

## Test plan
- [ ] Docs-only PR: confirm CI changes job skips code test/pack matrices (or passes with no domain hits)
- [ ] Spot-check README Postgres sample and `docs/design/postgres.md` against shipped attributes / `PostgresService.For`
- [ ] Confirm CONTRIBUTING package table lists `Observables.Postgres.R3` / `.Reactive` as in-repo pending nuget.org

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no API, generator, or version bumps.
> 
> **Overview**
> **Docs-only** PR that surfaces the in-repo **Postgres** LISTEN/NOTIFY domain for maintainers and contributors without changing runtime or package versions.
> 
> Adds **`docs/design/postgres.md`** (API with `[Postgres]` / `[Listen]` / `[Notify]`, `PostgresService.For<T>`, dedicated non-pooled connection + **Keepalive** invariants, payload/serialization, **OBS10001–OBS10008**, project layout, tests, and explicit v1 non-goals). Indexes it from **`docs/design/README.md`**.
> 
> **README** tagline and domain table now include Postgres; new **Postgres（LISTEN/NOTIFY）** section with a sample aligned to shipped attributes. **CONTRIBUTING** adds Postgres to PR scope, splits **16 nuget.org** vs **18 local PackVerify** packages, and lists `Observables.Postgres.R3` / `.Reactive` as in-repo pending nuget.org. **ROADMAP** updates baseline (nine domains, **68** diagnostics), documents the **OBS10xxx** segment, and adds **P1 — Postgres** follow-up (code ✅, nuget/docs cross-repo pending).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75e2109fb1edbff29ad016fb1fd1d985d993011. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->