### PR TITLE
Mark Postgres 0.1.7 as shipped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 目标** `0.1.7`（**18 包**，含 Postgres；tag/Publish 待推送）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
-- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成；`0.1.7` 准备发第九域）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅；`0.1.7` = Postgres 第九域）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.7`（**18 包**，含 Postgres）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
+- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，0.1.7 稳定版已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres 第九域已发）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,16 +1,16 @@
 # Observables 路线图
 
-本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前发版目标 **`0.1.7`** = 第九域 Postgres）。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
+本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前稳定版 **`0.1.7`** = 第九域 Postgres（18 包））。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（`0.1.7` = Postgres 第九域）
+## 现状基线（`0.1.7` 已发 nuget.org）
 
 | 维度 | 现状 |
 |------|------|
 | 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**（运行时 + 双路生成器 + 测试） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
-| nuget.org | 至 **`0.1.6`** 为 **16 包**；**`0.1.7`** 目标 **18 包**（+ Postgres R3/Reactive；tag/Publish 见维护者步骤） |
+| nuget.org 已发 | **`0.1.7`** — **18 包**（+ Postgres R3/Reactive；`v0.1.7` tag + GitHub Release） |
 | 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（manifest **18** 包） |
 | 示例仓 CI | `Observables.Samples` Nuke `Ci`（对齐库版本；Postgres 样例见跨仓 #9） |
 
@@ -175,8 +175,8 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | # | 行动项 | 状态 | 说明 |
 |---|--------|------|------|
 | P1-PG | Postgres LISTEN/NOTIFY Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + E2E（B-tier peer）+ PackVerify / nuget-smoke；设计文档 [`docs/design/postgres.md`](design/postgres.md)；README / CONTRIBUTING / ROADMAP 已同步 |
-| P1-PG-nuget | nuget.org 发第九域（+2 包 → 18） | 🔄 `0.1.7` 准备中 | `PackageVersion=0.1.7`；推 `v0.1.7` + Publish + GitHub Release 后勾完成；发版后 ADR-002 §6 mid-trigger |
-| P1-PG-docs | Observables.Docs / Samples | 🔄 跨仓收尾 | Docs 去掉 pending；Samples [#9](https://github.com/Skymly/Observables.Samples/issues/9) |
+| P1-PG-nuget | nuget.org 发第九域（+2 包 → 18） | ✅ `0.1.7` | `v0.1.7` tag + nuget.org / GitHub Packages + GitHub Release；ADR-002 §6 mid-trigger 已记 |
+| P1-PG-docs | Observables.Docs / Samples | ✅ | Docs PR #13；Samples PR #10（关 #9） |
 
 ### P2 — 中期处理
 

--- a/docs/design/postgres.md
+++ b/docs/design/postgres.md
@@ -1,6 +1,6 @@
 # 设计：Postgres 域
 
-> 状态：主仓已实现（运行时 + 双路生成器 + Package + 三层测试）；发版目标 **`0.1.7`**（**18 包**，含本域）。关联 Issue [#154](https://github.com/Skymly/Observables/issues/154)。面向用户文档见 Observables.Docs。
+> 状态：已随 **`0.1.7`** 发至 nuget.org（**18 包**）。关联 Issue [#154](https://github.com/Skymly/Observables/issues/154)（已关闭）。面向用户文档见 Observables.Docs。
 
 ## 1. 动机与定位
 
@@ -135,8 +135,8 @@ Observables.Postgres/
 
 ## 10. Follow-up
 
-- 推 `v0.1.7` → nuget.org Publish + GitHub Release（维护者）；完成后 ADR-002 §6 mid-trigger（剩余 top-4：Redis / Diagnostic Source / RabbitMQ / AMQP 1.0）
-- Observables.Samples.Postgres（跨仓 [#9](https://github.com/Skymly/Observables.Samples/issues/9)）
+- ✅ `v0.1.7` 已发；ADR-002 §6 mid-trigger 已记（剩余 top-4：Redis / Diagnostic Source / RabbitMQ / AMQP 1.0）
+- ✅ Observables.Samples.Postgres（跨仓 [#9](https://github.com/Skymly/Observables.Samples/issues/9)）
 - JSON sourcegen / 更严格 AOT 友好载荷路径
 
 ## 11. 参考


### PR DESCRIPTION
## Summary
- Flip ROADMAP / AGENTS / postgres design status from `0.1.7` preparing → shipped after `v0.1.7` Publish.

## Test plan
- [ ] Docs-only; no code change

Made with [Cursor](https://cursor.com)