### PR TITLE
Redis: Garnet Pub/Sub capability spike (#170)

### DIFF
--- a/eng/spikes/GarnetPubSub/Directory.Build.props
+++ b/eng/spikes/GarnetPubSub/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <!-- Spike harness only: do not inherit repo ProjectDefaults / CPM. -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/eng/spikes/GarnetPubSub/Directory.Packages.props
+++ b/eng/spikes/GarnetPubSub/Directory.Packages.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- Keep Microsoft.Garnet / StackExchange.Redis out of the repo-root CPM and pack graphs. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/eng/spikes/GarnetPubSub/GarnetPubSub.Spike.csproj
+++ b/eng/spikes/GarnetPubSub/GarnetPubSub.Spike.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>GarnetPubSub.Spike</RootNamespace>
+    <AssemblyName>GarnetPubSub.Spike</AssemblyName>
+    <Description>Issue #170 spike: prove Garnet in-process classic Redis Pub/Sub for Observables.Redis E2E.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Test/tooling only — must never appear on Observables.*.Package dependency graphs. -->
+    <PackageReference Include="Microsoft.Garnet" Version="2.1.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
+  </ItemGroup>
+
+</Project>

--- a/eng/spikes/GarnetPubSub/Program.cs
+++ b/eng/spikes/GarnetPubSub/Program.cs
@@ -1,0 +1,229 @@
+﻿using System.Net;
+using System.Net.Sockets;
+using Garnet;
+using StackExchange.Redis;
+
+// Issue #170 — Garnet Pub/Sub capability spike (SUBSCRIBE / PSUBSCRIBE / PUBLISH).
+// Seam: StackExchange.Redis ISubscriber against in-process Microsoft.Garnet GarnetServer.
+// No Observables.Redis product API.
+
+var workDir = Path.Combine(Path.GetTempPath(), "observables-garnet-pubsub-spike", Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(workDir);
+
+var port = ReserveFreeTcpPort();
+var results = new List<(string Family, bool Pass, string Detail)>();
+
+Console.WriteLine($"Garnet Pub/Sub spike (#170)");
+Console.WriteLine($"  workDir = {workDir}");
+Console.WriteLine($"  port    = {port}");
+Console.WriteLine();
+
+GarnetServer? server = null;
+try
+{
+    server = new GarnetServer(
+        [
+            "--bind", "127.0.0.1",
+            "--port", port.ToString(),
+            "--memory", "16m",
+            "--page", "8k",
+            "--segment", "1m",
+            "--index", "8m",
+            "--checkpointdir", workDir,
+            "--logger-level", "Error",
+            "--disable-console-logger", "true",
+        ],
+        cleanupDir: true);
+
+    server.Start();
+    Console.WriteLine("GarnetServer.Start() OK");
+    Console.WriteLine();
+
+    var config = ConfigurationOptions.Parse($"127.0.0.1:{port}");
+    config.AbortOnConnectFail = true;
+    config.ConnectTimeout = 5000;
+    config.SyncTimeout = 5000;
+    config.AsyncTimeout = 5000;
+    config.AllowAdmin = false;
+
+    await using var mux = await ConnectionMultiplexer.ConnectAsync(config).ConfigureAwait(false);
+    var subscriber = mux.GetSubscriber();
+
+    results.Add(await ProbeExactSubscribeAsync(subscriber).ConfigureAwait(false));
+    results.Add(await ProbePatternSubscribeAsync(subscriber).ConfigureAwait(false));
+    results.Add(await ProbePublishFanoutAsync(subscriber).ConfigureAwait(false));
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"FATAL: {ex.GetType().Name}: {ex.Message}");
+    Console.WriteLine(ex);
+    results.Add(("bootstrap", false, ex.Message));
+}
+finally
+{
+    try
+    {
+        server?.Dispose();
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Dispose warning: {ex.Message}");
+    }
+
+    try
+    {
+        if (Directory.Exists(workDir))
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+    catch
+    {
+        // best-effort cleanup
+    }
+}
+
+Console.WriteLine();
+Console.WriteLine("Results");
+Console.WriteLine("-------");
+foreach (var (family, pass, detail) in results)
+{
+    Console.WriteLine($"{(pass ? "PASS" : "FAIL"),-4}  {family,-28}  {detail}");
+}
+
+var allPass = results.Count > 0 && results.TrueForAll(static r => r.Pass);
+Console.WriteLine();
+Console.WriteLine(allPass
+    ? "DECISION: Garnet locked for Observables.Redis E2E (classic SUBSCRIBE / PSUBSCRIBE / PUBLISH)."
+    : "DECISION: Garnet NOT locked — use a documented fallback (portable redis-server / other) for E2E.");
+Console.WriteLine(allPass ? "OVERALL: PASS" : "OVERALL: FAIL");
+
+return allPass ? 0 : 1;
+
+static async Task<(string Family, bool Pass, string Detail)> ProbeExactSubscribeAsync(ISubscriber subscriber)
+{
+    const string family = "SUBSCRIBE (exact)";
+    var channel = RedisChannel.Literal($"obs-spike-exact-{Guid.NewGuid():N}");
+    const string payload = "exact-hello";
+    var received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    try
+    {
+        await subscriber.SubscribeAsync(channel, (_, value) =>
+        {
+            received.TrySetResult(value.ToString());
+        }).ConfigureAwait(false);
+
+        // Give the subscription handshake a moment before publish.
+        await Task.Delay(100).ConfigureAwait(false);
+
+        var receivers = await subscriber.PublishAsync(channel, payload).ConfigureAwait(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var message = await received.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await subscriber.UnsubscribeAsync(channel).ConfigureAwait(false);
+
+        if (!string.Equals(message, payload, StringComparison.Ordinal))
+        {
+            return (family, false, $"payload mismatch: got '{message}', receivers={receivers}");
+        }
+
+        return (family, true, $"payload OK, Publish receivers={receivers}");
+    }
+    catch (Exception ex)
+    {
+        return (family, false, $"{ex.GetType().Name}: {ex.Message}");
+    }
+}
+
+static async Task<(string Family, bool Pass, string Detail)> ProbePatternSubscribeAsync(ISubscriber subscriber)
+{
+    const string family = "PSUBSCRIBE (pattern)";
+    var token = Guid.NewGuid().ToString("N")[..8];
+    var pattern = RedisChannel.Pattern($"obs-spike-{token}:*");
+    var concrete = RedisChannel.Literal($"obs-spike-{token}:news");
+    const string payload = "pattern-hello";
+    var received = new TaskCompletionSource<(string Channel, string Payload)>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    try
+    {
+        await subscriber.SubscribeAsync(pattern, (ch, value) =>
+        {
+            received.TrySetResult((ch.ToString(), value.ToString()));
+        }).ConfigureAwait(false);
+
+        await Task.Delay(100).ConfigureAwait(false);
+
+        var receivers = await subscriber.PublishAsync(concrete, payload).ConfigureAwait(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (channel, message) = await received.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await subscriber.UnsubscribeAsync(pattern).ConfigureAwait(false);
+
+        if (!string.Equals(message, payload, StringComparison.Ordinal))
+        {
+            return (family, false, $"payload mismatch: got '{message}' on '{channel}', receivers={receivers}");
+        }
+
+        if (!string.Equals(channel, concrete.ToString(), StringComparison.Ordinal))
+        {
+            return (family, false, $"channel mismatch: got '{channel}', expected '{concrete}', receivers={receivers}");
+        }
+
+        return (family, true, $"matched channel '{channel}', Publish receivers={receivers}");
+    }
+    catch (Exception ex)
+    {
+        return (family, false, $"{ex.GetType().Name}: {ex.Message}");
+    }
+}
+
+static async Task<(string Family, bool Pass, string Detail)> ProbePublishFanoutAsync(ISubscriber subscriber)
+{
+    const string family = "PUBLISH (fan-out)";
+    var channel = RedisChannel.Literal($"obs-spike-pub-{Guid.NewGuid():N}");
+    const string payload = "publish-hello";
+    var a = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var b = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    try
+    {
+        await subscriber.SubscribeAsync(channel, (_, value) => a.TrySetResult(value.ToString())).ConfigureAwait(false);
+        // Second subscription on the same multiplexer still exercises PUBLISH delivery count.
+        await subscriber.SubscribeAsync(channel, (_, value) => b.TrySetResult(value.ToString())).ConfigureAwait(false);
+
+        await Task.Delay(100).ConfigureAwait(false);
+
+        var receivers = await subscriber.PublishAsync(channel, payload).ConfigureAwait(false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var msgA = await a.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        var msgB = await b.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+
+        await subscriber.UnsubscribeAsync(channel).ConfigureAwait(false);
+
+        if (!string.Equals(msgA, payload, StringComparison.Ordinal) || !string.Equals(msgB, payload, StringComparison.Ordinal))
+        {
+            return (family, false, $"payload mismatch a='{msgA}' b='{msgB}', receivers={receivers}");
+        }
+
+        return (family, true, $"both handlers received payload, Publish receivers={receivers}");
+    }
+    catch (Exception ex)
+    {
+        return (family, false, $"{ex.GetType().Name}: {ex.Message}");
+    }
+}
+
+static int ReserveFreeTcpPort()
+{
+    var listener = new TcpListener(IPAddress.Loopback, 0);
+    listener.Start();
+    try
+    {
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+    finally
+    {
+        listener.Stop();
+    }
+}

--- a/eng/spikes/GarnetPubSub/Program.cs
+++ b/eng/spikes/GarnetPubSub/Program.cs
@@ -51,7 +51,7 @@ try
 
     results.Add(await ProbeExactSubscribeAsync(subscriber).ConfigureAwait(false));
     results.Add(await ProbePatternSubscribeAsync(subscriber).ConfigureAwait(false));
-    results.Add(await ProbePublishFanoutAsync(subscriber).ConfigureAwait(false));
+    results.Add(await ProbePublishAsync(subscriber).ConfigureAwait(false));
 }
 catch (Exception ex)
 {
@@ -109,13 +109,11 @@ static async Task<(string Family, bool Pass, string Detail)> ProbeExactSubscribe
 
     try
     {
+        // SubscribeAsync completes after the server acknowledges SUBSCRIBE.
         await subscriber.SubscribeAsync(channel, (_, value) =>
         {
             received.TrySetResult(value.ToString());
         }).ConfigureAwait(false);
-
-        // Give the subscription handshake a moment before publish.
-        await Task.Delay(100).ConfigureAwait(false);
 
         var receivers = await subscriber.PublishAsync(channel, payload).ConfigureAwait(false);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -152,8 +150,6 @@ static async Task<(string Family, bool Pass, string Detail)> ProbePatternSubscri
             received.TrySetResult((ch.ToString(), value.ToString()));
         }).ConfigureAwait(false);
 
-        await Task.Delay(100).ConfigureAwait(false);
-
         var receivers = await subscriber.PublishAsync(concrete, payload).ConfigureAwait(false);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var (channel, message) = await received.Task.WaitAsync(cts.Token).ConfigureAwait(false);
@@ -178,35 +174,38 @@ static async Task<(string Family, bool Pass, string Detail)> ProbePatternSubscri
     }
 }
 
-static async Task<(string Family, bool Pass, string Detail)> ProbePublishFanoutAsync(ISubscriber subscriber)
+static async Task<(string Family, bool Pass, string Detail)> ProbePublishAsync(ISubscriber subscriber)
 {
-    const string family = "PUBLISH (fan-out)";
+    const string family = "PUBLISH";
     var channel = RedisChannel.Literal($"obs-spike-pub-{Guid.NewGuid():N}");
     const string payload = "publish-hello";
-    var a = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-    var b = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+    var received = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
     try
     {
-        await subscriber.SubscribeAsync(channel, (_, value) => a.TrySetResult(value.ToString())).ConfigureAwait(false);
-        // Second subscription on the same multiplexer still exercises PUBLISH delivery count.
-        await subscriber.SubscribeAsync(channel, (_, value) => b.TrySetResult(value.ToString())).ConfigureAwait(false);
-
-        await Task.Delay(100).ConfigureAwait(false);
+        // Dedicated publish probe: one subscriber, assert Publish returns receivers >= 1 and payload arrives.
+        await subscriber.SubscribeAsync(channel, (_, value) =>
+        {
+            received.TrySetResult(value.ToString());
+        }).ConfigureAwait(false);
 
         var receivers = await subscriber.PublishAsync(channel, payload).ConfigureAwait(false);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var msgA = await a.Task.WaitAsync(cts.Token).ConfigureAwait(false);
-        var msgB = await b.Task.WaitAsync(cts.Token).ConfigureAwait(false);
+        var message = await received.Task.WaitAsync(cts.Token).ConfigureAwait(false);
 
         await subscriber.UnsubscribeAsync(channel).ConfigureAwait(false);
 
-        if (!string.Equals(msgA, payload, StringComparison.Ordinal) || !string.Equals(msgB, payload, StringComparison.Ordinal))
+        if (receivers < 1)
         {
-            return (family, false, $"payload mismatch a='{msgA}' b='{msgB}', receivers={receivers}");
+            return (family, false, $"Publish reported receivers={receivers} (expected >= 1)");
         }
 
-        return (family, true, $"both handlers received payload, Publish receivers={receivers}");
+        if (!string.Equals(message, payload, StringComparison.Ordinal))
+        {
+            return (family, false, $"payload mismatch: got '{message}', receivers={receivers}");
+        }
+
+        return (family, true, $"payload OK, Publish receivers={receivers}");
     }
     catch (Exception ex)
     {

--- a/eng/spikes/GarnetPubSub/README.md
+++ b/eng/spikes/GarnetPubSub/README.md
@@ -1,0 +1,27 @@
+# Garnet Pub/Sub spike (#170)
+
+Runnable probe for the Observables.Redis E2E server decision.
+
+## What it proves
+
+Against an **in-process** `Microsoft.Garnet` `GarnetServer`, using `StackExchange.Redis`:
+
+| Command family | Client API |
+|----------------|------------|
+| Exact subscribe | `SUBSCRIBE` via `ISubscriber.SubscribeAsync(RedisChannel.Literal(...))` |
+| Pattern subscribe | `PSUBSCRIBE` via `ISubscriber.SubscribeAsync(RedisChannel.Pattern(...))` |
+| Publish | `PUBLISH` via `ISubscriber.PublishAsync(...)` |
+
+## Run
+
+```powershell
+dotnet run --project eng/spikes/GarnetPubSub/GarnetPubSub.Spike.csproj -c Release
+```
+
+Exit code `0` = all families passed; non-zero = fail (use a documented fallback server for Redis E2E).
+
+## Constraints
+
+- Spike / tooling only — **not** registered in `eng/Observables.BuildManifest.json`
+- Packages are pinned locally (`ManagePackageVersionsCentrally=false`); **do not** add `Microsoft.Garnet` to pack dependency graphs
+- No `Observables.Redis` product API surface


### PR DESCRIPTION
## Summary
- Add `eng/spikes/GarnetPubSub` in-process probe for classic Redis Pub/Sub (`SUBSCRIBE` / `PSUBSCRIBE` / `PUBLISH`) against Microsoft Garnet via StackExchange.Redis
- Record pass/fail + **Garnet locked** E2E server decision on #170; keep Garnet test/tooling-only (local CPM opt-out, not in BuildManifest / pack graphs)
- No Observables.Redis product API surface

## Test plan
- [x] `dotnet run --project eng/spikes/GarnetPubSub/GarnetPubSub.Spike.csproj -c Release` → OVERALL PASS
- [ ] CI green on this PR (eng-only; expect Shared/domain matrices to skip or be unaffected)
- [x] Results commented on https://github.com/Skymly/Observables/issues/170

Closes #170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Eng-only spike with isolated MSBuild/package wiring; no production Redis API or shared dependency graph changes.
> 
> **Overview**
> Adds **`eng/spikes/GarnetPubSub`**, a standalone console probe for issue #170 that starts an in-process **Microsoft.Garnet** server and exercises classic Redis Pub/Sub through **StackExchange.Redis** (`SUBSCRIBE`, `PSUBSCRIBE`, `PUBLISH`). The harness prints per-family pass/fail and exits **0** only when all probes succeed, with a console **DECISION** line on whether Garnet is locked for Observables.Redis E2E.
> 
> Isolation is explicit: local **`Directory.Build.props`** / **`Directory.Packages.props`** opt out of repo CPM and shared defaults; **Garnet** and **StackExchange.Redis** are pinned only on this spike project and are documented as **not** for pack graphs or **`Observables.BuildManifest.json`**. No Observables.Redis product API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915b5ba894792c26e53d33226338317ba7eb8898. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->