### PR TITLE
Complete mattpocock skills setup with triage labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,10 @@ Agent 行为准则——与「与用户沟通」并行生效：
 
 GitHub Issues, routed by surface: library → `Skymly/Observables`; user Docs → `Skymly/Observables.Docs`; Samples → `Skymly/Observables.Samples`; GitPulse only when that repo is the work. See `docs/agents/issue-tracker.md`.
 
+### Triage labels
+
+Default five roles: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
 ### Domain docs
 
 This is a single-context repository using root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finish `/setup-matt-pocock-skills` for this repo:

- Keep existing multi-repo GitHub issue tracker config (`docs/agents/issue-tracker.md`)
- Keep existing single-context domain docs (`docs/agents/domain.md`)
- Add default triage label mapping (`docs/agents/triage-labels.md`)
- Update `AGENTS.md` `## Agent skills` with a Triage labels subsection

## Related Issue

N/A — agent skills bootstrap.

## Solution module

- [x] Solution Items only
- [x] Docs (maintainer `docs/agents/`)

## Type of change

- [x] Docs / repo metadata only

## Test plan

- [x] Confirmed `docs/agents/{issue-tracker,domain,triage-labels}.md` present
- [x] Confirmed `AGENTS.md` Agent skills block includes Issue tracker / Triage labels / Domain docs
- [ ] GitHub labels `needs-triage`, `needs-info`, `ready-for-human` still need maintainer creation (API 403 from this agent); `ready-for-agent` and `wontfix` already exist

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module (see [AGENTS.md](AGENTS.md))
- [x] Commit messages are in **English**
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [x] No documentation changes needed (user Docs site)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a32ec94-bf8c-498d-9673-71f735e21a68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a32ec94-bf8c-498d-9673-71f735e21a68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

