### PR TITLE
Redis: OBS11xxx diagnostic matrix (R3 generator) (#173)

### DIFF
--- a/Observables.Redis/Observables.Redis.R3.SourceGenerators.Tests/GeneratorFailSafeTests.cs
+++ b/Observables.Redis/Observables.Redis.R3.SourceGenerators.Tests/GeneratorFailSafeTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+using Observables.Redis.Generators;
+using Observables.SourceGenerators.Shared;
+
+namespace Observables.Redis.R3.SourceGenerators.Tests;
+
+public sealed class GeneratorFailSafeTests
+{
+    [Fact]
+    public void ExecuteParse_converts_exception_to_internal_diagnostic()
+    {
+        var (diagnostics, model) = GeneratorFailSafe.ExecuteParse(
+            () => throw new InvalidOperationException("probe"),
+            DiagnosticDescriptors.InternalGeneratorError,
+            () => new ContextGenerationModel(ImmutableEquatableArray.Empty<RedisInterfaceModel>()));
+
+        Assert.Single(diagnostics);
+        Assert.Equal("OBS11008", diagnostics[0].Id);
+        Assert.Contains("InvalidOperationException", diagnostics[0].GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("probe", diagnostics[0].GetMessage(), StringComparison.Ordinal);
+        Assert.Empty(model.Interfaces);
+    }
+
+    [Fact]
+    public void TryEmit_converts_exception_to_internal_diagnostic()
+    {
+        Diagnostic? reported = null;
+        GeneratorFailSafe.TryEmit(
+            () => throw new InvalidOperationException("emit probe"),
+            d => reported = d,
+            DiagnosticDescriptors.InternalGeneratorError);
+
+        Assert.NotNull(reported);
+        Assert.Equal("OBS11008", reported.Id);
+        Assert.Contains("emit probe", reported.GetMessage(), StringComparison.Ordinal);
+    }
+}

--- a/Observables.Redis/Observables.Redis.R3.SourceGenerators.Tests/RedisInterfaceGeneratorTests.cs
+++ b/Observables.Redis/Observables.Redis.R3.SourceGenerators.Tests/RedisInterfaceGeneratorTests.cs
@@ -71,4 +71,182 @@ public sealed class RedisInterfaceGeneratorTests
         var output = GeneratorTestHarness.Run(userSource);
         return Verifier.Verify(GeneratorTestHarness.ToSnapshot(output));
     }
+
+    [Fact]
+    public void Redis_interface_OBS11001_on_unannotated_member()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                Observable<Unit> Publish(string topic, string payload);
+
+                [RedisSubscribe("news.alerts")]
+                Observable<string> Alerts { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11001", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11001_on_non_literal_channel()
+    {
+        const string userSource =
+            """
+            public static class Channels
+            {
+                public const string Alerts = "news.alerts";
+            }
+
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisSubscribe(Channels.Alerts)]
+                Observable<string> Alerts { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11001", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11002_when_runtime_missing()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisSubscribe("news.alerts")]
+                Observable<string> Alerts { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource, includeCoreReference: false);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11002", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11003_on_unsupported_return_type()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisPublish("news.alerts")]
+                Observable<string> Publish(string payload);
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11003", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11004_on_subscribe_method()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisSubscribe("news.alerts")]
+                Observable<string> Alerts();
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11004", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11004_on_publish_property()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisPublish("news.alerts")]
+                Observable<Unit> Publish { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11004", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11005_on_iobservable_with_r3_generator()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisSubscribe("news.alerts")]
+                IObservable<string> Alerts { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11005", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11006_on_subscribe_placeholder()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisSubscribe("news.{topic}")]
+                Observable<string> Alerts { get; }
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11006", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Redis_interface_OBS11006_on_publish_pattern_metacharacters()
+    {
+        const string userSource =
+            """
+            [Redis]
+            public interface INewsHub
+            {
+                [RedisPublish("news.*")]
+                Observable<Unit> Publish(string payload);
+            }
+            """;
+
+        var output = GeneratorTestHarness.Run(userSource);
+        var snapshot = GeneratorTestHarness.ToSnapshot(output);
+
+        Assert.Contains("OBS11006", snapshot, StringComparison.Ordinal);
+    }
 }

--- a/Observables.Redis/Observables.Redis.R3.SourceGenerators/Observables.Redis.R3.SourceGenerators.csproj
+++ b/Observables.Redis/Observables.Redis.R3.SourceGenerators/Observables.Redis.R3.SourceGenerators.csproj
@@ -11,6 +11,10 @@
     <PackageReference Include="R3" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Observables.Redis.R3.SourceGenerators.Tests" />
+  </ItemGroup>
+
   <Import Project="..\Observables.Redis.SourceGenerators.Shared\Observables.Redis.SourceGenerators.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
@@ -463,19 +463,29 @@ internal static class Parser
             return true;
         }
 
-        if (attribute.ConstructorArguments.Length == 0
-            || attribute.ConstructorArguments[0].IsNull)
+        var attributeSyntax = attribute.ApplicationSyntaxReference?.GetSyntax() as AttributeSyntax;
+        var argument = attributeSyntax?.ArgumentList?.Arguments.FirstOrDefault();
+        if (argument is null)
         {
             return true;
         }
 
-        if (attribute.ConstructorArguments[0].Value is string literal && !string.IsNullOrWhiteSpace(literal))
+        if (argument.Expression is LiteralExpressionSyntax literal
+            && literal.Token.IsKind(SyntaxKind.StringLiteralToken)
+            && literal.Token.Value is string text
+            && !string.IsNullOrWhiteSpace(text))
         {
-            channelTemplate = literal;
+            channelTemplate = text;
             return true;
         }
 
-        badLocation = attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation();
+        if (argument.Expression is LiteralExpressionSyntax nullLiteral
+            && nullLiteral.Token.IsKind(SyntaxKind.NullKeyword))
+        {
+            return true;
+        }
+
+        badLocation = argument.GetLocation();
         return false;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Locks the Redis domain generator diagnostic matrix (`OBS11xxx`) with R3 generator tests and aligns Channel template parsing with Postgres so non-literal Channel arguments fail at compile time.

## Related Issue

Closes #173

## Solution module

- [x] Redis (single `/Redis/` module only)

## Type of change

- [x] Source generator / diagnostic change
- [x] Feature

## What changed

- R3 generator tests assert user-facing IDs: `OBS11001`–`OBS11006` (missing boundary / non-literal Channel, missing runtime, unsupported return, shape mismatch, Reactive required for `IObservable<T>`, Subscribe `{param}`, Publish Pattern metacharacters)
- `GeneratorFailSafeTests` lock `OBS11008` via shared `GeneratorFailSafe` (`ExecuteParse` / `TryEmit`, sibling SignalR unit pattern)
- `InternalsVisibleTo` for the R3 generator test project
- `Parser.TryResolveChannelTemplate` now requires a **syntax** string literal (const/`nameof` → `OBS11001`), matching Postgres `TryGetLiteralChannel` — needed so OBS11001 “non-literal Channel template” is actually reachable under C# attribute constant rules
- Descriptors + `AnalyzerReleases.Unshipped.md` were already registered in the vertical slice; left unchanged (`OBS11007` empty-proxy remains Shared)

## Test plan

- [x] `dotnet test Observables.Redis/Observables.Redis.R3.SourceGenerators.Tests` (Release) — **14 passed**
- [x] Filter `OBS110|FailSafe` — **11 passed**

## Breaking changes

- [x] None for happy-path string literals / omitted Channel
- Note: Channel templates that previously accepted const/`nameof` string arguments now emit `OBS11001` (intentional; matches Postgres and the OBS11001 descriptor text)

## Checklist

- [x] This PR touches **only one** solution module (Redis)
- [x] Commit messages are in **English**
- [x] No version bumps, tags, releases, or NuGet publish steps
- [ ] Design Doc — maintainer `docs/design/redis.md` not yet present (parent #169); no Docs/Samples change in this library PR
- [x] No user-facing Docs/Samples changes in this PR

## Code review (implement skill)

- **Standards:** no hard violations; test duplication matches Postgres/SignalR patterns
- **Spec:** AC matrix covered; fail-safe covered at unit seam (SignalR also has a generator-harness probe — not required by other sibling domains); syntax-literal change intentional vs Postgres / OBS11001 wording
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6da46dc1-03a0-46ce-a4b2-69345450313f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6da46dc1-03a0-46ce-a4b2-69345450313f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

