### PR TITLE
Shared: register Redis in proxy catalog, OBS0001, OBS11007

### DIFF
--- a/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/EmptyProxyInterfaceAnalyzerTests.cs
@@ -180,6 +180,37 @@ public sealed class EmptyProxyInterfaceAnalyzerTests
     }
 
     [Fact]
+    public void OBS11007_on_empty_redis_interface()
+    {
+        const string source =
+            """
+            using Observables.Redis;
+
+            [Redis]
+            public interface IChannels
+            {
+            }
+            """;
+
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            BuildSource(source, "Observables.Redis"),
+            additionalReferences: [AnalyzerTestHarness.CreateReference<global::Observables.Redis.RedisAttribute>()],
+            new EmptyProxyInterfaceAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "OBS11007");
+    }
+
+    [Fact]
+    public void ProxyDomainCatalog_Redis_lists_publish_and_subscribe_suggestions()
+    {
+        var domain = ProxyDomainCatalog.Redis;
+        Assert.Equal("OBS11007", domain.EmptyInterfaceDescriptor.Id);
+        Assert.Equal("Observables.Redis.RedisAttribute", domain.InterfaceMarkerMetadataName);
+        Assert.Contains(domain.MethodAttributes, s => s.DisplayText == "RedisPublish");
+        Assert.Contains(domain.PropertyAttributes, s => s.DisplayText == "RedisSubscribe");
+    }
+
+    [Fact]
     public void OBS3007_on_empty_restapi_interface()
     {
         const string source =

--- a/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
+++ b/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
@@ -21,6 +21,8 @@
     <ProjectReference Include="..\..\Observables.Mqtt\Observables.Mqtt\Observables.Mqtt.csproj" />
     <ProjectReference Include="..\..\Observables.Nats\Observables.Nats\Observables.Nats.csproj" />
     <ProjectReference Include="..\..\Observables.Postgres\Observables.Postgres\Observables.Postgres.csproj" />
+    <ProjectReference Include="..\..\Observables.Redis\Observables.Redis\Observables.Redis.csproj" />
+    <ProjectReference Include="..\..\Observables.Redis\Observables.Redis.Reactive\Observables.Redis.Reactive.csproj" />
     <ProjectReference Include="..\..\Observables.WebSocket\Observables.WebSocket\Observables.WebSocket.csproj" />
     <ProjectReference Include="..\..\Observables.RestAPI\Observables.RestAPI\Observables.RestAPI.csproj" />
     <ProjectReference Include="..\..\Observables.Grpc\Observables.Grpc\Observables.Grpc.csproj" />

--- a/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
@@ -28,6 +28,28 @@ public sealed class ReactivePackageConflictAnalyzerTests
     }
 
     [Fact]
+    public void OBS0001_when_r3_and_redis_reactive_are_referenced()
+    {
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            """
+            namespace Test;
+
+            public interface IMarker { }
+            """,
+            additionalReferences:
+            [
+                AnalyzerTestHarness.CreateReference<global::R3.Unit>(),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.Redis.RedisAttribute)),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.Redis.Reactive.SystemReactiveRedisAdapter)),
+            ],
+            new ReactivePackageConflictAnalyzer());
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Id == "OBS0001" && d.GetMessage().Contains("Redis", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void No_OBS0001_when_only_r3_is_referenced()
     {
         var diagnostics = AnalyzerTestHarness.RunAnalyzers(

--- a/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Observables.Shared/Observables.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+OBS11007 | Observables.Redis | Warning | Empty Redis proxy interface

--- a/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
+++ b/Observables.Shared/Observables.Analyzers/DiagnosticDescriptors.cs
@@ -94,6 +94,17 @@ internal static class DiagnosticDescriptors
             description: "Empty [Postgres] interface.",
             helpLinkUri: DiagnosticHelpLink.For("OBS10007"));
 
+    public static readonly DiagnosticDescriptor EmptyRedisInterface =
+        new(
+            "OBS11007",
+            "Empty Redis proxy interface",
+            "Interface '{0}' is marked with [Redis] but declares no members. Add Redis Pub/Sub boundary members or remove [Redis].",
+            "Observables.Redis",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Empty [Redis] interface.",
+            helpLinkUri: DiagnosticHelpLink.For("OBS11007"));
+
     public static readonly DiagnosticDescriptor EmptyRestApiInterface =
         new(
             "OBS3007",

--- a/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
+++ b/Observables.Shared/Observables.Analyzers/EmptyProxyInterfaceAnalyzer.cs
@@ -16,6 +16,7 @@ public sealed class EmptyProxyInterfaceAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.EmptySseInterface,
             DiagnosticDescriptors.EmptyNatsInterface,
             DiagnosticDescriptors.EmptyPostgresInterface,
+            DiagnosticDescriptors.EmptyRedisInterface,
             DiagnosticDescriptors.EmptyRestApiInterface);
 
     public override void Initialize(AnalysisContext context)

--- a/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
+++ b/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
@@ -142,6 +142,20 @@ internal static class ProxyDomainCatalog
             new BoundaryAttributeSuggestion("Listen", "Listen"),
         ]);
 
+    internal static readonly ProxyDomain Redis = new(
+        displayName: "Redis",
+        interfaceMarkerMetadataName: "Observables.Redis.RedisAttribute",
+        reactiveAdapterMetadataName: "Observables.Redis.Reactive.SystemReactiveRedisAdapter",
+        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyRedisInterface,
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("RedisPublish", "RedisPublish"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("RedisSubscribe", "RedisSubscribe"),
+        ]);
+
     internal static readonly ProxyDomain RestApi = new(
         displayName: "RestAPI",
         interfaceMarkerMetadataName: "Observables.RestAPI.RestApiAttribute",
@@ -150,10 +164,11 @@ internal static class ProxyDomainCatalog
         methodAttributes: [],
         propertyAttributes: []);
 
-    internal static readonly IReadOnlyList<ProxyDomain> InterfaceProxyDomains = [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, RestApi];
+    internal static readonly IReadOnlyList<ProxyDomain> InterfaceProxyDomains =
+        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, RestApi];
 
     internal static readonly IReadOnlyList<ProxyDomain> ReactiveConflictDomains =
-        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, RestApi];
+        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, RestApi];
 
     internal static readonly string[] RestApiHttpMethodNames =
         ["Get", "Post", "Put", "Delete", "Patch", "Head", "Options"];

--- a/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
+++ b/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
@@ -22,13 +22,5 @@ internal static class ReactivePackageConflictDetection
         HasAssemblyReference(compilation, "R3");
 
     internal static bool HasReactiveBridgeReference(Compilation compilation, ProxyDomainCatalog.ProxyDomain domain) =>
-        domain switch
-        {
-            { DisplayName: "SignalR" } => HasAssemblyReference(compilation, "Observables.SignalR.Reactive"),
-            { DisplayName: "Mqtt" } => HasAssemblyReference(compilation, "Observables.Mqtt.Reactive"),
-            { DisplayName: "WebSocket" } => HasAssemblyReference(compilation, "Observables.WebSocket.Reactive"),
-            { DisplayName: "Grpc" } => HasAssemblyReference(compilation, "Observables.Grpc.Reactive"),
-            { DisplayName: "RestAPI" } => HasAssemblyReference(compilation, "Observables.RestAPI.Reactive"),
-            _ => false,
-        };
+        HasAssemblyReference(compilation, $"Observables.{domain.DisplayName}.Reactive");
 }

--- a/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
+++ b/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
@@ -22,5 +22,14 @@ internal static class ReactivePackageConflictDetection
         HasAssemblyReference(compilation, "R3");
 
     internal static bool HasReactiveBridgeReference(Compilation compilation, ProxyDomainCatalog.ProxyDomain domain) =>
-        HasAssemblyReference(compilation, $"Observables.{domain.DisplayName}.Reactive");
+        domain switch
+        {
+            { DisplayName: "SignalR" } => HasAssemblyReference(compilation, "Observables.SignalR.Reactive"),
+            { DisplayName: "Mqtt" } => HasAssemblyReference(compilation, "Observables.Mqtt.Reactive"),
+            { DisplayName: "WebSocket" } => HasAssemblyReference(compilation, "Observables.WebSocket.Reactive"),
+            { DisplayName: "Grpc" } => HasAssemblyReference(compilation, "Observables.Grpc.Reactive"),
+            { DisplayName: "RestAPI" } => HasAssemblyReference(compilation, "Observables.RestAPI.Reactive"),
+            { DisplayName: "Redis" } => HasAssemblyReference(compilation, "Observables.Redis.Reactive"),
+            _ => false,
+        };
 }

--- a/Observables.Shared/Observables.CodeFixes.Tests/ObservablesPackageReferenceMappingsTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/ObservablesPackageReferenceMappingsTests.cs
@@ -6,7 +6,7 @@ public sealed class ObservablesPackageReferenceMappingsTests
     public void RuntimePackageByDiagnosticId_covers_core_not_referenced_diagnostics()
     {
         Assert.Equal(
-            ["OBS10002", "OBS3002", "OBS4002", "OBS5002", "OBS6002", "OBS7002", "OBS8002", "OBS9002"],
+            ["OBS10002", "OBS11002", "OBS3002", "OBS4002", "OBS5002", "OBS6002", "OBS7002", "OBS8002", "OBS9002"],
             ObservablesPackageReferenceMappings.RuntimePackageByDiagnosticId.Keys.OrderBy(id => id, StringComparer.Ordinal));
     }
 
@@ -14,7 +14,43 @@ public sealed class ObservablesPackageReferenceMappingsTests
     public void ReactivePackageByDiagnosticId_covers_reactive_package_diagnostics()
     {
         Assert.Equal(
-            ["OBS10005", "OBS3005", "OBS4005", "OBS5005", "OBS6005", "OBS7005", "OBS8005", "OBS9005"],
+            ["OBS10005", "OBS11005", "OBS3005", "OBS4005", "OBS5005", "OBS6005", "OBS7005", "OBS8005", "OBS9005"],
             ObservablesPackageReferenceMappings.ReactivePackageByDiagnosticId.Keys.OrderBy(id => id, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void R3PackageByReactivePackageId_includes_redis()
+    {
+        Assert.True(ObservablesPackageReferenceMappings.R3PackageByReactivePackageId.TryGetValue(
+            "Observables.Redis.Reactive",
+            out var r3PackageId));
+        Assert.Equal("Observables.Redis.R3", r3PackageId);
+    }
+
+    [Fact]
+    public void TryGetDomain_maps_redis_missing_boundary_and_shape_diagnostics()
+    {
+        Assert.True(ObservablesMemberDiagnosticIds.TryGetDomain("OBS11001", out var missingDomain));
+        Assert.Equal(ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis, missingDomain);
+
+        Assert.True(ObservablesMemberDiagnosticIds.TryGetDomain("OBS11004", out var shapeDomain));
+        Assert.Equal(ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis, shapeDomain);
+    }
+
+    [Fact]
+    public void BoundaryAttributeDefaults_redis_publish_and_subscribe()
+    {
+        Assert.Equal(
+            "[RedisPublish(\"Alerts\")]",
+            BoundaryAttributeDefaults.MethodAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis,
+                "Alerts"));
+        Assert.Equal(
+            "[RedisSubscribe(\"Alerts\")]",
+            BoundaryAttributeDefaults.PropertyAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis,
+                "Alerts"));
+        Assert.True(BoundaryAttributeDefaults.RequiresMethod("RedisPublishAttribute"));
+        Assert.True(BoundaryAttributeDefaults.RequiresProperty("RedisSubscribeAttribute"));
     }
 }

--- a/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
+++ b/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
@@ -8,6 +8,7 @@ internal static class BoundaryAttributeDefaults
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubInvoke(\"{memberName}\")]",
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttPublish(\"{memberName}\")]",
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketSend(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis => $"[RedisPublish(\"{memberName}\")]",
             _ => throw new ArgumentOutOfRangeException(nameof(domain)),
         };
 
@@ -17,14 +18,17 @@ internal static class BoundaryAttributeDefaults
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubOn(\"{memberName}\")]",
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttSubscribe(\"{memberName}\")]",
             ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketReceive(\"{memberName}\")]",
+            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis => $"[RedisSubscribe(\"{memberName}\")]",
             _ => throw new ArgumentOutOfRangeException(nameof(domain)),
         };
 
     internal static bool RequiresProperty(string attributeName) =>
-        attributeName is "HubOnAttribute" or "MqttSubscribeAttribute" or "WebSocketReceiveAttribute";
+        attributeName is "HubOnAttribute" or "MqttSubscribeAttribute" or "WebSocketReceiveAttribute"
+            or "RedisSubscribeAttribute";
 
     internal static bool RequiresMethod(string attributeName) =>
         attributeName is "HubInvokeAttribute" or "HubSendAttribute" or "HubStreamAttribute"
             or "MqttPublishAttribute"
-            or "WebSocketSendAttribute" or "WebSocketConnectAttribute" or "WebSocketCloseAttribute";
+            or "WebSocketSendAttribute" or "WebSocketConnectAttribute" or "WebSocketCloseAttribute"
+            or "RedisPublishAttribute";
 }

--- a/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
+++ b/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
@@ -9,10 +9,10 @@ internal static class ObservablesMemberDiagnosticIds
     internal static readonly ImmutableArray<string> PathParameterMismatch = ["OBS3004"];
 
     internal static readonly ImmutableArray<string> MissingBoundaryAttribute =
-        ["OBS4001", "OBS5001", "OBS6001", "OBS8001", "OBS9001"];
+        ["OBS4001", "OBS5001", "OBS6001", "OBS8001", "OBS9001", "OBS11001"];
 
     internal static readonly ImmutableArray<string> MemberShapeMismatch =
-        ["OBS4004", "OBS5004", "OBS6004", "OBS8004", "OBS9004"];
+        ["OBS4004", "OBS5004", "OBS6004", "OBS8004", "OBS9004", "OBS11004"];
 
     internal enum InterfaceProxyDomain
     {
@@ -21,6 +21,7 @@ internal static class ObservablesMemberDiagnosticIds
         WebSocket,
         Sse,
         Nats,
+        Redis,
     }
 
     internal static bool TryGetDomain(string diagnosticId, out InterfaceProxyDomain domain)
@@ -32,10 +33,12 @@ internal static class ObservablesMemberDiagnosticIds
             "OBS6001" or "OBS6004" => InterfaceProxyDomain.WebSocket,
             "OBS8001" or "OBS8004" => InterfaceProxyDomain.Sse,
             "OBS9001" or "OBS9004" => InterfaceProxyDomain.Nats,
+            "OBS11001" or "OBS11004" => InterfaceProxyDomain.Redis,
             _ => default,
         };
 
         return diagnosticId is "OBS4001" or "OBS4004" or "OBS5001" or "OBS5004" or "OBS6001" or "OBS6004"
-            or "OBS8001" or "OBS8004" or "OBS9001" or "OBS9004";
+            or "OBS8001" or "OBS8004" or "OBS9001" or "OBS9004"
+            or "OBS11001" or "OBS11004";
     }
 }

--- a/Observables.Shared/Observables.CodeFixes/ObservablesPackageReferenceMappings.cs
+++ b/Observables.Shared/Observables.CodeFixes/ObservablesPackageReferenceMappings.cs
@@ -15,6 +15,7 @@ internal static class ObservablesPackageReferenceMappings
             ["OBS8002"] = "Observables.Sse",
             ["OBS9002"] = "Observables.Nats",
             ["OBS10002"] = "Observables.Postgres",
+            ["OBS11002"] = "Observables.Redis",
         }.ToImmutableDictionary(StringComparer.Ordinal);
 
     internal static readonly ImmutableDictionary<string, string> ReactivePackageByDiagnosticId =
@@ -28,6 +29,7 @@ internal static class ObservablesPackageReferenceMappings
             ["OBS8005"] = "Observables.Sse.Reactive",
             ["OBS9005"] = "Observables.Nats.Reactive",
             ["OBS10005"] = "Observables.Postgres.Reactive",
+            ["OBS11005"] = "Observables.Redis.Reactive",
         }.ToImmutableDictionary(StringComparer.Ordinal);
 
     internal static readonly ImmutableDictionary<string, string> R3PackageByReactivePackageId =
@@ -41,6 +43,7 @@ internal static class ObservablesPackageReferenceMappings
             ["Observables.Sse.Reactive"] = "Observables.Sse.R3",
             ["Observables.Nats.Reactive"] = "Observables.Nats.R3",
             ["Observables.Postgres.Reactive"] = "Observables.Postgres.R3",
+            ["Observables.Redis.Reactive"] = "Observables.Redis.R3",
         }.ToImmutableDictionary(StringComparer.Ordinal);
 
     internal static bool TryGetRuntimePackage(string diagnosticId, out string packageId) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registers Redis on the Shared analyzer/CodeFix surface so empty `[Redis]` interfaces warn (`OBS11007`), R3 vs Reactive package conflicts include Redis (`OBS0001`), and boundary completions/fixes know the Redis domain — without Redis Feature implementation beyond Shared references.

## Related Issue

Closes #175

## Solution module

- [x] Shared
- [ ] Events
- [ ] RestAPI
- [ ] SignalR
- [ ] WebSocket
- [ ] Mqtt
- [ ] Grpc
- [ ] Solution Items only

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Source generator / diagnostic change
- [ ] Refactor (no behavior change)
- [ ] Docs / repo metadata only

## Test plan

- [x] `dotnet test` (Shared analyzer + CodeFixes):
  ```
  dotnet test Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
  dotnet test Observables.Shared/Observables.CodeFixes.Tests/Observables.CodeFixes.Tests.csproj
  ```
  Both green (20 + 14 tests).

## Breaking changes

- [x] None
- [ ] Yes — describe migration steps:

## Checklist

- [x] This PR touches **only one** solution module (see [AGENTS.md](AGENTS.md))
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [ ] Design Doc updated if API / diagnostic / implementation changed
- [ ] Observables.Docs / Samples synced if user-visible (separate PRs)
- [x] No documentation changes needed (Docs/design sync left to follow-up Docs PR; `AnalyzerReleases.Unshipped.md` updated in Shared)

### Changes

- `ProxyDomainCatalog`: Redis domain with `RedisPublish` / `RedisSubscribe` completion suggestions; listed in interface proxy + reactive conflict catalogs
- `OBS11007` empty `[Redis]` interface descriptor + `EmptyProxyInterfaceAnalyzer` registration + Unshipped release tracking
- `ReactivePackageConflictDetection`: add Redis arm to existing Reactive-bridge assembly switch (OBS0001)
- CodeFixes: package mappings for `OBS11002` / `OBS11005`, domain mapping for `OBS11001` / `OBS11004`, boundary attribute defaults for Redis Publish/Subscribe
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf524eb7-899f-4ab1-8704-faceaf849662?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf524eb7-899f-4ab1-8704-faceaf849662&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

