### PR TITLE
Redis: PackVerify, nuget-smoke, and CI domain matrix (#176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
       sse: ${{ steps.filter.outputs.sse }}
       nats: ${{ steps.filter.outputs.nats }}
       postgres: ${{ steps.filter.outputs.postgres }}
+      redis: ${{ steps.filter.outputs.redis }}
       shared: ${{ steps.filter.outputs.shared }}
       any: ${{ steps.filter.outputs.any }}
     steps:
@@ -152,6 +153,9 @@ jobs:
               - 'Observables.slnx'
             postgres:
               - 'Observables.Postgres/**'
+              - 'Observables.slnx'
+            redis:
+              - 'Observables.Redis/**'
               - 'Observables.slnx'
             shared:
               - 'Observables.Shared/**'
@@ -223,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres, redis]
     steps:
       - name: Skip if domain not changed and not shared
         if: |
@@ -283,7 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres]
+        domain: [events, restapi, signalr, mqtt, websocket, grpc, sse, nats, postgres, redis]
     steps:
       - name: Skip if domain not changed, push event skipped, or PR missing pack label
         if: |

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -258,9 +258,19 @@ sealed class Build : NukeBuild
 
                 if (packageId.StartsWith("Observables.Redis.", StringComparison.Ordinal))
                 {
-                    bool hasGarnet = entries.Any(e =>
+                    bool hasGarnetEntry = entries.Any(e =>
                         e.Contains("Garnet", StringComparison.OrdinalIgnoreCase));
-                    Assert.False(hasGarnet, $"{packageId}: Garnet must stay out of pack dependency graphs");
+                    Assert.False(hasGarnetEntry, $"{packageId}: Garnet must stay out of pack dependency graphs");
+
+                    ZipArchiveEntry? nuspec = archive.Entries.FirstOrDefault(e =>
+                        e.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
+                    Assert.True(nuspec is not null, $"{packageId}: missing .nuspec");
+                    using Stream nuspecStream = nuspec!.Open();
+                    using var nuspecReader = new StreamReader(nuspecStream);
+                    string nuspecText = nuspecReader.ReadToEnd();
+                    Assert.False(
+                        nuspecText.Contains("Garnet", StringComparison.OrdinalIgnoreCase),
+                        $"{packageId}: Garnet must stay out of pack dependency graphs (nuspec)");
                 }
 
                 Assert.True(

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -223,7 +223,8 @@ sealed class Build : NukeBuild
                     || packageId.StartsWith("Observables.Grpc.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Sse.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal)
-                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal))
+                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.Redis.", StringComparison.Ordinal))
                 {
                     Assert.True(
                         entries.Contains("analyzers/dotnet/roslyn4.12/cs/Observables.CodeFixes.dll"),
@@ -247,11 +248,19 @@ sealed class Build : NukeBuild
                     || packageId.StartsWith("Observables.Grpc.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Sse.", StringComparison.Ordinal)
                     || packageId.StartsWith("Observables.Nats.", StringComparison.Ordinal)
-                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal))
+                    || packageId.StartsWith("Observables.Postgres.", StringComparison.Ordinal)
+                    || packageId.StartsWith("Observables.Redis.", StringComparison.Ordinal))
                 {
                     bool hasLib = entries.Any(e => e.StartsWith("lib/", StringComparison.OrdinalIgnoreCase)
                         && e.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
                     Assert.True(hasLib, $"{packageId}: missing runtime assemblies under lib/");
+                }
+
+                if (packageId.StartsWith("Observables.Redis.", StringComparison.Ordinal))
+                {
+                    bool hasGarnet = entries.Any(e =>
+                        e.Contains("Garnet", StringComparison.OrdinalIgnoreCase));
+                    Assert.False(hasGarnet, $"{packageId}: Garnet must stay out of pack dependency graphs");
                 }
 
                 Assert.True(

--- a/eng/Observables.BuildManifest.json
+++ b/eng/Observables.BuildManifest.json
@@ -71,6 +71,14 @@
     {
       "packProject": "Observables.Postgres/Observables.Postgres.Package/Observables.Postgres.Reactive.Pack.csproj",
       "packageId": "Observables.Postgres.Reactive"
+    },
+    {
+      "packProject": "Observables.Redis/Observables.Redis.Package/Observables.Redis.R3.csproj",
+      "packageId": "Observables.Redis.R3"
+    },
+    {
+      "packProject": "Observables.Redis/Observables.Redis.Package/Observables.Redis.Reactive.Pack.csproj",
+      "packageId": "Observables.Redis.Reactive"
     }
   ],
   "testProjects": [
@@ -135,6 +143,8 @@
     "eng/nuget-smoke/Nats.R3.Consumer/Nats.R3.Consumer.csproj",
     "eng/nuget-smoke/Nats.Reactive.Consumer/Nats.Reactive.Consumer.csproj",
     "eng/nuget-smoke/Postgres.R3.Consumer/Postgres.R3.Consumer.csproj",
-    "eng/nuget-smoke/Postgres.Reactive.Consumer/Postgres.Reactive.Consumer.csproj"
+    "eng/nuget-smoke/Postgres.Reactive.Consumer/Postgres.Reactive.Consumer.csproj",
+    "eng/nuget-smoke/Redis.R3.Consumer/Redis.R3.Consumer.csproj",
+    "eng/nuget-smoke/Redis.Reactive.Consumer/Redis.Reactive.Consumer.csproj"
   ]
 }

--- a/eng/nuget-smoke/Redis.R3.Consumer/Program.cs
+++ b/eng/nuget-smoke/Redis.R3.Consumer/Program.cs
@@ -1,0 +1,19 @@
+using Observables.Redis;
+using R3;
+
+namespace Observables.NuGetSmoke.Redis.R3;
+
+[Redis]
+public interface ISmokeChannels
+{
+    [RedisSubscribe("ping")]
+    Observable<string> Ping { get; }
+
+    [RedisPublish("ping")]
+    Observable<Unit> PublishPing(string payload);
+}
+
+public static class Program
+{
+    public static void Main() => Console.WriteLine("Observables.Redis.R3 consumer smoke OK");
+}

--- a/eng/nuget-smoke/Redis.R3.Consumer/Redis.R3.Consumer.csproj
+++ b/eng/nuget-smoke/Redis.R3.Consumer/Redis.R3.Consumer.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Observables.Redis.R3" Version="$(ObservablesConsumerPackageVersion)" />
     <PackageReference Include="R3" Version="1.3.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
   </ItemGroup>
 
 </Project>

--- a/eng/nuget-smoke/Redis.R3.Consumer/Redis.R3.Consumer.csproj
+++ b/eng/nuget-smoke/Redis.R3.Consumer/Redis.R3.Consumer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Observables.Redis.R3" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="R3" Version="1.3.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
+  </ItemGroup>
+
+</Project>

--- a/eng/nuget-smoke/Redis.Reactive.Consumer/Program.cs
+++ b/eng/nuget-smoke/Redis.Reactive.Consumer/Program.cs
@@ -1,0 +1,15 @@
+using Observables.Redis;
+
+namespace Observables.NuGetSmoke.Redis.Reactive;
+
+[Redis]
+public interface ISmokeChannels
+{
+    [RedisSubscribe("ping")]
+    IObservable<string> Ping { get; }
+}
+
+public static class Program
+{
+    public static void Main() => Console.WriteLine("Observables.Redis.Reactive consumer smoke OK");
+}

--- a/eng/nuget-smoke/Redis.Reactive.Consumer/Redis.Reactive.Consumer.csproj
+++ b/eng/nuget-smoke/Redis.Reactive.Consumer/Redis.Reactive.Consumer.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Observables.Redis.Reactive" Version="$(ObservablesConsumerPackageVersion)" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
   </ItemGroup>
 
 </Project>

--- a/eng/nuget-smoke/Redis.Reactive.Consumer/Redis.Reactive.Consumer.csproj
+++ b/eng/nuget-smoke/Redis.Reactive.Consumer/Redis.Reactive.Consumer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Observables.Redis.Reactive" Version="$(ObservablesConsumerPackageVersion)" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the packaging/CI gate for Observables.Redis (ticket #176, parent PRD #169).

- Register `Observables.Redis.R3` / `Observables.Redis.Reactive` pack projects in `eng/Observables.BuildManifest.json`
- Add Redis R3 and Reactive nuget-smoke consumers (Observables package + reactive backend only)
- Extend Nuke `PackVerify` for Redis analyzers + `lib/`, and assert Garnet stays out of packed nupkgs (zip entries **and** `.nuspec` text)
- Add `redis` to CI `paths-filter` and `test-domain` / `pack-domain` matrices

Test projects were already listed in the manifest from earlier Redis slices.

## Test plan

- [x] `dotnet run --project build/_build.csproj -- --target PackOnly --configuration Release --pack-domains redis` — PackVerify succeeded
- [x] Build `eng/nuget-smoke/Redis.{R3,Reactive}.Consumer` against local `artifacts/package` with `ObservablesConsumerPackageVersion=0.1.7` — both succeeded (transitive StackExchange.Redis)
- [x] Packed Redis nupkgs include analyzers/`lib/`; PackVerify asserts no Garnet in entries or nuspec

## Code review

- **Standards**: 0 hard violations (Solution Items scope; soft note that AGENTS “18 packages” prose is updated in #177)
- **Spec**: AC covered; follow-up tightened Garnet nuspec scan and removed extra StackExchange.Redis smoke refs

## Documentation checklist

- [x] N/A for this Solution Items PR (maintainer status/docs are #177)

Closes #176
Related: #169

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23b479a9-7216-428b-9c6b-58ec93089a9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23b479a9-7216-428b-9c6b-58ec93089a9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

