### PR TITLE
Redis: maintainer design doc and status tables (#177)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Observables/
 | **Sse** | `Observables.Sse` | `Sse.R3.SourceGenerators` | `Sse.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Sse.Tests` / `Sse.Reactive.Tests`，内嵌 HTTP server） |
 | **Nats** | `Observables.Nats` | `Nats.R3.SourceGenerators` | `Nats.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Nats.Tests` / `Nats.Reactive.Tests`，进程内 nats-server） |
 | **Postgres** | `Observables.Postgres` | `Postgres.R3.SourceGenerators` | `Postgres.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Postgres.Tests` / `Postgres.Reactive.Tests`，B-tier portable peer）；`Postgres.Package` + PackVerify + nuget-smoke |
-| **Redis** | `Observables.Redis` | `Redis.R3.SourceGenerators` | `Redis.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Redis.Tests` / `Redis.Reactive.Tests`，进程内 Garnet）；`Redis.Package`；PackVerify / nuget-smoke / CI 见 #176 |
+| **Redis** | `Observables.Redis` | `Redis.R3.SourceGenerators` | `Redis.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Redis.Tests` / `Redis.Reactive.Tests`，进程内 Garnet）；`Redis.Package`；PackVerify / nuget-smoke / CI 登记见 [#176](https://github.com/Skymly/Observables/issues/176) |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,13 +347,13 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | **Test** | 同 `Ci`（`Compile` + `UnitTest`）；可附加 `--test-domains <逗号分隔>` 过滤测试项目（例如 `--test-domains mqtt,shared`） |
 | **Pack** | 打包 pack 子项目 → `artifacts/package/`（**不**依赖 UnitTest）；可附加 `--pack-domains <逗号分隔>` 过滤包（按 `PackageId` 前缀 `Observables.<d>.` 匹配） |
 | **PackOnly** | `Pack` + `PackVerify`（**不**跑 UnitTest） |
-| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats/Postgres/Redis `lib/`（`0.1.7` nuget.org **18** 包；Redis 登记后 manifest **20** 包） |
+| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats/Postgres `lib/`（nuget.org **`0.1.7`** = **18** 包）；Redis 包登记与 PackVerify 扩展见 [#176](https://github.com/Skymly/Observables/issues/176)（目标 **20** 包） |
 | **CiPack** | CI 完整流水线：`Test` + `PackOnly` + `NuGetConsumerSmoke`（本地包）；保留供本地或 release.yml 全链路调试 |
 | **Publish** | 推送到 nuget.org（`NUGET_API_KEY`）与 GitHub Packages（`GITHUB_TOKEN`，`packages:write`）；`DependsOn(Test, PackVerify)` 确保发版前测试已通过 |
 
 | Workflow | 触发 | 作用 |
 |----------|------|------|
-| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres / redis；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
+| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过。Redis 域矩阵登记见 [#176](https://github.com/Skymly/Observables/issues/176) |
 | [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 actor；内部 `Test` → `PackVerify` → push） |
 
 ## 工作约定

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.7`（**18 包**，含 Postgres）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
-- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，0.1.7 稳定版已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres 第九域已发）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.7`（**18 包**，含 Postgres）；Redis 主仓已落地，nuget.org 规划 **`0.1.8`**（+2 → **20** 包，须维护者授权）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
+- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，0.1.7 稳定版已发）；**Redis** 发版门槛见 [`docs/ROADMAP.md`](docs/ROADMAP.md) P1b / 规划 `0.1.8`
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres 第九域已发；Redis = 第十域主仓已落地）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标
@@ -159,6 +159,7 @@ Observables/
 | **Sse** | `Observables.Sse` | `Sse.R3.SourceGenerators` | `Sse.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Sse.Tests` / `Sse.Reactive.Tests`，内嵌 HTTP server） |
 | **Nats** | `Observables.Nats` | `Nats.R3.SourceGenerators` | `Nats.Reactive.SourceGenerators` | R3 + Reactive 生成器测试；E2E（`Nats.Tests` / `Nats.Reactive.Tests`，进程内 nats-server） |
 | **Postgres** | `Observables.Postgres` | `Postgres.R3.SourceGenerators` | `Postgres.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Postgres.Tests` / `Postgres.Reactive.Tests`，B-tier portable peer）；`Postgres.Package` + PackVerify + nuget-smoke |
+| **Redis** | `Observables.Redis` | `Redis.R3.SourceGenerators` | `Redis.Reactive.SourceGenerators` | R3/Reactive 生成器测试；E2E（`Redis.Tests` / `Redis.Reactive.Tests`，进程内 Garnet）；`Redis.Package`；PackVerify / nuget-smoke / CI 见 #176 |
 
 **RestAPI 运行时**：`RestApiSettings`、`RestService.For<T>()`；命名空间 `Observables.RestAPI`。
 
@@ -346,13 +347,13 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | **Test** | 同 `Ci`（`Compile` + `UnitTest`）；可附加 `--test-domains <逗号分隔>` 过滤测试项目（例如 `--test-domains mqtt,shared`） |
 | **Pack** | 打包 pack 子项目 → `artifacts/package/`（**不**依赖 UnitTest）；可附加 `--pack-domains <逗号分隔>` 过滤包（按 `PackageId` 前缀 `Observables.<d>.` 匹配） |
 | **PackOnly** | `Pack` + `PackVerify`（**不**跑 UnitTest） |
-| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats/Postgres `lib/`（manifest 当前 **18 包**） |
+| **PackVerify** | 断言 nupkg 含 analyzer、Events `observables.events.props`、RestAPI/SignalR/Mqtt/WebSocket/Sse/Grpc/Nats/Postgres/Redis `lib/`（`0.1.7` nuget.org **18** 包；Redis 登记后 manifest **20** 包） |
 | **CiPack** | CI 完整流水线：`Test` + `PackOnly` + `NuGetConsumerSmoke`（本地包）；保留供本地或 release.yml 全链路调试 |
 | **Publish** | 推送到 nuget.org（`NUGET_API_KEY`）与 GitHub Packages（`GITHUB_TOKEN`，`packages:write`）；`DependsOn(Test, PackVerify)` 确保发版前测试已通过 |
 
 | Workflow | 触发 | 作用 |
 |----------|------|------|
-| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
+| [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres / redis；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
 | [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 actor；内部 `Test` → `PackVerify` → push） |
 
 ## 工作约定
@@ -371,7 +372,7 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | **Shared** | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.Analyzers`、`Observables.CodeFixes` |
 | **Events** | `/Events/`（含 `Observables.Events/targets`、Shared 诊断 `OBS2001`–`OBS2005`） |
 | **RestAPI** | `/RestAPI/`（含 `SourceGenerators.Shared`、Tests） |
-| **SignalR** / **WebSocket** / **Mqtt** / **Grpc** / **Sse** / **Nats** / **Postgres** | 各对应文件夹 |
+| **SignalR** / **WebSocket** / **Mqtt** / **Grpc** / **Sse** / **Nats** / **Postgres** / **Redis** | 各对应文件夹 |
 | **Docs** | 本仓 `docs/`（维护者/中文）；用户文档站 [Observables.Docs](https://github.com/Skymly/Observables.Docs)（VitePress，**分 PR**） |
 | **Repository (root README)** | 根 `README.md`、`CONTRIBUTING.md` |
 | **Solution Items** | 根 `AGENTS.md`、`Observables.slnx`、`Directory.Build.props`、`Directory.Packages.props`（CPM）、公共 props、`eng/`、`build/`（Nuke）、`.github/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Release notes: update the version table in this file and [docs/ROADMAP.md](docs/
 ### PR conventions
 
 - **Titles and descriptions**: English.
-- **Scope**: Prefer one solution-folder module per PR (Shared, Events, RestAPI, SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, or Solution Items for root props / `eng/` / `build/` / `.github/`).
+- **Scope**: Prefer one solution-folder module per PR (Shared, Events, RestAPI, SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, or Solution Items for root props / `eng/` / `build/` / `.github/`).
 - **Commits**: English; do not mention AI or agent tools in commit messages.
 - **Do not** change `eng/Observables.Package.props` version or create tags unless the task explicitly requests a release.
 
@@ -66,6 +66,8 @@ Stable packages are published to [nuget.org](https://www.nuget.org/profiles/Skym
 | **0.1.6** | Stable release — package icon; C# keyword identifier escaping in six domain source generators; source generator fail-safe with per-domain internal error diagnostics (OBS2005–OBS9008). |
 | **0.1.7** | Stable release — ninth domain **Postgres** (LISTEN/NOTIFY): `Observables.Postgres.R3` / `.Reactive` (+2 → **18** packages); OBS10xxx; PackVerify / nuget-smoke / Public API baselines. |
 
+Planned (not published): **0.1.8** — tenth domain **Redis** Pub/Sub (`Observables.Redis.R3` / `.Reactive`, +2 → **20** packages, OBS11xxx). Requires explicit maintainer authorization before version bump / tag / Publish.
+
 Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with tags only (no GitHub Release). Details and milestone planning: [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ### Package set
@@ -83,6 +85,8 @@ Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with
 | `Observables.Sse.R3` / `.Reactive` | Server-Sent Events (`text/event-stream`) |
 | `Observables.Nats.R3` / `.Reactive` | Core NATS subject proxy |
 | `Observables.Postgres.R3` / `.Reactive` | PostgreSQL LISTEN/NOTIFY channel proxy |
+
+**In-repo (not yet on nuget.org):** `Observables.Redis.R3` / `.Reactive` — classic Redis Pub/Sub channel proxy (planned `0.1.8`).
 
 Version source of truth: `eng/Observables.Package.props` (`PackageVersion` / `Version`).
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Observables
 
-> **Roslyn source generators bridging events & IO boundaries to R3 / System.Reactive.** Declarative interface-driven proxies for HTTP, SignalR, MQTT, WebSocket, gRPC, SSE, NATS, and PostgreSQL LISTEN/NOTIFY — write the interface, get the `Observable<T>`.
+> **Roslyn source generators bridging events & IO boundaries to R3 / System.Reactive.** Declarative interface-driven proxies for HTTP, SignalR, MQTT, WebSocket, gRPC, SSE, NATS, PostgreSQL LISTEN/NOTIFY, and Redis Pub/Sub — write the interface, get the `Observable<T>`.
 
 [![NuGet](https://img.shields.io/nuget/v/Observables.Events.R3.svg?label=NuGet&logo=nuget)](https://www.nuget.org/profiles/Skymly)
 [![CI](https://img.shields.io/github/actions/workflow/status/Skymly/Observables/ci.yml?branch=main&label=CI&logo=github)](https://github.com/Skymly/Observables/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/Skymly/Observables.svg?label=License&logo=opensourcehardware)](LICENSE)
 
-面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件：用声明式接口把 .NET 事件、HTTP、SignalR、MQTT、WebSocket、gRPC、SSE、NATS、PostgreSQL LISTEN/NOTIFY 等边界桥接到 **R3** 或 **System.Reactive**。
+面向 **反应式编程（Rx）** 的 Roslyn 源生成器套件：用声明式接口把 .NET 事件、HTTP、SignalR、MQTT、WebSocket、gRPC、SSE、NATS、PostgreSQL LISTEN/NOTIFY、Redis Pub/Sub 等边界桥接到 **R3** 或 **System.Reactive**。
 
 | 资源 | 链接 |
 |------|------|
@@ -43,7 +43,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 
 ## 功能域
 
-九域均已在主仓提供运行时（按需）、双路源生成器与测试；**`0.1.7`** 将九域 **18 包**（含 **Postgres**）发至 nuget.org。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
+九域已在 nuget.org **`0.1.7`** 以 **18 包**发布；**第十域 Redis** 已在主仓提供运行时、双路源生成器与测试（nuget.org 规划 **`0.1.8`** → **20 包**，须维护者授权）。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
 
 | 域 | 说明 |
 |----|------|
@@ -56,6 +56,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 | **Sse** | `text/event-stream` 事件流 |
 | **Nats** | Core NATS subject 代理（v1 不含 JetStream） |
 | **Postgres** | PostgreSQL LISTEN/NOTIFY 通道代理（专用非池化连接；推荐 keepalive） |
+| **Redis** | Redis 经典 Pub/Sub 通道代理（exact Channel + Pattern；`RedisMessage<T>` 信封） |
 
 设计稿见 [`docs/`](docs/README.md)（文档体系见 [`docs/DOCUMENTATION.md`](docs/DOCUMENTATION.md)）。路由事件生成默认关闭；在消费者项目中设置 `<ObservableRoutedEvents>true</ObservableRoutedEvents>`（见 `Observables.Events/Observables.Events/targets/observables.events.props`）。
 
@@ -316,6 +317,30 @@ var hub = PostgresService.For<IOrderHub>(connection);
 ```
 
 依赖 [Npgsql](https://www.nuget.org/packages/Npgsql)。维护者设计说明见 [`docs/design/postgres.md`](docs/design/postgres.md)。
+
+## Redis（Pub/Sub）
+
+在 `[Redis]` 接口上用 `[RedisSubscribe]` / `[RedisPublish]` 标注成员，生成器产出 Subscribe 热流与 Publish 冷流。含 `*` / `?` 的 Channel 走 Pattern（`PSUBSCRIBE`）；返回 `Observable<RedisMessage<T>>` 时附带具体 Channel。`RedisService.For<T>` 接受 `IConnectionMultiplexer`。
+
+```csharp
+[Redis]
+public interface INewsHub
+{
+    [RedisSubscribe("news.sports")]
+    Observable<string> Sports { get; }
+
+    [RedisSubscribe("news.*")]
+    Observable<RedisMessage<string>> NewsFamily { get; }
+
+    [RedisPublish("news.{topic}")]
+    Observable<Unit> Publish(string topic, string payload, CancellationToken cancellationToken = default);
+}
+
+await using var mux = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
+var hub = RedisService.For<INewsHub>(mux);
+```
+
+依赖 [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis)。维护者设计说明见 [`docs/design/redis.md`](docs/design/redis.md)。v1 **不含** Streams / keyspace / sharded Pub/Sub。
 
 ## 构建
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,18 +1,19 @@
 # Observables 路线图
 
-本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前稳定版 **`0.1.7`** = 第九域 Postgres（18 包））。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
+本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前 nuget.org 稳定版 **`0.1.7`** = 第九域 Postgres（18 包）；**第十域 Redis** 主仓已落地，规划 **`0.1.8`**）。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（`0.1.7` 已发 nuget.org）
+## 现状基线（`0.1.7` 已发 nuget.org；Redis 主仓已落地）
 
 | 维度 | 现状 |
 |------|------|
-| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**（运行时 + 双路生成器 + 测试） |
+| 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis**（运行时 + 双路生成器 + 测试） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
 | nuget.org 已发 | **`0.1.7`** — **18 包**（+ Postgres R3/Reactive；`v0.1.7` tag + GitHub Release） |
-| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（manifest **18** 包） |
-| 示例仓 CI | `Observables.Samples` Nuke `Ci`（对齐库版本；Postgres 样例见跨仓 #9） |
+| 主仓下一域 | **Redis** Pub/Sub — 代码已落地；PackVerify / smoke / CI 见 [#176](https://github.com/Skymly/Observables/issues/176)；nuget.org 规划 **`0.1.8`**（+2 → **20** 包，**未**授权 bump/tag） |
+| 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（`0.1.7` manifest **18** 包；Redis 登记后 **20**） |
+| 示例仓 CI | `Observables.Samples` Nuke `Ci`（对齐库版本；Postgres 样例见跨仓 #9；Redis Samples 待 companion） |
 
 ### 已知工程债（详见 AGENTS.md「工程治理」）
 
@@ -43,8 +44,9 @@
 | `OBS8001`–`OBS8999` | SSE | 使用中（8001–8007；8006 为内部 fail-safe） |
 | `OBS9001`–`OBS9999` | NATS | 使用中（9001–9008；9008 为内部 fail-safe） |
 | `OBS10001`–`OBS10999` | Postgres | 使用中（10001–10008；10008 为内部 fail-safe；10007 为空接口，Shared Analyzer） |
+| `OBS11001`–`OBS11999` | Redis | 使用中（11001–11008；11008 为内部 fail-safe；11007 为空接口，Shared Analyzer） |
 
-当前共 **68** 个唯一诊断（含 Postgres OBS10xxx）：前八域 **60** 个 + Postgres **8** 个。新增诊断须落入对应段并在 `AnalyzerReleases.Unshipped.md` 登记（见 AGENTS.md）。
+当前共 **76** 个唯一诊断（含 Postgres OBS10xxx + Redis OBS11xxx）：前九域 **68** 个 + Redis **8** 个。新增诊断须落入对应段并在 `AnalyzerReleases.Unshipped.md` 登记（见 AGENTS.md）。
 
 ## 里程碑
 
@@ -165,6 +167,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | `0.1.6-preview1` | 预览版：NuGet 包图标（六边形紫→品红渐变 + Rx 造型，`PackageIcon` 接入）（**16 包** + **16 snupkg**） |
 | `0.1.6` | 稳定版：包图标 + C# 关键字标识符转义（6 域）+ 源生成器 fail-safe（E2，OBS* 内部错误诊断）（**16 包** + **16 snupkg**，`v0.1.6` tag + GitHub Release） |
 | `0.1.7` | 稳定版：第九域 **Postgres** LISTEN/NOTIFY（**18 包** + **18 snupkg**；OBS10xxx；ADR-002 §6 mid-trigger） |
+| `0.1.8` | 规划：第十域 **Redis** Pub/Sub（**20 包**；OBS11xxx；主仓已落地，发版须维护者授权） |
 
 ## Post-1.0 Follow-up（按需，不绑定版本）
 
@@ -177,6 +180,15 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | P1-PG | Postgres LISTEN/NOTIFY Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + E2E（B-tier peer）+ PackVerify / nuget-smoke；设计文档 [`docs/design/postgres.md`](design/postgres.md)；README / CONTRIBUTING / ROADMAP 已同步 |
 | P1-PG-nuget | nuget.org 发第九域（+2 包 → 18） | ✅ `0.1.7` | `v0.1.7` tag + nuget.org / GitHub Packages + GitHub Release；ADR-002 §6 mid-trigger 已记 |
 | P1-PG-docs | Observables.Docs / Samples | ✅ | Docs PR #13；Samples PR #10（关 #9） |
+
+### P1b — 第十域 Redis（ADR-002）
+
+| # | 行动项 | 状态 | 说明 |
+|---|--------|------|------|
+| P1-RD | Redis Pub/Sub Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + Garnet E2E + Shared catalog（#170–#175）；设计文档 [`docs/design/redis.md`](design/redis.md) |
+| P1-RD-pack | PackVerify / nuget-smoke / CI | 🔄 [#176](https://github.com/Skymly/Observables/issues/176) | BuildManifest + PackVerify + smoke + paths-filter |
+| P1-RD-nuget | nuget.org 发第十域（+2 包 → 20） | ⏳ 规划 `0.1.8` | **须**维护者明确授权后再 bump / tag / Publish |
+| P1-RD-docs | Observables.Docs / Samples | ⏳ companion | 用户文档与 Samples 跨仓；不在本库 PR 内实现 |
 
 ### P2 — 中期处理
 

--- a/docs/adr/ADR-002-domain-admission-and-ranking.md
+++ b/docs/adr/ADR-002-domain-admission-and-ranking.md
@@ -72,12 +72,14 @@ Observables 在 `0.1.6` 已于 nuget.org 稳定发布：**8 域 / 16 包 / 60 �
 | 序 | 候选 | 要点 | 状态 |
 |----|------|------|------|
 | 1 | PostgreSQL LISTEN/NOTIFY | Npgsql + SO `postgresql`；契合；E2E B | **已落地**（主仓；nuget.org 目标 `0.1.7`） |
-| 2 | Redis Pub/Sub | StackExchange.Redis + SO `redis`；契合；E2E A（Garnet） | 待实现 |
+| 2 | Redis Pub/Sub | StackExchange.Redis + SO `redis`；契合；E2E A（Garnet） | **主仓已落地**（nuget.org 目标 `0.1.8`） |
 | 3 | .NET 诊断源 | 诊断栈无处不在（BCL 降权后仍强）；契合；E2E A | 待实现 |
 | 4 | RabbitMQ（AMQP 0-9-1） | 「部分」可剥 ack；E2E C；Apache-2.0 一侧 | 待实现 |
 | 5 | AMQP 1.0 | 契合；E2E A（AMQPNetLite listener）；Apache-2.0 | 待实现 |
 
 **§6 mid-trigger 复审（`0.1.7` / Postgres）：** #1 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #2–#5 维持不变**。本复审**不**自动开 Redis epic / 实现排期。
+
+**状态更新（主仓 Redis）：** #2 Redis Pub/Sub 已按 PRD [#169](https://github.com/Skymly/Observables/issues/169) 在主仓落地（运行时 + 双路生成器 + Garnet E2E + Shared catalog）；**不**改写 §1–§4 准入规则或 §5 排序口径。nuget.org 发版仍待维护者授权（规划 `0.1.8`）。
 
 **单 OS 殿后（过 gating，不进 top-5）：** WMI 事件；Windows 事件日志。
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,6 +18,7 @@
 | Sse | [sse.md](sse.md) |
 | Nats | [nats.md](nats.md) |
 | Postgres | [postgres.md](postgres.md) |
+| Redis | [redis.md](redis.md) |
 
 ## 横切工程文档
 

--- a/docs/design/redis.md
+++ b/docs/design/redis.md
@@ -1,0 +1,161 @@
+# 设计：Redis 域
+
+> 状态：主仓代码已落地（PRD [#169](https://github.com/Skymly/Observables/issues/169) 切片 #170–#175）；PackVerify / nuget-smoke / CI 登记见 [#176](https://github.com/Skymly/Observables/issues/176)。**nuget.org 目标 `0.1.8`**（+2 → **20** 包）；**未**改 `PackageVersion`、未 tag、未 Publish。面向用户文档见 Observables.Docs（跨仓 companion）。
+
+## 1. 动机与定位
+
+`Observables.Redis` 将 **经典 Redis Pub/Sub**（[StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis)）桥接为 interface-proxy IO 边界：
+
+| 边界 | 方向 | Redis 命令 | 反应式映射 |
+|------|------|------------|------------|
+| **Subscribe** | server → client（流） | `SUBSCRIBE` / `PSUBSCRIBE` | 热流 `Observable<T>` / `IObservable<T>` 属性 |
+| **Publish** | client → server | `PUBLISH` | 冷流 `Observable<Unit>` / `IObservable<Unit>` 方法 |
+
+工程骨架以 **Nats** 为模板（Subscribe 属性 + Publish 方法；**无** Request 边界）。排名依据 [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)（Redis Pub/Sub 白名单 #2）。
+
+## 2. 公共面
+
+### 属性
+
+| 属性 | 目标 | 说明 |
+|------|------|------|
+| `[Redis]` | `interface` | 标记 Pub/Sub 代理接口 |
+| `[RedisSubscribe(string? channel = null)]` | `property` | 订阅 Channel / Pattern；热流；未指定时回退成员名 |
+| `[RedisPublish(string? channelTemplate = null)]` | `method` | 发布；Channel 模板支持 `{param}`；未指定时回退成员名 |
+
+### 运行时入口
+
+```csharp
+namespace Observables.Redis;
+
+public static class RedisService
+{
+    public static T For<T>(IConnectionMultiplexer multiplexer);
+}
+```
+
+代理内部经 `multiplexer.GetSubscriber()` 获取 `ISubscriber`；**不**释放调用方传入的 multiplexer。
+
+### 消费者示例
+
+```csharp
+[Redis]
+public interface INewsHub
+{
+    [RedisSubscribe("news.sports")]
+    Observable<string> Sports { get; }
+
+    [RedisSubscribe("news.*")]
+    Observable<RedisMessage<string>> NewsFamily { get; }
+
+    [RedisPublish("news.{topic}")]
+    Observable<Unit> Publish(string topic, string payload, CancellationToken cancellationToken = default);
+}
+
+await using var mux = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
+var hub = RedisService.For<INewsHub>(mux);
+```
+
+Reactive 路径：成员返回 `IObservable<T>`，引用 `Observables.Redis.Reactive`；桥接为 `SystemReactiveRedisAdapter`。
+
+## 3. Channel / Pattern 规则
+
+- **Subscribe**：字面量 Channel 或 Pattern。若字符串含 `*` 或 `?` → `PSUBSCRIBE`（Pattern）；否则 → `SUBSCRIBE`（exact）。**禁止** `{param}` 占位符（OBS11006）。
+- **Publish**：exact Channel only；模板支持 `{param}` 绑定方法参数名（`RedisChannelTemplate`）。**禁止** Pattern 元字符 `*` / `?`（OBS11006）。可选末尾 `CancellationToken`。
+- 未指定 Channel / 模板时回退为成员名（与 Nats/Mqtt 同惯例）。
+
+## 4. 流元素类型
+
+| 返回类型 | 语义 |
+|----------|------|
+| `Observable<T>` / `IObservable<T>` | 仅载荷（payload-only） |
+| `Observable<RedisMessage<T>>` / `IObservable<RedisMessage<T>>` | 信封：具体 Channel + 载荷（Pattern 场景可按 Channel 分支） |
+
+`RedisMessage<T>` 位于 `Observables.Redis`，避免与 StackExchange.Redis `ChannelMessage` 命名冲突。
+
+## 5. 生成映射
+
+- Subscribe 属性 → `RedisObservable.FromSubscribe` / `FromPatternSubscribe`（或 `*Message` 信封变体）
+- Publish 方法 → `RedisObservable.FromPublish`（含模板格式化与序列化）
+
+Reactive：`SystemReactiveRedisAdapter` 同名方法，返回 `IObservable<T>`。
+
+## 6. Payload
+
+| 类型 | 行为 |
+|------|------|
+| `string` / `byte[]`（及约定的原始等价类型） | 透传，不经 JSON |
+| 其它 `T` | 默认 `System.Text.Json`（支持 TFM） |
+| 自定义 | `RedisPayloadSerializers.Register<T>(…)` |
+
+trim/AOT：JSON 反射路径带 `RequiresUnreferencedCode` / `RequiresDynamicCode`（与兄弟 IO 域一致）。
+
+## 7. 分发
+
+v1 **固定顺序** Subscribe 投递（StackExchange.Redis `ChannelMessageQueue` / `OnMessage` 顺序路径）；**无**并发开关。
+
+Dispose 订阅 → 取消 Redis 订阅，避免泄漏。
+
+## 8. 诊断（OBS11xxx）
+
+| ID | 严重性 | 触发 |
+|----|--------|------|
+| OBS11001 | Warning | 缺少边界特性或 Channel 非字面量 |
+| OBS11002 | Error | 未引用 `Observables.Redis` |
+| OBS11003 | Error | 不支持的返回类型 |
+| OBS11004 | Error | 成员形态与特性不匹配（如 `[RedisSubscribe]` 在方法上） |
+| OBS11005 | Error | `IObservable<T>` 需 `Observables.Redis.Reactive` |
+| OBS11006 | Error | Channel/模板违规（Subscribe `{param}`、Publish glob、参数形态等） |
+| OBS11007 | Warning | 空 `[Redis]` 接口（`EmptyProxyInterfaceAnalyzer`） |
+| OBS11008 | Error | 生成器内部 fail-safe |
+
+段分配权威见 `AGENTS.md` / `docs/ROADMAP.md`。OBS11007 在 Shared 分析器登记；其余在域 `DiagnosticDescriptors.cs`。OBS0001 将 Redis R3/Reactive 与其它域一样纳入冲突检测。
+
+## 9. 项目组成
+
+```
+Observables.Redis/
+├── Observables.Redis/
+├── Observables.Redis.Reactive/
+├── Observables.Redis.SourceGenerators.Shared/
+├── Observables.Redis.R3.SourceGenerators/
+├── Observables.Redis.Reactive.SourceGenerators/
+├── Observables.Redis.Package/
+├── Observables.Redis.R3.SourceGenerators.Tests/
+├── Observables.Redis.Reactive.SourceGenerators.Tests/
+├── Observables.Redis.Tests/
+└── Observables.Redis.Reactive.Tests/
+```
+
+登记：`Observables.slnx` `/Redis/`、`ProxyDomainCatalog`、`eng/Observables.BuildManifest.json`（目标 **20** 包，见 #176）、`ci.yml` redis 矩阵、`eng/nuget-smoke`。
+
+## 10. 测试
+
+- **生成器**：R3 + Reactive Verify / 诊断断言（OBS11xxx）
+- **E2E**：进程内 **Microsoft Garnet**（spike #170 通过后锁定）；覆盖 exact Channel、Pattern、payload-only vs `RedisMessage<T>`、Publish `{param}`、顺序投递
+- **nuget-smoke**：`Redis.{R3,Reactive}.Consumer`（#176）
+- **PackVerify**：analyzers + `lib/`；断言 Garnet **不**进入 pack 依赖图（仅测试项目引用 `Microsoft.Garnet`）
+
+## 11. 非目标（v1 显式排除）
+
+- Redis **Streams**、consumer groups、ack/cursor/lease
+- Keyspace notifications
+- Request-reply（含临时 reply-Channel RPC）
+- Cluster **sharded** Pub/Sub（`SPUBLISH` / `SSUBSCRIBE` 等）
+- 并发 Subscribe 分发开关
+- 第三反应式后端；R3 包引用 System.Reactive 或反向（ADR-001）
+
+## 12. Follow-up
+
+- nuget.org **`0.1.8`**（维护者授权后 bump + tag + Publish）
+- Observables.Docs Redis 页 + `diagnostics.md` OBS11xxx
+- Observables.Samples.Redis
+- JSON sourcegen / 更严格 AOT 友好载荷路径（可选）
+
+## 13. 参考
+
+- 仓库内范本：**Nats**、**Mqtt**
+- [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)
+- Spike：[`eng/spikes/GarnetPubSub`](../../eng/spikes/GarnetPubSub/README.md)
+- [StackExchange.Redis Pub/Sub order](https://stackexchange.github.io/StackExchange.Redis/PubSubOrder.html)
+- [Redis Pub/Sub](https://redis.io/docs/latest/develop/pubsub/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maintainer documentation and status sync for Observables.Redis (ticket #177, parent PRD #169).

- Add `docs/design/redis.md` (API, diagnostics OBS11xxx, Pattern/`RedisMessage<T>`, Garnet E2E, non-goals)
- Index the design doc; update ROADMAP / README / CONTRIBUTING / AGENTS status tables
- Mark ADR-002 Redis row as main-repo landed (nuget.org target `0.1.8`) without rewriting admission rules
- **No** `PackageVersion` change, tag, or NuGet publish

`CONTEXT.md` is not present in this repo (domain skill: proceed silently). Companion Docs/Samples remain out of scope.

Note: this ticket intentionally spans Docs + root README/CONTRIBUTING + AGENTS status sync (filed as one maintainer-docs ticket).

## Test plan

- [x] Docs-only review: design doc matches shipped generator/runtime decisions
- [x] Confirm `eng/Observables.Package.props` still `0.1.7`
- [x] AGENTS PackVerify/CI wording defers redis matrix/lib asserts to #176 (accurate vs current `main`)

## Code review

- **Standards**: hard finding — multi-module PR (Docs + Repository + Solution Items); accepted because #177 AC explicitly bundles these status surfaces. Version guard pass.
- **Spec**: design doc / ROADMAP / README / ADR AC met; follow-up softened AGENTS pack/CI claims that were ahead of #176.

## Documentation checklist

- [x] Maintainer design doc added
- [x] ROADMAP / README / CONTRIBUTING / AGENTS updated
- [x] ADR-002 ranking status updated (no rule rewrite)
- [x] User Docs / Samples deferred to companion repos

Closes #177
Related: #169, #176

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23b479a9-7216-428b-9c6b-58ec93089a9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23b479a9-7216-428b-9c6b-58ec93089a9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

