### PR TITLE
Prepare 0.1.9 release after 0.1.8 publish skip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.8`（**20 包**，含 Redis）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
-- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，`0.1.8` = 第十域 Redis 已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres，0.1.8 = Redis）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.9`（**20 包**，含 Redis）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
+- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，`0.1.9` = 第十域 Redis 已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres，0.1.9 = Redis）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,14 @@ Stable packages are published to [nuget.org](https://www.nuget.org/profiles/Skym
 | **0.1.6-preview1** | Preview release — NuGet package icon added (hexagon purple→magenta gradient + Rx shape, `PackageIcon` wired into all 16 packages). |
 | **0.1.6** | Stable release — package icon; C# keyword identifier escaping in six domain source generators; source generator fail-safe with per-domain internal error diagnostics (OBS2005–OBS9008). |
 | **0.1.7** | Stable release — ninth domain **Postgres** (LISTEN/NOTIFY): `Observables.Postgres.R3` / `.Reactive` (+2 → **18** packages); OBS10xxx; PackVerify / nuget-smoke / Public API baselines. |
-| **0.1.8** | Stable release — tenth domain **Redis** Pub/Sub: `Observables.Redis.R3` / `.Reactive` (+2 → **20** packages); OBS11xxx; PackVerify / nuget-smoke / Public API baselines. |
+| **0.1.8** | Tag only — Redis release prep on `main`; Publish skipped (`cursor[bot]` not allowlisted). Superseded by **0.1.9**. |
+| **0.1.9** | Stable release — tenth domain **Redis** Pub/Sub: `Observables.Redis.R3` / `.Reactive` (+2 → **20** packages); OBS11xxx; PackVerify / nuget-smoke / Public API baselines. |
 
 Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with tags only (no GitHub Release). Details and milestone planning: [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ### Package set
 
-**nuget.org (`0.1.8`)**: twenty packages — ten domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
+**nuget.org (`0.1.9`)**: twenty packages — ten domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
 
 | Package ID | Domain |
 |------------|--------|

--- a/Observables.Redis/Observables.Redis.Package/README.Redis.R3.pack.md
+++ b/Observables.Redis/Observables.Redis.Package/README.Redis.R3.pack.md
@@ -5,7 +5,7 @@ Declarative Redis Pub/Sub proxies with Roslyn source generators — annotate int
 ## Install
 
 ```xml
-<PackageReference Include="Observables.Redis.R3" Version="0.1.8" />
+<PackageReference Include="Observables.Redis.R3" Version="0.1.9" />
 <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
 <PackageReference Include="R3" Version="1.3.0" />
 ```

--- a/Observables.Redis/Observables.Redis.Package/README.Redis.Reactive.pack.md
+++ b/Observables.Redis/Observables.Redis.Package/README.Redis.Reactive.pack.md
@@ -5,7 +5,7 @@ Declarative Redis Pub/Sub proxies with Roslyn source generators — annotate int
 ## Install
 
 ```xml
-<PackageReference Include="Observables.Redis.Reactive" Version="0.1.8" />
+<PackageReference Include="Observables.Redis.Reactive" Version="0.1.9" />
 <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
 <PackageReference Include="System.Reactive" Version="6.0.1" />
 ```

--- a/Observables.Redis/Observables.Redis.SourceGenerators.Shared/AnalyzerReleases.Shipped.md
+++ b/Observables.Redis/Observables.Redis.SourceGenerators.Shared/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 0.1.8
+## Release 0.1.9
 
 ### New Rules
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 
 ## 功能域
 
-十域均已在主仓提供运行时（按需）、双路源生成器与测试；**`0.1.8`** 将十域 **20 包**（含 **Redis**）发至 nuget.org。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
+十域均已在主仓提供运行时（按需）、双路源生成器与测试；**`0.1.9`** 将十域 **20 包**（含 **Redis**）发至 nuget.org。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
 
 | 域 | 说明 |
 |----|------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,16 +1,16 @@
 # Observables 路线图
 
-本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前 nuget.org 稳定版 **`0.1.8`** = 第十域 Redis（20 包））。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
+本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前 nuget.org 稳定版 **`0.1.9`** = 第十域 Redis（20 包））。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（`0.1.8` 已发 nuget.org）
+## 现状基线（`0.1.9` 已发 nuget.org）
 
 | 维度 | 现状 |
 |------|------|
 | 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis**（运行时 + 双路生成器 + 测试） |
 | 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
-| nuget.org 已发 | **`0.1.8`** — **20 包**（+ Redis R3/Reactive；`v0.1.8` tag + GitHub Release） |
+| nuget.org 已发 | **`0.1.9`** — **20 包**（+ Redis R3/Reactive；`v0.1.9` tag + GitHub Release） |
 | 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（manifest **20** 包） |
 | 示例仓 CI | `Observables.Samples` Nuke `Ci`（对齐库版本；Redis Samples 见跨仓 companion） |
 
@@ -166,7 +166,8 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | `0.1.6-preview1` | 预览版：NuGet 包图标（六边形紫→品红渐变 + Rx 造型，`PackageIcon` 接入）（**16 包** + **16 snupkg**） |
 | `0.1.6` | 稳定版：包图标 + C# 关键字标识符转义（6 域）+ 源生成器 fail-safe（E2，OBS* 内部错误诊断）（**16 包** + **16 snupkg**，`v0.1.6` tag + GitHub Release） |
 | `0.1.7` | 稳定版：第九域 **Postgres** LISTEN/NOTIFY（**18 包** + **18 snupkg**；OBS10xxx；ADR-002 §6 mid-trigger） |
-| `0.1.8` | 稳定版：第十域 **Redis** Pub/Sub（**20 包** + **20 snupkg**；OBS11xxx；ADR-002 #2） |
+| `0.1.8` | 仅 tag：Redis 发版准备已合入；Publish 因 `cursor[bot]` 不在 allowlist 被跳过；由 **`0.1.9`** 取代 |
+| `0.1.9` | 稳定版：第十域 **Redis** Pub/Sub（**20 包** + **20 snupkg**；OBS11xxx；ADR-002 #2） |
 
 ## Post-1.0 Follow-up（按需，不绑定版本）
 
@@ -186,7 +187,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 |---|--------|------|------|
 | P1-RD | Redis Pub/Sub Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + Garnet E2E + Shared catalog（#170–#175）；设计文档 [`docs/design/redis.md`](design/redis.md) |
 | P1-RD-pack | PackVerify / nuget-smoke / CI | ✅ [#176](https://github.com/Skymly/Observables/issues/176) / [#186](https://github.com/Skymly/Observables/pull/186) | BuildManifest + PackVerify + smoke + paths-filter |
-| P1-RD-nuget | nuget.org 发第十域（+2 包 → 20） | ✅ `0.1.8` | `v0.1.8` tag + nuget.org / GitHub Packages + GitHub Release |
+| P1-RD-nuget | nuget.org 发第十域（+2 包 → 20） | ✅ `0.1.9` | `v0.1.8` tag 仅存在、Publish 跳过；实际 nuget.org / GitHub Packages / GitHub Release 为 `v0.1.9` |
 | P1-RD-docs | Observables.Docs / Samples | ⏳ companion | Docs [#14](https://github.com/Skymly/Observables.Docs/issues/14)；Samples [#11](https://github.com/Skymly/Observables.Samples/issues/11) |
 
 ### P2 — 中期处理

--- a/docs/adr/ADR-002-domain-admission-and-ranking.md
+++ b/docs/adr/ADR-002-domain-admission-and-ranking.md
@@ -72,14 +72,14 @@ Observables 在 `0.1.6` 已于 nuget.org 稳定发布：**8 域 / 16 包 / 60 �
 | 序 | 候选 | 要点 | 状态 |
 |----|------|------|------|
 | 1 | PostgreSQL LISTEN/NOTIFY | Npgsql + SO `postgresql`；契合；E2E B | **已发版**（`0.1.7`） |
-| 2 | Redis Pub/Sub | StackExchange.Redis + SO `redis`；契合；E2E A（Garnet） | **已发版**（`0.1.8`） |
+| 2 | Redis Pub/Sub | StackExchange.Redis + SO `redis`；契合；E2E A（Garnet） | **已发版**（`0.1.9`） |
 | 3 | .NET 诊断源 | 诊断栈无处不在（BCL 降权后仍强）；契合；E2E A | 待实现 |
 | 4 | RabbitMQ（AMQP 0-9-1） | 「部分」可剥 ack；E2E C；Apache-2.0 一侧 | 待实现 |
 | 5 | AMQP 1.0 | 契合；E2E A（AMQPNetLite listener）；Apache-2.0 | 待实现 |
 
 **§6 mid-trigger 复审（`0.1.7` / Postgres）：** #1 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #2–#5 维持不变**。本复审**不**自动开 Redis epic / 实现排期。
 
-**§6 mid-trigger 复审（`0.1.8` / Redis）：** #2 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #3–#5 维持不变**。本复审**不**改写 §1–§4 准入规则。
+**§6 mid-trigger 复审（`0.1.9` / Redis）：** #2 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #3–#5 维持不变**。本复审**不**改写 §1–§4 准入规则。
 
 **单 OS 殿后（过 gating，不进 top-5）：** WMI 事件；Windows 事件日志。
 

--- a/docs/design/redis.md
+++ b/docs/design/redis.md
@@ -1,6 +1,6 @@
 # 设计：Redis 域
 
-> 状态：已随 **`0.1.8`** 发至 nuget.org（**20 包**）。关联 PRD [#169](https://github.com/Skymly/Observables/issues/169)（库内切片 #170–#177）。面向用户文档见 Observables.Docs（跨仓 companion [#14](https://github.com/Skymly/Observables.Docs/issues/14)）。
+> 状态：已随 **`0.1.9`** 发至 nuget.org（**20 包**）。关联 PRD [#169](https://github.com/Skymly/Observables/issues/169)（库内切片 #170–#177）。面向用户文档见 Observables.Docs（跨仓 companion [#14](https://github.com/Skymly/Observables.Docs/issues/14)）。
 
 ## 1. 动机与定位
 
@@ -147,7 +147,7 @@ Observables.Redis/
 
 ## 12. Follow-up
 
-- ✅ `v0.1.8` 已发
+- ✅ `v0.1.9` 已发
 - Observables.Docs Redis 页 + `diagnostics.md` OBS11xxx（跨仓 [#14](https://github.com/Skymly/Observables.Docs/issues/14)）
 - Observables.Samples.Redis（跨仓 [#11](https://github.com/Skymly/Observables.Samples/issues/11)）
 - JSON sourcegen / 更严格 AOT 友好载荷路径（可选）

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.1.8</Version>
-    <PackageVersion>0.1.8</PackageVersion>
+    <Version>0.1.9</Version>
+    <PackageVersion>0.1.9</PackageVersion>
     <Authors>Skymly</Authors>
     <Copyright>Copyright (c) Skymly. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump `PackageVersion` / docs from 0.1.8 → **0.1.9** so Redis (20 packages) can ship after `v0.1.8` Publish was skipped (`cursor[bot]` not allowlisted).
- Record `v0.1.8` as tag-only in CONTRIBUTING / ROADMAP.

## Test plan
- [ ] Merge as Skymly
- [ ] Push annotated tag `v0.1.9` as Skymly (not cursor bot)
- [ ] Confirm `release.yml` Publish succeeds and nuget.org lists `Observables.Events.R3` / `Observables.Redis.R3` **0.1.9**
- [ ] Create GitHub Release for stable `0.1.9`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and package version metadata only; no library or CI logic changes beyond the version string.
> 
> **Overview**
> Bumps the repo **version source of truth** in `eng/Observables.Package.props` from **0.1.8 → 0.1.9** so tag-triggered `Publish` can ship the Redis **20-package** stable line after `v0.1.8` only tagged and CI skipped NuGet push (`cursor[bot]` not on the maintainer allowlist).
> 
> **Documentation** is aligned to **0.1.9** as the current nuget.org stable (AGENTS, README, CONTRIBUTING, ROADMAP, Redis pack READMEs, `docs/design/redis.md`, ADR-002). **0.1.8** is recorded as **tag-only / superseded**; Redis analyzer release notes header moves to **Release 0.1.9**. No runtime, generator, or test code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da2853b292d78b9e0b69b06609d332c73655f97. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->