### PR TITLE
Authorize NuGet Publish via actor or triggering_actor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,30 @@ permissions:
 
 jobs:
   publish:
-    if: contains(fromJson('["Skymly","wys0610"]'), github.actor)
+    # Authorize on actor OR triggering_actor so maintainer-driven agent tag
+    # pushes (e.g. cursor[bot] with triggering_actor=Skymly) still publish.
+    # Do not gate with job-level `if:` — a false condition skips silently
+    # (0.1.8); fail the job instead so the miss is visible.
     runs-on: windows-latest
 
     steps:
+      - name: Authorize publisher
+        shell: bash
+        env:
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          is_maintainer() {
+            local who="$1"
+            [[ "$who" == "Skymly" || "$who" == "wys0610" ]]
+          }
+          echo "actor=${GITHUB_ACTOR} triggering_actor=${TRIGGERING_ACTOR:-}"
+          if is_maintainer "$GITHUB_ACTOR" || is_maintainer "${TRIGGERING_ACTOR:-}"; then
+            echo "Authorized publisher."
+            exit 0
+          fi
+          echo "::error::Publish refused: neither github.actor (${GITHUB_ACTOR}) nor github.triggering_actor (${TRIGGERING_ACTOR:-}) is a maintainer (Skymly|wys0610). Push the v* tag (or workflow_dispatch) as a maintainer, or have a maintainer re-run."
+          exit 1
+
       - uses: actions/checkout@v4
 
       - name: Setup .NET SDKs
@@ -97,5 +117,6 @@ jobs:
             echo "- Trigger: \`${GITHUB_EVENT_NAME}\`"
             echo "- Ref: \`${GITHUB_REF}\`"
             echo "- Actor: \`${GITHUB_ACTOR}\`"
+            echo "- Triggering actor: \`${{ github.triggering_actor }}\`"
             echo "- Job status: \`${{ job.status }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,8 +331,8 @@ git tag -a v0.1.0-preview1 -m "0.1.0-preview1"
 git push origin v0.1.0-preview1
 ```
 
-4. [`.github/workflows/release.yml`](.github/workflows/release.yml) 在 **`push` `v*` tag** 时运行 Nuke **`Publish`**（`PackVerify` → nuget.org + GitHub Packages）。仅允许维护者账号（workflow 内 `github.actor` 校验）。**不**创建 GitHub Release。
-5. 紧急重发可用 **workflow_dispatch** 并手动填写 `version`（仍受 actor 限制；同样**不**发 GitHub Release）。
+4. [`.github/workflows/release.yml`](.github/workflows/release.yml) 在 **`push` `v*` tag** 时运行 Nuke **`Publish`**（`PackVerify` → nuget.org + GitHub Packages）。授权：`github.actor` **或** `github.triggering_actor` 须为维护者（`Skymly` / `wys0610`）——覆盖维护者驱动的 agent 打 tag（如 `cursor[bot]` + `triggering_actor=Skymly`）；未授权时 **失败**（不静默 skip）。**不**创建 GitHub Release。
+5. 紧急重发可用 **workflow_dispatch** 并手动填写 `version`（同样受上述授权约束；**不**发 GitHub Release）。
 
 ## 构建与测试
 
@@ -354,7 +354,7 @@ dotnet run --project build/_build.csproj -- --target Ci --configuration Release
 | Workflow | 触发 | 作用 |
 |----------|------|------|
 | [`ci.yml`](.github/workflows/ci.yml) | PR / push `main` | **changes** job（`dorny/paths-filter`）→ 域 `test-domain` 矩阵（含 postgres / redis；**Shared 改动 → 全域跑**）+ `test-shared`（仅 Shared 改动时跑）+ 域 `pack-domain` 矩阵（push main / PR 带 `pack` label，且域命中）；各 job **完全并行**，未命中的域整列跳过 |
-| [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 actor；内部 `Test` → `PackVerify` → push） |
+| [`release.yml`](.github/workflows/release.yml) | push tag `v*` / `workflow_dispatch` | **Publish**（须 Secrets + 维护者 `actor`/`triggering_actor`；内部 `Test` → `PackVerify` → push） |
 
 ## 工作约定
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,8 @@ Publishing is **tag-triggered** (aligned with [MvvmAIO.Markup](https://github.co
    git push origin v0.1.1
    ```
 
-4. [`.github/workflows/release.yml`](.github/workflows/release.yml) runs Nuke **`Publish`** on `push` of `v*` tags (`Test` → `PackVerify` → nuget.org + GitHub Packages). Maintainer actor only. Does **not** create a GitHub Release automatically.
-5. For stable releases, create a GitHub Release separately if desired. Emergency republish: `workflow_dispatch` with manual `version`.
+4. [`.github/workflows/release.yml`](.github/workflows/release.yml) runs Nuke **`Publish`** on `push` of `v*` tags (`Test` → `PackVerify` → nuget.org + GitHub Packages). Authorized when `github.actor` **or** `github.triggering_actor` is a maintainer (`Skymly` / `wys0610`) — covers maintainer-driven agent tag pushes; unauthorized runs **fail** (not silent skip). Does **not** create a GitHub Release automatically.
+5. For stable releases, create a GitHub Release separately if desired. Emergency republish: `workflow_dispatch` with manual `version` (same authorization).
 
 ### Local pack and verify
 


### PR DESCRIPTION
## Summary
- Fix `release.yml` so Publish runs when **`github.actor` or `github.triggering_actor`** is a maintainer (`Skymly` / `wys0610`), covering maintainer-driven agent tag pushes (`cursor[bot]` + `triggering_actor=Skymly`).
- Replace job-level `if:` (silent **skipped**) with an **Authorize publisher** step that **fails** when unauthorized — same root cause as the `v0.1.8` miss.
- Sync AGENTS.md / CONTRIBUTING.md publish rules.

## Test plan
- [ ] Review workflow YAML
- [ ] Next release: agent-pushed `v*` tag with maintainer `triggering_actor` should run Publish (not skip)
- [ ] Non-maintainer actor+triggering_actor should fail Authorize with a clear error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the tag-triggered publish gate for nuget.org and GitHub Packages; misconfiguration could block legitimate releases or briefly widen who can pass authorization if maintainer names are wrong.
> 
> **Overview**
> Fixes **silent skipped** NuGet publishes when a maintainer’s agent pushes a `v*` tag (e.g. `cursor[bot]` with `triggering_actor=Skymly`), which caused the **0.1.8** miss.
> 
> **`release.yml`** drops the job-level `if:` on `github.actor` and adds an **Authorize publisher** step that allows publish when **`github.actor` or `github.triggering_actor`** is `Skymly` or `wys0610`; otherwise the job **fails** with an explicit `::error::` message. The publish summary now logs **triggering actor**.
> 
> **AGENTS.md** and **CONTRIBUTING.md** describe the same actor/triggering_actor rules and failure-vs-skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e348f30ddb2f01585f38069919a1bcffeb702330. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->