### PR TITLE
Mark Redis Docs/Samples companions complete

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -188,7 +188,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | P1-RD | Redis Pub/Sub Feature（主仓） | ✅ 代码落地 | 运行时 + 双路生成器 + Package + Garnet E2E + Shared catalog（#170–#175）；设计文档 [`docs/design/redis.md`](design/redis.md) |
 | P1-RD-pack | PackVerify / nuget-smoke / CI | ✅ [#176](https://github.com/Skymly/Observables/issues/176) / [#186](https://github.com/Skymly/Observables/pull/186) | BuildManifest + PackVerify + smoke + paths-filter |
 | P1-RD-nuget | nuget.org 发第十域（+2 包 → 20） | ✅ `0.1.9` | `v0.1.8` tag 仅存在、Publish 跳过；实际 nuget.org / GitHub Packages / GitHub Release 为 `v0.1.9` |
-| P1-RD-docs | Observables.Docs / Samples | ⏳ companion | Docs [#14](https://github.com/Skymly/Observables.Docs/issues/14)；Samples [#11](https://github.com/Skymly/Observables.Samples/issues/11) |
+| P1-RD-docs | Observables.Docs / Samples | ✅ | Docs [#14](https://github.com/Skymly/Observables.Docs/issues/14) / PR [#15](https://github.com/Skymly/Observables.Docs/pull/15)；Samples [#11](https://github.com/Skymly/Observables.Samples/issues/11) / PR [#12](https://github.com/Skymly/Observables.Samples/pull/12) |
 
 ### P2 — 中期处理
 

--- a/docs/design/redis.md
+++ b/docs/design/redis.md
@@ -1,6 +1,6 @@
 # 设计：Redis 域
 
-> 状态：已随 **`0.1.9`** 发至 nuget.org（**20 包**）。关联 PRD [#169](https://github.com/Skymly/Observables/issues/169)（库内切片 #170–#177）。面向用户文档见 Observables.Docs（跨仓 companion [#14](https://github.com/Skymly/Observables.Docs/issues/14)）。
+> 状态：已随 **`0.1.9`** 发至 nuget.org（**20 包**）。关联 PRD [#169](https://github.com/Skymly/Observables/issues/169)（库内切片 #170–#177）。面向用户文档：Observables.Docs（[#14](https://github.com/Skymly/Observables.Docs/issues/14) / PR [#15](https://github.com/Skymly/Observables.Docs/pull/15)）；Samples：[#11](https://github.com/Skymly/Observables.Samples/issues/11) / PR [#12](https://github.com/Skymly/Observables.Samples/pull/12)。
 
 ## 1. 动机与定位
 
@@ -148,8 +148,8 @@ Observables.Redis/
 ## 12. Follow-up
 
 - ✅ `v0.1.9` 已发
-- Observables.Docs Redis 页 + `diagnostics.md` OBS11xxx（跨仓 [#14](https://github.com/Skymly/Observables.Docs/issues/14)）
-- Observables.Samples.Redis（跨仓 [#11](https://github.com/Skymly/Observables.Samples/issues/11)）
+- ✅ Observables.Docs Redis 页 + `diagnostics.md` OBS11xxx（[#14](https://github.com/Skymly/Observables.Docs/issues/14) / PR [#15](https://github.com/Skymly/Observables.Docs/pull/15)）
+- ✅ Observables.Samples.Redis（[#11](https://github.com/Skymly/Observables.Samples/issues/11) / PR [#12](https://github.com/Skymly/Observables.Samples/pull/12)）
 - JSON sourcegen / 更严格 AOT 友好载荷路径（可选）
 
 ## 13. 参考


### PR DESCRIPTION
## Summary
- Mark `P1-RD-docs` ✅ in ROADMAP after Docs PR #15 and Samples PR #12.
- Update `docs/design/redis.md` status + follow-up checkmarks.
- Closes #169 once merged (Redis PRD fully delivered: library + 0.1.9 + Docs + Samples).

## Test plan
- [ ] Docs-only diff review
- [ ] Close #169 after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only status and link updates; no runtime, build, or API changes.
> 
> **Overview**
> **Documentation-only** update to reflect that Redis tenth-domain companion work (Observables.Docs + Observables.Samples) is finished after the merged companion PRs.
> 
> In `docs/ROADMAP.md`, **`P1-RD-docs`** moves from ⏳ companion to **✅**, with links to Docs issue/PR [#14](https://github.com/Skymly/Observables.Docs/issues/14) / [#15](https://github.com/Skymly/Observables.Docs/pull/15) and Samples [#11](https://github.com/Skymly/Observables.Samples/issues/11) / [#12](https://github.com/Skymly/Observables.Samples/pull/12).
> 
> In `docs/design/redis.md`, the status blurb and **§12 Follow-up** checkmarks are updated the same way so Redis design docs stay aligned with the roadmap (library + `0.1.9` + user docs + samples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d456a9539e4ce9edb57acf76b16df287ecde97d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->