### PR TITLE
Park ADR-002 #3 Diagnostics (docs only)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,6 +190,13 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | P1-RD-nuget | nuget.org 发第十域（+2 包 → 20） | ✅ `0.1.9` | `v0.1.8` tag 仅存在、Publish 跳过；实际 nuget.org / GitHub Packages / GitHub Release 为 `v0.1.9` |
 | P1-RD-docs | Observables.Docs / Samples | ✅ | Docs [#14](https://github.com/Skymly/Observables.Docs/issues/14) / PR [#15](https://github.com/Skymly/Observables.Docs/pull/15)；Samples [#11](https://github.com/Skymly/Observables.Samples/issues/11) / PR [#12](https://github.com/Skymly/Observables.Samples/pull/12) |
 
+### P1c — Diagnostics（ADR-002 #3，Park）
+
+| # | 行动项 | 状态 | 说明 |
+|---|--------|------|------|
+| P1-DG | .NET `DiagnosticListener` Feature | ⏸ Park | 维护者 grill 后暂缓：BCL 已是 `IObservable`；名次保留。冻结 v1 形状见 [`docs/design/diagnostics.md`](design/diagnostics.md)；ADR-002 §5/#3 + §6 排期备注 |
+| P1-DG-impl | 运行时 / 生成器 / nuget | — | **未排期**；un-park 须维护者明确批准 |
+
 ### P2 — 中期处理
 
 | # | 行动项 | 工作量 | 说明 |

--- a/docs/adr/ADR-002-domain-admission-and-ranking.md
+++ b/docs/adr/ADR-002-domain-admission-and-ranking.md
@@ -73,13 +73,15 @@ Observables 在 `0.1.6` 已于 nuget.org 稳定发布：**8 域 / 16 包 / 60 �
 |----|------|------|------|
 | 1 | PostgreSQL LISTEN/NOTIFY | Npgsql + SO `postgresql`；契合；E2E B | **已发版**（`0.1.7`） |
 | 2 | Redis Pub/Sub | StackExchange.Redis + SO `redis`；契合；E2E A（Garnet） | **已发版**（`0.1.9`） |
-| 3 | .NET 诊断源 | 诊断栈无处不在（BCL 降权后仍强）；契合；E2E A | 待实现 |
+| 3 | .NET 诊断源 | 诊断栈无处不在（BCL 降权后仍强）；契合；E2E A | **暂缓（Park）** — `DiagnosticListener` 已是 `IObservable`；强类型 Feature 经 grill（2026-08-06）后由维护者推迟，见 [`diagnostics.md`](../design/diagnostics.md) |
 | 4 | RabbitMQ（AMQP 0-9-1） | 「部分」可剥 ack；E2E C；Apache-2.0 一侧 | 待实现 |
 | 5 | AMQP 1.0 | 契合；E2E A（AMQPNetLite listener）；Apache-2.0 | 待实现 |
 
 **§6 mid-trigger 复审（`0.1.7` / Postgres）：** #1 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #2–#5 维持不变**。本复审**不**自动开 Redis epic / 实现排期。
 
 **§6 mid-trigger 复审（`0.1.9` / Redis）：** #2 已发版落地触发复审。未发现可点名的采用度位次翻转、许可/官方 codegen 剧变或 gating 规则变更；**剩余次序 #3–#5 维持不变**。本复审**不**改写 §1–§4 准入规则。
+
+**§6 排期备注（`2026-08-06` / Diagnostics Park）：** #3 标 **暂缓（Park）**，不改变 #3–#5 名次，**不**自动开 RabbitMQ（#4）或其它域实现。翻案 / un-park 须维护者明确批准；冻结的 v1 形状见 [`docs/design/diagnostics.md`](../design/diagnostics.md)。
 
 **单 OS 殿后（过 gating，不进 top-5）：** WMI 事件；Windows 事件日志。
 

--- a/docs/design/diagnostics.md
+++ b/docs/design/diagnostics.md
@@ -1,0 +1,74 @@
+# 设计：Diagnostics 域（Parked）
+
+> 状态：**Parked（暂缓）** — 无运行时 / 生成器 / NuGet 排期。ADR-002 白名单 **#3** 仍保留名次，不自动实现。
+> 关联：[ADR-002](../adr/ADR-002-domain-admission-and-ranking.md) §5；研究草图 [io-boundary-candidates.md §6.7](../research/io-boundary-candidates.md#67--net-诊断源eventsource--diagnosticlistener--activity--meter)。
+> 本文记录 2026-08-06 grill 冻结的 **若 un-park 则采用的 v1 形状**；**不是**实现授权。
+
+## 1. 为何 Park
+
+BCL `DiagnosticListener` 已实现 `IObservable<KeyValuePair<string, object>>`。Observables 的增量是弱类型 → 强类型接口代理 + 双后端 `For<T>`，但维护者认定当前重叠成本高于收益，选择 **暂缓**，而非从排名表删除。
+
+## 2. 动机与定位（若 un-park）
+
+`Observables.Diagnostics` 将 **`DiagnosticListener` 事件**桥接为 interface-proxy IO 边界（仅 Subscribe）：
+
+| 边界 | 方向 | BCL | 反应式映射 |
+|------|------|-----|------------|
+| **Subscribe** | listener → 消费者 | `DiagnosticListener.Subscribe` + `IsEnabled` | 热流 `Observable<T>` / `IObservable<T>` 属性 |
+
+排名依据 [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)（.NET 诊断源白名单 #3）。
+
+## 3. 冻结的 v1 决策（grill Q1–Q11）
+
+| 主题 | 决策 |
+|------|------|
+| 机制范围 | **仅** `DiagnosticListener`；不做 `Activity` / `EventSource` / `Meter` |
+| Feature stem / 包 | `Diagnostics` → `Observables.Diagnostics.R3` / `.Reactive` |
+| 诊断段 | 预留 **`OBS12xxx`**（未登记实现） |
+| 入口 | 仅 `DiagnosticService.For<T>(DiagnosticListener listener)`；不做 `AllListeners` |
+| 写方向 | **不做** `DiagnosticSource.Write` / Publish 冷流 |
+| 属性声明 | 接口 `[Diagnostics]`；成员 `[DiagnosticEvent("exact.name")]` **仅事件名**（listener 身份由 `For` 注入） |
+| 事件名匹配 | **仅 Exact**；无 glob / prefix |
+| Payload | **Cast**（`Value is T`）+ 可选 Envelope **`DiagnosticEvent<T>`**（`EventName` + `Value`）；不做 JSON deserialize |
+| Cast 失败 | **一律 Skip**（含不匹配 / 不合适的 `null`） |
+| `IsEnabled` | **Declared-only 并集**（接口上所有已声明事件名） |
+| 订阅模型 | **每代理一次** `Subscribe` + 内部按事件名扇出 |
+
+### 非目标（v1）
+
+- ActivityListener / EventSource / Meter
+- Write / Publish
+- `DiagnosticListener.AllListeners` 全局入口
+- 事件名 glob / regex
+- JSON / 自定义 deserialize 路径
+- 接口级强制期望 `listener.Name` 校验（可 follow-up）
+
+### 示意（未实现）
+
+```csharp
+[Diagnostics]
+public interface IHttpDiagnostics
+{
+    [DiagnosticEvent("System.Net.Http.HttpRequestOut.Start")]
+    Observable<HttpRequestMessage> RequestStarted { get; }
+
+    [DiagnosticEvent("System.Net.Http.HttpRequestOut.Stop")]
+    Observable<DiagnosticEvent<object>> RequestStopped { get; } // Envelope 例；T 依真实 payload
+}
+
+// var proxy = DiagnosticService.For<IHttpDiagnostics>(listener);
+```
+
+## 4. Un-park 检查清单（将来）
+
+1. 维护者明确批准实现与版本号
+2. 按 AGENTS Feature 检查清单建运行时 + 双路生成器 + Package + 测试 + manifest
+3. 登记 `OBS12xxx` + AnalyzerReleases
+4. 三仓同步（Docs / Samples）
+5. 视需要更新 ADR-002 #3 状态为已发版，并跑 §6 mid-trigger
+
+## 5. 参考
+
+- [ADR-002](../adr/ADR-002-domain-admission-and-ranking.md)
+- [io-boundary-candidates.md §6.7](../research/io-boundary-candidates.md#67--net-诊断源eventsource--diagnosticlistener--activity--meter)
+- [DiagnosticListener](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticlistener)


### PR DESCRIPTION
## Summary
- Mark ADR-002 #3 (.NET Diagnostics / `DiagnosticListener`) as **Park** — BCL already `IObservable`; strong-typing Feature deferred after grill.
- Add parked design memo [`docs/design/diagnostics.md`](docs/design/diagnostics.md) with frozen v1 decisions.
- Add ROADMAP **P1c** Park rows; no code / PRD / packages.

## Test plan
- [ ] Docs-only review
- [ ] Confirm no Observables.Diagnostics* scaffold in this PR
