### PR TITLE
Derive OBS0001 Reactive bridges from catalog DisplayName

### DIFF
--- a/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
+++ b/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\Observables.RestAPI\Observables.RestAPI\Observables.RestAPI.csproj" />
     <ProjectReference Include="..\..\Observables.Grpc\Observables.Grpc\Observables.Grpc.csproj" />
     <ProjectReference Include="..\..\Observables.Sse\Observables.Sse\Observables.Sse.csproj" />
+    <ProjectReference Include="..\..\Observables.Sse\Observables.Sse.Reactive\Observables.Sse.Reactive.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="R3" />
   </ItemGroup>

--- a/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/ReactivePackageConflictAnalyzerTests.cs
@@ -1,10 +1,20 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Observables.Analyzers.Tests;
 
 public sealed class ReactivePackageConflictAnalyzerTests
 {
+    [Fact]
+    public void ReactiveAssemblyName_matches_Observables_DisplayName_Reactive_for_all_conflict_domains()
+    {
+        foreach (var domain in ProxyDomainCatalog.ReactiveConflictDomains)
+        {
+            Assert.Equal(
+                $"Observables.{domain.DisplayName}.Reactive",
+                domain.ReactiveAssemblyName);
+        }
+    }
+
     [Fact]
     public void OBS0001_when_r3_and_signalr_reactive_are_referenced()
     {
@@ -47,6 +57,28 @@ public sealed class ReactivePackageConflictAnalyzerTests
         Assert.Contains(
             diagnostics,
             d => d.Id == "OBS0001" && d.GetMessage().Contains("Redis", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void OBS0001_when_r3_and_sse_reactive_are_referenced()
+    {
+        var diagnostics = AnalyzerTestHarness.RunAnalyzers(
+            """
+            namespace Test;
+
+            public interface IMarker { }
+            """,
+            additionalReferences:
+            [
+                AnalyzerTestHarness.CreateReference<global::R3.Unit>(),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.Sse.SseAttribute)),
+                AnalyzerTestHarness.CreateReferenceFromAssemblyOf(typeof(global::Observables.Sse.Reactive.SystemReactiveSseAdapter)),
+            ],
+            new ReactivePackageConflictAnalyzer());
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Id == "OBS0001" && d.GetMessage().Contains("Sse", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
+++ b/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
@@ -28,6 +28,12 @@ internal static class ProxyDomainCatalog
         internal DiagnosticDescriptor EmptyInterfaceDescriptor { get; }
         internal IReadOnlyList<BoundaryAttributeSuggestion> MethodAttributes { get; }
         internal IReadOnlyList<BoundaryAttributeSuggestion> PropertyAttributes { get; }
+
+        /// <summary>
+        /// NuGet / assembly id for the System.Reactive bridge package
+        /// (<c>Observables.{DisplayName}.Reactive</c>).
+        /// </summary>
+        internal string ReactiveAssemblyName => $"Observables.{DisplayName}.Reactive";
     }
 
     internal sealed class BoundaryAttributeSuggestion

--- a/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
+++ b/Observables.Shared/Observables.Analyzers/ReactivePackageConflictDetection.cs
@@ -22,14 +22,5 @@ internal static class ReactivePackageConflictDetection
         HasAssemblyReference(compilation, "R3");
 
     internal static bool HasReactiveBridgeReference(Compilation compilation, ProxyDomainCatalog.ProxyDomain domain) =>
-        domain switch
-        {
-            { DisplayName: "SignalR" } => HasAssemblyReference(compilation, "Observables.SignalR.Reactive"),
-            { DisplayName: "Mqtt" } => HasAssemblyReference(compilation, "Observables.Mqtt.Reactive"),
-            { DisplayName: "WebSocket" } => HasAssemblyReference(compilation, "Observables.WebSocket.Reactive"),
-            { DisplayName: "Grpc" } => HasAssemblyReference(compilation, "Observables.Grpc.Reactive"),
-            { DisplayName: "RestAPI" } => HasAssemblyReference(compilation, "Observables.RestAPI.Reactive"),
-            { DisplayName: "Redis" } => HasAssemblyReference(compilation, "Observables.Redis.Reactive"),
-            _ => false,
-        };
+        HasAssemblyReference(compilation, domain.ReactiveAssemblyName);
 }


### PR DESCRIPTION
## Summary
- Add `ProxyDomain.ReactiveAssemblyName` (`Observables.{DisplayName}.Reactive`).
- Replace the incomplete `HasReactiveBridgeReference` switch so Sse/Nats/Postgres OBS0001 conflicts are detected.
- Lock naming across `ReactiveConflictDomains` + Sse E2E regression.

## Test plan
- [x] `dotnet test Observables.Shared/Observables.Analyzers.Tests --filter ReactivePackageConflict` (6 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small analyzer-only refactor with behavior fix for previously undetected domains; covered by unit tests and no runtime API changes.
> 
> **Overview**
> **OBS0001** (R3 + System.Reactive bridge conflict) now resolves reactive bridge assemblies from the proxy domain catalog instead of a hand-maintained switch, so domains like **Sse**, **Nats**, and **Postgres** are covered the same way as SignalR and Redis.
> 
> `ProxyDomain` gains **`ReactiveAssemblyName`** (`Observables.{DisplayName}.Reactive`), and **`HasReactiveBridgeReference`** uses that name for every entry in **`ReactiveConflictDomains`**. Tests assert the naming convention for all conflict domains and add an SSE-specific OBS0001 case; the analyzer test project references **`Observables.Sse.Reactive`** for that coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93cb32e3e25f66e6b75b301faf3693fe9de972ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->