### PR TITLE
Unify proxy domain catalog and add IO generator Shared APIs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Observables
+
+Roslyn source generators that bridge event and IO boundaries onto reactive surfaces (R3 and System.Reactive).
+
+## Language
+
+**Feature (domain)**:
+A disk folder `Observables.<Feature>/` that ships as the pair of NuGet packages `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
+_Avoid_: module (in the product sense), package family
+
+**Proxy domain catalog**:
+The single table of interface-proxy Feature metadata (markers, member diagnostic IDs, default boundary attributes) shared by analyzers and code fixes.
+_Avoid_: domain registry, analyzer catalog (when meaning this shared table)
+
+**IO stub generator pipeline**:
+The shared incremental wiring for `ForAttributeWithMetadataName` interface-proxy generators (parse → diagnostics → emit), configured per Feature by adapters.
+_Avoid_: generator host, stub framework
+
+**Proxy registration emitter**:
+The shared emitter of ModuleInitializer factory registration for single-client `*Service.RegisterGeneratedFactory` Features.
+_Avoid_: module initializer helper (when meaning this registration template)

--- a/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
+++ b/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Observables.Roslyn.Shared;
 
 namespace Observables.Analyzers;
 
@@ -92,7 +93,7 @@ public sealed class BoundaryAttributeCompletionProvider : CompletionProvider
         }
     }
 
-    static CompletionItem CreateItem(ProxyDomainCatalog.BoundaryAttributeSuggestion suggestion, string memberName)
+    static CompletionItem CreateItem(ProxyDomainTable.BoundaryAttributeSuggestion suggestion, string memberName)
     {
         var insertText = suggestion.InsertText.Contains('(')
             ? suggestion.InsertText

--- a/Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj
+++ b/Observables.Shared/Observables.Analyzers/Observables.Analyzers.csproj
@@ -27,6 +27,9 @@
     <Compile Include="..\..\Observables.Shared\Observables.SourceGenerators.Shared\DiagnosticHelpLink.cs">
       <Link>Shared/DiagnosticHelpLink.cs</Link>
     </Compile>
+    <Compile Include="..\Observables.Roslyn.Shared\ProxyDomainTable.cs">
+      <Link>Shared/ProxyDomainTable.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
+++ b/Observables.Shared/Observables.Analyzers/ProxyDomainCatalog.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Observables.Roslyn.Shared;
 
 namespace Observables.Analyzers;
 
@@ -7,177 +8,67 @@ internal static class ProxyDomainCatalog
     internal sealed class ProxyDomain
     {
         internal ProxyDomain(
-            string displayName,
-            string interfaceMarkerMetadataName,
-            string reactiveAdapterMetadataName,
-            DiagnosticDescriptor emptyInterfaceDescriptor,
-            IReadOnlyList<BoundaryAttributeSuggestion> methodAttributes,
-            IReadOnlyList<BoundaryAttributeSuggestion> propertyAttributes)
+            ProxyDomainTable.ProxyDomainDefinition definition,
+            DiagnosticDescriptor emptyInterfaceDescriptor)
         {
-            DisplayName = displayName;
-            InterfaceMarkerMetadataName = interfaceMarkerMetadataName;
-            ReactiveAdapterMetadataName = reactiveAdapterMetadataName;
+            Definition = definition;
             EmptyInterfaceDescriptor = emptyInterfaceDescriptor;
-            MethodAttributes = methodAttributes;
-            PropertyAttributes = propertyAttributes;
         }
 
-        internal string DisplayName { get; }
-        internal string InterfaceMarkerMetadataName { get; }
-        internal string ReactiveAdapterMetadataName { get; }
+        internal ProxyDomainTable.ProxyDomainDefinition Definition { get; }
+        internal string DisplayName => Definition.DisplayName;
+        internal string InterfaceMarkerMetadataName => Definition.InterfaceMarkerMetadataName;
+        internal string ReactiveAdapterMetadataName => Definition.ReactiveAdapterMetadataName;
         internal DiagnosticDescriptor EmptyInterfaceDescriptor { get; }
-        internal IReadOnlyList<BoundaryAttributeSuggestion> MethodAttributes { get; }
-        internal IReadOnlyList<BoundaryAttributeSuggestion> PropertyAttributes { get; }
-
-        /// <summary>
-        /// NuGet / assembly id for the System.Reactive bridge package
-        /// (<c>Observables.{DisplayName}.Reactive</c>).
-        /// </summary>
-        internal string ReactiveAssemblyName => $"Observables.{DisplayName}.Reactive";
-    }
-
-    internal sealed class BoundaryAttributeSuggestion
-    {
-        internal BoundaryAttributeSuggestion(string displayText, string insertText)
-        {
-            DisplayText = displayText;
-            InsertText = insertText;
-        }
-
-        internal string DisplayText { get; }
-        internal string InsertText { get; }
+        internal IReadOnlyList<ProxyDomainTable.BoundaryAttributeSuggestion> MethodAttributes =>
+            Definition.MethodAttributes;
+        internal IReadOnlyList<ProxyDomainTable.BoundaryAttributeSuggestion> PropertyAttributes =>
+            Definition.PropertyAttributes;
+        internal string ReactiveAssemblyName => Definition.ReactiveAssemblyName;
     }
 
     internal static readonly ProxyDomain SignalR = new(
-        displayName: "SignalR",
-        interfaceMarkerMetadataName: "Observables.SignalR.HubAttribute",
-        reactiveAdapterMetadataName: "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyHubInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("HubInvoke", "HubInvoke"),
-            new BoundaryAttributeSuggestion("HubSend", "HubSend"),
-            new BoundaryAttributeSuggestion("HubStream", "HubStream"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("HubOn", "HubOn"),
-        ]);
+        ProxyDomainTable.SignalR,
+        DiagnosticDescriptors.EmptyHubInterface);
 
     internal static readonly ProxyDomain Mqtt = new(
-        displayName: "Mqtt",
-        interfaceMarkerMetadataName: "Observables.Mqtt.MqttAttribute",
-        reactiveAdapterMetadataName: "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyMqttInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("MqttPublish", "MqttPublish"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("MqttSubscribe", "MqttSubscribe"),
-        ]);
+        ProxyDomainTable.Mqtt,
+        DiagnosticDescriptors.EmptyMqttInterface);
 
     internal static readonly ProxyDomain WebSocket = new(
-        displayName: "WebSocket",
-        interfaceMarkerMetadataName: "Observables.WebSocket.WebSocketAttribute",
-        reactiveAdapterMetadataName: "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyWebSocketInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("WebSocketSend", "WebSocketSend"),
-            new BoundaryAttributeSuggestion("WebSocketConnect", "WebSocketConnect"),
-            new BoundaryAttributeSuggestion("WebSocketClose", "WebSocketClose"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("WebSocketReceive", "WebSocketReceive"),
-        ]);
+        ProxyDomainTable.WebSocket,
+        DiagnosticDescriptors.EmptyWebSocketInterface);
 
     internal static readonly ProxyDomain Grpc = new(
-        displayName: "Grpc",
-        interfaceMarkerMetadataName: "Observables.Grpc.GrpcAttribute",
-        reactiveAdapterMetadataName: "Observables.Grpc.Reactive.SystemReactiveGrpcAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyGrpcInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("GrpcUnary", "GrpcUnary"),
-            new BoundaryAttributeSuggestion("GrpcServerStream", "GrpcServerStream"),
-            new BoundaryAttributeSuggestion("GrpcClientStream", "GrpcClientStream"),
-            new BoundaryAttributeSuggestion("GrpcDuplex", "GrpcDuplex"),
-        ],
-        propertyAttributes: []);
+        ProxyDomainTable.Grpc,
+        DiagnosticDescriptors.EmptyGrpcInterface);
 
     internal static readonly ProxyDomain Sse = new(
-        displayName: "Sse",
-        interfaceMarkerMetadataName: "Observables.Sse.SseAttribute",
-        reactiveAdapterMetadataName: "Observables.Sse.Reactive.SystemReactiveSseAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptySseInterface,
-        methodAttributes: [],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("SseEvent", "SseEvent"),
-        ]);
+        ProxyDomainTable.Sse,
+        DiagnosticDescriptors.EmptySseInterface);
 
     internal static readonly ProxyDomain Nats = new(
-        displayName: "Nats",
-        interfaceMarkerMetadataName: "Observables.Nats.NatsAttribute",
-        reactiveAdapterMetadataName: "Observables.Nats.Reactive.SystemReactiveNatsAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyNatsInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("NatsPublish", "NatsPublish"),
-            new BoundaryAttributeSuggestion("NatsRequest", "NatsRequest"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("NatsSubscribe", "NatsSubscribe"),
-        ]);
+        ProxyDomainTable.Nats,
+        DiagnosticDescriptors.EmptyNatsInterface);
 
     internal static readonly ProxyDomain Postgres = new(
-        displayName: "Postgres",
-        interfaceMarkerMetadataName: "Observables.Postgres.PostgresAttribute",
-        reactiveAdapterMetadataName: "Observables.Postgres.Reactive.SystemReactivePostgresAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyPostgresInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("Notify", "Notify"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("Listen", "Listen"),
-        ]);
+        ProxyDomainTable.Postgres,
+        DiagnosticDescriptors.EmptyPostgresInterface);
 
     internal static readonly ProxyDomain Redis = new(
-        displayName: "Redis",
-        interfaceMarkerMetadataName: "Observables.Redis.RedisAttribute",
-        reactiveAdapterMetadataName: "Observables.Redis.Reactive.SystemReactiveRedisAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyRedisInterface,
-        methodAttributes:
-        [
-            new BoundaryAttributeSuggestion("RedisPublish", "RedisPublish"),
-        ],
-        propertyAttributes:
-        [
-            new BoundaryAttributeSuggestion("RedisSubscribe", "RedisSubscribe"),
-        ]);
+        ProxyDomainTable.Redis,
+        DiagnosticDescriptors.EmptyRedisInterface);
 
     internal static readonly ProxyDomain RestApi = new(
-        displayName: "RestAPI",
-        interfaceMarkerMetadataName: "Observables.RestAPI.RestApiAttribute",
-        reactiveAdapterMetadataName: "Observables.RestAPI.Reactive.SystemReactiveObservableAdapter",
-        emptyInterfaceDescriptor: DiagnosticDescriptors.EmptyRestApiInterface,
-        methodAttributes: [],
-        propertyAttributes: []);
+        ProxyDomainTable.RestApi,
+        DiagnosticDescriptors.EmptyRestApiInterface);
 
     internal static readonly IReadOnlyList<ProxyDomain> InterfaceProxyDomains =
         [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, RestApi];
 
-    internal static readonly IReadOnlyList<ProxyDomain> ReactiveConflictDomains =
-        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, RestApi];
+    internal static readonly IReadOnlyList<ProxyDomain> ReactiveConflictDomains = InterfaceProxyDomains;
 
-    internal static readonly string[] RestApiHttpMethodNames =
-        ["Get", "Post", "Put", "Delete", "Patch", "Head", "Options"];
+    internal static readonly string[] RestApiHttpMethodNames = ProxyDomainTable.RestApiHttpMethodNames;
 
     internal static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
     {

--- a/Observables.Shared/Observables.CodeFixes.Tests/ProxyDomainTableTests.cs
+++ b/Observables.Shared/Observables.CodeFixes.Tests/ProxyDomainTableTests.cs
@@ -1,0 +1,142 @@
+using Observables.Roslyn.Shared;
+
+namespace Observables.CodeFixes.Tests;
+
+public sealed class ProxyDomainTableTests
+{
+    public static TheoryData<string, string> MissingBoundaryCases()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var domain in ProxyDomainTable.MemberBoundaryDomains)
+        {
+            data.Add(domain.MissingBoundaryDiagnosticId!, domain.Kind.ToString());
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string, string> ShapeMismatchCases()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var domain in ProxyDomainTable.MemberBoundaryDomains)
+        {
+            data.Add(domain.MemberShapeMismatchDiagnosticId!, domain.Kind.ToString());
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string, string, string?> DefaultAttributeCases()
+    {
+        var data = new TheoryData<string, string, string?>();
+        foreach (var domain in ProxyDomainTable.MemberBoundaryDomains)
+        {
+            data.Add(domain.Kind.ToString(), "method", domain.DefaultMethodAttribute("Alerts"));
+            data.Add(domain.Kind.ToString(), "property", domain.DefaultPropertyAttribute("Alerts"));
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(MissingBoundaryCases))]
+    public void TryGetDomain_maps_missing_boundary_ids(string diagnosticId, string expectedKind)
+    {
+        Assert.True(ObservablesMemberDiagnosticIds.TryGetDomain(diagnosticId, out var domain));
+        Assert.Equal(expectedKind, domain.ToString());
+        Assert.Contains(diagnosticId, ObservablesMemberDiagnosticIds.MissingBoundaryAttribute);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShapeMismatchCases))]
+    public void TryGetDomain_maps_shape_mismatch_ids(string diagnosticId, string expectedKind)
+    {
+        Assert.True(ObservablesMemberDiagnosticIds.TryGetDomain(diagnosticId, out var domain));
+        Assert.Equal(expectedKind, domain.ToString());
+        Assert.Contains(diagnosticId, ObservablesMemberDiagnosticIds.MemberShapeMismatch);
+    }
+
+    [Fact]
+    public void MissingBoundaryAttribute_covers_all_member_boundary_domains()
+    {
+        Assert.Equal(
+            ProxyDomainTable.MemberBoundaryDomains.Select(d => d.MissingBoundaryDiagnosticId!).OrderBy(id => id, StringComparer.Ordinal),
+            ObservablesMemberDiagnosticIds.MissingBoundaryAttribute.OrderBy(id => id, StringComparer.Ordinal));
+    }
+
+    [Theory]
+    [MemberData(nameof(DefaultAttributeCases))]
+    public void BoundaryAttributeDefaults_match_catalog(string domainKind, string memberKind, string? expected)
+    {
+        var domain = Enum.Parse<ObservablesMemberDiagnosticIds.InterfaceProxyDomain>(domainKind);
+        var actual = memberKind == "method"
+            ? BoundaryAttributeDefaults.MethodAttribute(domain, "Alerts")
+            : BoundaryAttributeDefaults.PropertyAttribute(domain, "Alerts");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RequiresMethod_and_RequiresProperty_cover_catalog_attribute_type_names()
+    {
+        foreach (var name in ProxyDomainTable.MethodAttributeTypeNames)
+        {
+            Assert.True(BoundaryAttributeDefaults.RequiresMethod(name), name);
+            Assert.False(BoundaryAttributeDefaults.RequiresProperty(name), name);
+        }
+
+        foreach (var name in ProxyDomainTable.PropertyAttributeTypeNames)
+        {
+            Assert.True(BoundaryAttributeDefaults.RequiresProperty(name), name);
+            Assert.False(BoundaryAttributeDefaults.RequiresMethod(name), name);
+        }
+    }
+
+    [Fact]
+    public void Postgres_Grpc_Sse_Nats_defaults_are_wired()
+    {
+        Assert.Contains("OBS10001", ObservablesMemberDiagnosticIds.MissingBoundaryAttribute);
+        Assert.Contains("OBS10004", ObservablesMemberDiagnosticIds.MemberShapeMismatch);
+        Assert.Contains("OBS7001", ObservablesMemberDiagnosticIds.MissingBoundaryAttribute);
+        Assert.Contains("OBS7004", ObservablesMemberDiagnosticIds.MemberShapeMismatch);
+
+        Assert.Equal(
+            "[Notify(\"Alerts\")]",
+            BoundaryAttributeDefaults.MethodAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Postgres,
+                "Alerts"));
+        Assert.Equal(
+            "[Listen(\"Alerts\")]",
+            BoundaryAttributeDefaults.PropertyAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Postgres,
+                "Alerts"));
+        Assert.Equal(
+            "[GrpcUnary(\"Alerts\")]",
+            BoundaryAttributeDefaults.MethodAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Grpc,
+                "Alerts"));
+        Assert.Null(
+            BoundaryAttributeDefaults.PropertyAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Grpc,
+                "Alerts"));
+        Assert.Null(
+            BoundaryAttributeDefaults.MethodAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Sse,
+                "Alerts"));
+        Assert.Equal(
+            "[SseEvent(\"Alerts\")]",
+            BoundaryAttributeDefaults.PropertyAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Sse,
+                "Alerts"));
+        Assert.Equal(
+            "[NatsPublish(\"Alerts\")]",
+            BoundaryAttributeDefaults.MethodAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Nats,
+                "Alerts"));
+        Assert.Equal(
+            "[NatsSubscribe(\"Alerts\")]",
+            BoundaryAttributeDefaults.PropertyAttribute(
+                ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Nats,
+                "Alerts"));
+    }
+}

--- a/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
+++ b/Observables.Shared/Observables.CodeFixes/BoundaryAttributeDefaults.cs
@@ -1,34 +1,18 @@
+using Observables.Roslyn.Shared;
+
 namespace Observables.CodeFixes;
 
 internal static class BoundaryAttributeDefaults
 {
-    internal static string MethodAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
-        domain switch
-        {
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubInvoke(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttPublish(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketSend(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis => $"[RedisPublish(\"{memberName}\")]",
-            _ => throw new ArgumentOutOfRangeException(nameof(domain)),
-        };
+    internal static string? MethodAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
+        ProxyDomainTable.Get((ProxyDomainTable.DomainKind)domain).DefaultMethodAttribute(memberName);
 
-    internal static string PropertyAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
-        domain switch
-        {
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.SignalR => $"[HubOn(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Mqtt => $"[MqttSubscribe(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.WebSocket => $"[WebSocketReceive(\"{memberName}\")]",
-            ObservablesMemberDiagnosticIds.InterfaceProxyDomain.Redis => $"[RedisSubscribe(\"{memberName}\")]",
-            _ => throw new ArgumentOutOfRangeException(nameof(domain)),
-        };
+    internal static string? PropertyAttribute(ObservablesMemberDiagnosticIds.InterfaceProxyDomain domain, string memberName) =>
+        ProxyDomainTable.Get((ProxyDomainTable.DomainKind)domain).DefaultPropertyAttribute(memberName);
 
     internal static bool RequiresProperty(string attributeName) =>
-        attributeName is "HubOnAttribute" or "MqttSubscribeAttribute" or "WebSocketReceiveAttribute"
-            or "RedisSubscribeAttribute";
+        ProxyDomainTable.PropertyAttributeTypeNames.Contains(attributeName);
 
     internal static bool RequiresMethod(string attributeName) =>
-        attributeName is "HubInvokeAttribute" or "HubSendAttribute" or "HubStreamAttribute"
-            or "MqttPublishAttribute"
-            or "WebSocketSendAttribute" or "WebSocketConnectAttribute" or "WebSocketCloseAttribute"
-            or "RedisPublishAttribute";
+        ProxyDomainTable.MethodAttributeTypeNames.Contains(attributeName);
 }

--- a/Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj
+++ b/Observables.Shared/Observables.CodeFixes/Observables.CodeFixes.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Observables.Roslyn.Shared\ProxyDomainTable.cs">
+      <Link>Shared/ProxyDomainTable.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Observables.CodeFixes.Tests" />
   </ItemGroup>
 

--- a/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
+++ b/Observables.Shared/Observables.CodeFixes/ObservablesMemberDiagnosticIds.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Observables.Roslyn.Shared;
 
 namespace Observables.CodeFixes;
 
@@ -9,36 +10,37 @@ internal static class ObservablesMemberDiagnosticIds
     internal static readonly ImmutableArray<string> PathParameterMismatch = ["OBS3004"];
 
     internal static readonly ImmutableArray<string> MissingBoundaryAttribute =
-        ["OBS4001", "OBS5001", "OBS6001", "OBS8001", "OBS9001", "OBS11001"];
+        ProxyDomainTable.MissingBoundaryDiagnosticIds;
 
     internal static readonly ImmutableArray<string> MemberShapeMismatch =
-        ["OBS4004", "OBS5004", "OBS6004", "OBS8004", "OBS9004", "OBS11004"];
+        ProxyDomainTable.MemberShapeMismatchDiagnosticIds;
 
+    /// <summary>
+    /// Alias of <see cref="ProxyDomainTable.DomainKind"/> for CodeFix call sites / tests.
+    /// RestAPI is intentionally omitted — it uses HTTP-specific fixes.
+    /// </summary>
     internal enum InterfaceProxyDomain
     {
-        SignalR,
-        Mqtt,
-        WebSocket,
-        Sse,
-        Nats,
-        Redis,
+        SignalR = ProxyDomainTable.DomainKind.SignalR,
+        Mqtt = ProxyDomainTable.DomainKind.Mqtt,
+        WebSocket = ProxyDomainTable.DomainKind.WebSocket,
+        Grpc = ProxyDomainTable.DomainKind.Grpc,
+        Sse = ProxyDomainTable.DomainKind.Sse,
+        Nats = ProxyDomainTable.DomainKind.Nats,
+        Postgres = ProxyDomainTable.DomainKind.Postgres,
+        Redis = ProxyDomainTable.DomainKind.Redis,
     }
 
     internal static bool TryGetDomain(string diagnosticId, out InterfaceProxyDomain domain)
     {
-        domain = diagnosticId switch
+        if (ProxyDomainTable.TryGetByDiagnosticId(diagnosticId, out var definition)
+            && definition.Kind != ProxyDomainTable.DomainKind.RestApi)
         {
-            "OBS4001" or "OBS4004" => InterfaceProxyDomain.SignalR,
-            "OBS5001" or "OBS5004" => InterfaceProxyDomain.Mqtt,
-            "OBS6001" or "OBS6004" => InterfaceProxyDomain.WebSocket,
-            "OBS8001" or "OBS8004" => InterfaceProxyDomain.Sse,
-            "OBS9001" or "OBS9004" => InterfaceProxyDomain.Nats,
-            "OBS11001" or "OBS11004" => InterfaceProxyDomain.Redis,
-            _ => default,
-        };
+            domain = (InterfaceProxyDomain)definition.Kind;
+            return true;
+        }
 
-        return diagnosticId is "OBS4001" or "OBS4004" or "OBS5001" or "OBS5004" or "OBS6001" or "OBS6004"
-            or "OBS8001" or "OBS8004" or "OBS9001" or "OBS9004"
-            or "OBS11001" or "OBS11004";
+        domain = default;
+        return false;
     }
 }

--- a/Observables.Shared/Observables.Roslyn.Shared/ProxyDomainTable.cs
+++ b/Observables.Shared/Observables.Roslyn.Shared/ProxyDomainTable.cs
@@ -1,0 +1,304 @@
+using System.Collections.Immutable;
+
+namespace Observables.Roslyn.Shared;
+
+/// <summary>
+/// Pure proxy-domain catalog shared by Analyzers and CodeFixes (linked into both assemblies).
+/// No <c>DiagnosticDescriptor</c> — analyzers bind empty-interface descriptors separately.
+/// </summary>
+internal static class ProxyDomainTable
+{
+    internal enum DomainKind
+    {
+        SignalR,
+        Mqtt,
+        WebSocket,
+        Grpc,
+        Sse,
+        Nats,
+        Postgres,
+        Redis,
+        RestApi,
+    }
+
+    internal sealed class BoundaryAttributeSuggestion
+    {
+        internal BoundaryAttributeSuggestion(string displayText, string insertText)
+        {
+            DisplayText = displayText;
+            InsertText = insertText;
+        }
+
+        internal string DisplayText { get; }
+        internal string InsertText { get; }
+
+        internal string AttributeTypeName => InsertText.EndsWith("Attribute", StringComparison.Ordinal)
+            ? InsertText
+            : InsertText + "Attribute";
+    }
+
+    internal sealed class ProxyDomainDefinition
+    {
+        internal ProxyDomainDefinition(
+            DomainKind kind,
+            string displayName,
+            string interfaceMarkerMetadataName,
+            string reactiveAdapterMetadataName,
+            string? missingBoundaryDiagnosticId,
+            string? memberShapeMismatchDiagnosticId,
+            IReadOnlyList<BoundaryAttributeSuggestion> methodAttributes,
+            IReadOnlyList<BoundaryAttributeSuggestion> propertyAttributes)
+        {
+            Kind = kind;
+            DisplayName = displayName;
+            InterfaceMarkerMetadataName = interfaceMarkerMetadataName;
+            ReactiveAdapterMetadataName = reactiveAdapterMetadataName;
+            MissingBoundaryDiagnosticId = missingBoundaryDiagnosticId;
+            MemberShapeMismatchDiagnosticId = memberShapeMismatchDiagnosticId;
+            MethodAttributes = methodAttributes;
+            PropertyAttributes = propertyAttributes;
+        }
+
+        internal DomainKind Kind { get; }
+        internal string DisplayName { get; }
+        internal string InterfaceMarkerMetadataName { get; }
+        internal string ReactiveAdapterMetadataName { get; }
+        internal string? MissingBoundaryDiagnosticId { get; }
+        internal string? MemberShapeMismatchDiagnosticId { get; }
+        internal IReadOnlyList<BoundaryAttributeSuggestion> MethodAttributes { get; }
+        internal IReadOnlyList<BoundaryAttributeSuggestion> PropertyAttributes { get; }
+
+        internal string ReactiveAssemblyName => $"Observables.{DisplayName}.Reactive";
+
+        internal string? DefaultMethodAttribute(string memberName) =>
+            FormatAttribute(MethodAttributes.Count > 0 ? MethodAttributes[0] : null, memberName);
+
+        internal string? DefaultPropertyAttribute(string memberName) =>
+            FormatAttribute(PropertyAttributes.Count > 0 ? PropertyAttributes[0] : null, memberName);
+
+        static string? FormatAttribute(BoundaryAttributeSuggestion? suggestion, string memberName)
+        {
+            if (suggestion is null)
+            {
+                return null;
+            }
+
+            if (suggestion.InsertText.IndexOf('(') >= 0)
+            {
+                return suggestion.InsertText.StartsWith("[", StringComparison.Ordinal)
+                    ? suggestion.InsertText
+                    : $"[{suggestion.InsertText}";
+            }
+
+            return $"[{suggestion.InsertText}(\"{memberName}\")]";
+        }
+    }
+
+    internal static readonly ProxyDomainDefinition SignalR = new(
+        DomainKind.SignalR,
+        displayName: "SignalR",
+        interfaceMarkerMetadataName: "Observables.SignalR.HubAttribute",
+        reactiveAdapterMetadataName: "Observables.SignalR.Reactive.SystemReactiveSignalRAdapter",
+        missingBoundaryDiagnosticId: "OBS4001",
+        memberShapeMismatchDiagnosticId: "OBS4004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("HubInvoke", "HubInvoke"),
+            new BoundaryAttributeSuggestion("HubSend", "HubSend"),
+            new BoundaryAttributeSuggestion("HubStream", "HubStream"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("HubOn", "HubOn"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition Mqtt = new(
+        DomainKind.Mqtt,
+        displayName: "Mqtt",
+        interfaceMarkerMetadataName: "Observables.Mqtt.MqttAttribute",
+        reactiveAdapterMetadataName: "Observables.Mqtt.Reactive.SystemReactiveMqttAdapter",
+        missingBoundaryDiagnosticId: "OBS5001",
+        memberShapeMismatchDiagnosticId: "OBS5004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("MqttPublish", "MqttPublish"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("MqttSubscribe", "MqttSubscribe"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition WebSocket = new(
+        DomainKind.WebSocket,
+        displayName: "WebSocket",
+        interfaceMarkerMetadataName: "Observables.WebSocket.WebSocketAttribute",
+        reactiveAdapterMetadataName: "Observables.WebSocket.Reactive.SystemReactiveWebSocketAdapter",
+        missingBoundaryDiagnosticId: "OBS6001",
+        memberShapeMismatchDiagnosticId: "OBS6004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("WebSocketSend", "WebSocketSend"),
+            new BoundaryAttributeSuggestion("WebSocketConnect", "WebSocketConnect"),
+            new BoundaryAttributeSuggestion("WebSocketClose", "WebSocketClose"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("WebSocketReceive", "WebSocketReceive"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition Grpc = new(
+        DomainKind.Grpc,
+        displayName: "Grpc",
+        interfaceMarkerMetadataName: "Observables.Grpc.GrpcAttribute",
+        reactiveAdapterMetadataName: "Observables.Grpc.Reactive.SystemReactiveGrpcAdapter",
+        missingBoundaryDiagnosticId: "OBS7001",
+        memberShapeMismatchDiagnosticId: "OBS7004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("GrpcUnary", "GrpcUnary"),
+            new BoundaryAttributeSuggestion("GrpcServerStream", "GrpcServerStream"),
+            new BoundaryAttributeSuggestion("GrpcClientStream", "GrpcClientStream"),
+            new BoundaryAttributeSuggestion("GrpcDuplex", "GrpcDuplex"),
+        ],
+        propertyAttributes: []);
+
+    internal static readonly ProxyDomainDefinition Sse = new(
+        DomainKind.Sse,
+        displayName: "Sse",
+        interfaceMarkerMetadataName: "Observables.Sse.SseAttribute",
+        reactiveAdapterMetadataName: "Observables.Sse.Reactive.SystemReactiveSseAdapter",
+        missingBoundaryDiagnosticId: "OBS8001",
+        memberShapeMismatchDiagnosticId: "OBS8004",
+        methodAttributes: [],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("SseEvent", "SseEvent"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition Nats = new(
+        DomainKind.Nats,
+        displayName: "Nats",
+        interfaceMarkerMetadataName: "Observables.Nats.NatsAttribute",
+        reactiveAdapterMetadataName: "Observables.Nats.Reactive.SystemReactiveNatsAdapter",
+        missingBoundaryDiagnosticId: "OBS9001",
+        memberShapeMismatchDiagnosticId: "OBS9004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("NatsPublish", "NatsPublish"),
+            new BoundaryAttributeSuggestion("NatsRequest", "NatsRequest"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("NatsSubscribe", "NatsSubscribe"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition Postgres = new(
+        DomainKind.Postgres,
+        displayName: "Postgres",
+        interfaceMarkerMetadataName: "Observables.Postgres.PostgresAttribute",
+        reactiveAdapterMetadataName: "Observables.Postgres.Reactive.SystemReactivePostgresAdapter",
+        missingBoundaryDiagnosticId: "OBS10001",
+        memberShapeMismatchDiagnosticId: "OBS10004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("Notify", "Notify"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("Listen", "Listen"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition Redis = new(
+        DomainKind.Redis,
+        displayName: "Redis",
+        interfaceMarkerMetadataName: "Observables.Redis.RedisAttribute",
+        reactiveAdapterMetadataName: "Observables.Redis.Reactive.SystemReactiveRedisAdapter",
+        missingBoundaryDiagnosticId: "OBS11001",
+        memberShapeMismatchDiagnosticId: "OBS11004",
+        methodAttributes:
+        [
+            new BoundaryAttributeSuggestion("RedisPublish", "RedisPublish"),
+        ],
+        propertyAttributes:
+        [
+            new BoundaryAttributeSuggestion("RedisSubscribe", "RedisSubscribe"),
+        ]);
+
+    internal static readonly ProxyDomainDefinition RestApi = new(
+        DomainKind.RestApi,
+        displayName: "RestAPI",
+        interfaceMarkerMetadataName: "Observables.RestAPI.RestApiAttribute",
+        reactiveAdapterMetadataName: "Observables.RestAPI.Reactive.SystemReactiveObservableAdapter",
+        missingBoundaryDiagnosticId: null,
+        memberShapeMismatchDiagnosticId: null,
+        methodAttributes: [],
+        propertyAttributes: []);
+
+    /// <summary>
+    /// Domains with interface markers (including RestAPI). Used by empty-interface analysis and OBS0001.
+    /// </summary>
+    internal static readonly IReadOnlyList<ProxyDomainDefinition> InterfaceProxyDomains =
+        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis, RestApi];
+
+    /// <summary>
+    /// Domains that participate in member missing-attribute / shape CodeFixes (excludes RestAPI).
+    /// </summary>
+    internal static readonly IReadOnlyList<ProxyDomainDefinition> MemberBoundaryDomains =
+        [SignalR, Mqtt, WebSocket, Grpc, Sse, Nats, Postgres, Redis];
+
+    internal static readonly string[] RestApiHttpMethodNames =
+        ["Get", "Post", "Put", "Delete", "Patch", "Head", "Options"];
+
+    internal static readonly ImmutableArray<string> MissingBoundaryDiagnosticIds =
+        MemberBoundaryDomains
+            .Select(d => d.MissingBoundaryDiagnosticId!)
+            .ToImmutableArray();
+
+    internal static readonly ImmutableArray<string> MemberShapeMismatchDiagnosticIds =
+        MemberBoundaryDomains
+            .Select(d => d.MemberShapeMismatchDiagnosticId!)
+            .ToImmutableArray();
+
+    internal static readonly ImmutableHashSet<string> MethodAttributeTypeNames =
+        MemberBoundaryDomains
+            .SelectMany(d => d.MethodAttributes)
+            .Select(a => a.AttributeTypeName)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+    internal static readonly ImmutableHashSet<string> PropertyAttributeTypeNames =
+        MemberBoundaryDomains
+            .SelectMany(d => d.PropertyAttributes)
+            .Select(a => a.AttributeTypeName)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+    internal static bool TryGetByDiagnosticId(string diagnosticId, out ProxyDomainDefinition domain)
+    {
+        foreach (var candidate in MemberBoundaryDomains)
+        {
+            if (candidate.MissingBoundaryDiagnosticId == diagnosticId
+                || candidate.MemberShapeMismatchDiagnosticId == diagnosticId)
+            {
+                domain = candidate;
+                return true;
+            }
+        }
+
+        domain = null!;
+        return false;
+    }
+
+    internal static ProxyDomainDefinition Get(DomainKind kind) =>
+        kind switch
+        {
+            DomainKind.SignalR => SignalR,
+            DomainKind.Mqtt => Mqtt,
+            DomainKind.WebSocket => WebSocket,
+            DomainKind.Grpc => Grpc,
+            DomainKind.Sse => Sse,
+            DomainKind.Nats => Nats,
+            DomainKind.Postgres => Postgres,
+            DomainKind.Redis => Redis,
+            DomainKind.RestApi => RestApi,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+}

--- a/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs
@@ -1,0 +1,73 @@
+#if ROSLYN_4
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Deep pipeline for ForAttributeWithMetadataName interface-proxy stub generators.
+/// Domains supply marker name, parse, emit delegates, and tracking names as adapters.
+/// RestAPI (CreateSyntaxProvider) and Events are out of scope.
+/// </summary>
+internal static class IoProxyGeneratorPipeline
+{
+    internal static void RegisterForAttributeInterfaces<TContextModel, TInterfaceModel>(
+        IncrementalGeneratorInitializationContext context,
+        string interfaceMarkerMetadataName,
+        Func<CSharpCompilation, ImmutableArray<InterfaceDeclarationSyntax>, CancellationToken, (List<Diagnostic> diagnostics, TContextModel model)> parse,
+        DiagnosticDescriptor internalErrorDescriptor,
+        Func<TContextModel> emptyModelFactory,
+        Func<TContextModel, IEnumerable<TInterfaceModel>> getInterfaces,
+        string reportDiagnosticsTrackingName,
+        string buildInterfacesTrackingName,
+        Action<TInterfaceModel, Action<string, SourceText>> emitInterface,
+        Action<TContextModel, Action<string, SourceText>> emitModuleInitializers)
+    {
+        var candidateInterfaces = context.SyntaxProvider.ForAttributeWithMetadataName(
+            interfaceMarkerMetadataName,
+            static (node, _) => node is InterfaceDeclarationSyntax,
+            static (ctx, _) => (InterfaceDeclarationSyntax)ctx.TargetNode);
+
+        var collected = candidateInterfaces
+            .Collect()
+            .Combine(context.CompilationProvider)
+            .Select(static (pair, _) => (pair.Left, pair.Right));
+
+        var parseStep = collected.Select(
+            (input, ct) =>
+                GeneratorFailSafe.ExecuteParse(
+                    () => parse((CSharpCompilation)input.Right, input.Left, ct),
+                    internalErrorDescriptor,
+                    emptyModelFactory));
+
+        var diagnostics = parseStep
+            .Select(static (x, _) => x.diagnostics.ToImmutableEquatableArray())
+            .WithTrackingName(reportDiagnosticsTrackingName);
+        context.ReportDiagnostics(diagnostics);
+
+        var contextModel = parseStep.Select(static (x, _) => x.model);
+        var interfaceModels = contextModel
+            .SelectMany((model, _) => getInterfaces(model))
+            .WithTrackingName(buildInterfacesTrackingName);
+
+        context.RegisterImplementationSourceOutput(
+            interfaceModels,
+            (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => emitInterface(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    internalErrorDescriptor));
+
+        context.RegisterImplementationSourceOutput(
+            contextModel,
+            (spc, model) =>
+                GeneratorFailSafe.TryEmit(
+                    () => emitModuleInitializers(model, (name, code) => spc.AddSource(name, code)),
+                    spc.ReportDiagnostic,
+                    internalErrorDescriptor));
+    }
+}
+#endif

--- a/Observables.Shared/Observables.SourceGenerators.Shared/ProxyRegistrationEmitter.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/ProxyRegistrationEmitter.cs
@@ -1,0 +1,106 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Emits ModuleInitializer registration for single-client
+/// <c>*Service.RegisterGeneratedFactory(Type, Func&lt;TClient, T&gt;)</c> proxies.
+/// RestAPI (two-arg factory) is out of scope.
+/// </summary>
+internal static class ProxyRegistrationEmitter
+{
+    internal readonly struct ProxyTypeRegistration
+    {
+        internal ProxyTypeRegistration(string interfaceDisplayName, string generatedNamespace, string className)
+        {
+            InterfaceDisplayName = interfaceDisplayName;
+            GeneratedNamespace = generatedNamespace;
+            ClassName = className;
+        }
+
+        internal string InterfaceDisplayName { get; }
+        internal string GeneratedNamespace { get; }
+        internal string ClassName { get; }
+    }
+
+    /// <param name="hintName">Source hint, e.g. <c>RedisProxyRegistration.g.cs</c>.</param>
+    /// <param name="registrationClassName">Generated static class name, e.g. <c>RedisProxyRegistration</c>.</param>
+    /// <param name="registerGeneratedFactoryMetadataName">
+    /// Fully-qualified call target without trailing call, e.g.
+    /// <c>global::Observables.Redis.RedisService.RegisterGeneratedFactory</c>.
+    /// </param>
+    /// <param name="registrations">Interfaces to register; empty → no source emitted.</param>
+    /// <param name="addSource">Destination for the generated file.</param>
+    internal static void Emit(
+        string hintName,
+        string registrationClassName,
+        string registerGeneratedFactoryMetadataName,
+        IReadOnlyList<ProxyTypeRegistration> registrations,
+        Action<string, SourceText> addSource)
+    {
+        if (registrations.Count == 0)
+        {
+            return;
+        }
+
+        var dependencyAttributes = string.Join(
+            "\n",
+            registrations.Select(static m =>
+                $"                    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({m.GeneratedNamespace}.{m.ClassName}))]"));
+
+        var registrationCalls = string.Join(
+            "\n",
+            registrations.Select(m =>
+                $"            {registerGeneratedFactoryMetadataName}(typeof({m.InterfaceDisplayName}), static c => new {m.GeneratedNamespace}.{m.ClassName}(c));"));
+
+        // Preserve prior domain behavior: file namespace = first interface's generated namespace.
+        var ns = registrations[0].GeneratedNamespace;
+        addSource(
+            hintName,
+            GeneratedSourceHeader.ToSourceText(
+                $$"""
+                namespace {{ns}}
+                {
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                    internal static class {{registrationClassName}}
+                    {
+                #if NET5_0_OR_GREATER
+                {{dependencyAttributes}}
+                        [System.Runtime.CompilerServices.ModuleInitializer]
+                        [global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026", Justification = "Factory registration only; the proxy is invoked by user code that declares RequiresUnreferencedCode.")]
+                        internal static void Initialize()
+                        {
+                {{registrationCalls}}
+                        }
+                #endif
+                    }
+                }
+                """));
+    }
+
+    /// <summary>
+    /// Builds the registration source text without adding it (for tests / callers that own <see cref="SourceText"/>).
+    /// Returns <see langword="null"/> when <paramref name="registrations"/> is empty.
+    /// </summary>
+    internal static string? BuildSource(
+        string registrationClassName,
+        string registerGeneratedFactoryMetadataName,
+        IReadOnlyList<ProxyTypeRegistration> registrations)
+    {
+        if (registrations.Count == 0)
+        {
+            return null;
+        }
+
+        SourceText? captured = null;
+        Emit(
+            hintName: "unused.g.cs",
+            registrationClassName,
+            registerGeneratedFactoryMetadataName,
+            registrations,
+            (_, text) => captured = text);
+
+        return captured?.ToString();
+    }
+}

--- a/Observables.SourceGenerators.SharedSource.props
+++ b/Observables.SourceGenerators.SharedSource.props
@@ -46,6 +46,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/DiagnosticHelpLink.cs">
       <Link>Shared/DiagnosticHelpLink.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/ProxyRegistrationEmitter.cs">
+      <Link>Shared/ProxyRegistrationEmitter.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs">
+      <Link>Shared/IoProxyGeneratorPipeline.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <!-- Global using to avoid qualifying shared types -->


### PR DESCRIPTION
## Summary
- Add linked `ProxyDomainTable` (`Observables.Roslyn.Shared`) so Analyzers and CodeFixes share one proxy-domain catalog; fix Postgres/Grpc/Sse/Nats CodeFix gaps.
- Add `ProxyRegistrationEmitter` and `IoProxyGeneratorPipeline` for ForAttribute IO stub generators (RestAPI/Events out of scope).
- Record deepened-module terms in `CONTEXT.md`.

Follow-up PRs (stacked on this branch) migrate each IO domain onto these Shared APIs.

## Related Issue

N/A — architecture deepening from improve-codebase-architecture.

## Solution module

- [x] Shared
- [ ] Events
- [ ] RestAPI
- [ ] SignalR
- [ ] WebSocket
- [ ] Mqtt
- [ ] Grpc
- [ ] Solution Items only

Note: also updates root `Observables.SourceGenerators.SharedSource.props` (generator Shared wiring) and adds root `CONTEXT.md`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Source generator / diagnostic change
- [x] Refactor (no behavior change)
- [ ] Docs / repo metadata only

## Test plan

- [x] `dotnet test` Observables.CodeFixes.Tests
- [x] `dotnet test` Observables.Analyzers.Tests
- [ ] Domain generator migrations covered in follow-up PRs

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module (see AGENTS.md) — Shared (+ necessary SharedSource.props / CONTEXT.md)
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [ ] Design Doc updated if API / diagnostic / implementation changed
- [ ] Observables.Docs / Samples synced if user-visible (separate PRs)
- [x] No documentation changes needed (maintainer CONTEXT.md only)

Made with [Cursor](https://cursor.com)