### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@
 
 - **类型**：个人项目（Skymly 工作区）
 - **远端**：https://github.com/Skymly/Observables（私有）；文件夹名 `Observables` = 仓库名；同步状态以 `git status` 为准
-- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.1.9`（**20 包**，含 Redis）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
-- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成，`0.1.9` = 第十域 Redis 已发）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
-- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres，0.1.9 = Redis）
+- **阶段**：**Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis** 已实现（运行时 + 双路生成器 + 测试）；共享层另含 `Observables.CodeFixes` 与 `Observables.Analyzers`；**nuget.org 已发** `0.2.0`（**20 包**）；Nuke `PackVerify` + `eng/nuget-smoke` 覆盖 manifest 包清单
+- **下一里程碑**：post-1.0 维护期（M1–M7 全部完成；`0.1.9` = Redis，`0.2.0` = Shared IO 生成器加深）；待定项见 [`docs/ROADMAP.md`](docs/ROADMAP.md) 末尾
+- **路线图**：里程碑与发版顺序见 [`docs/ROADMAP.md`](docs/ROADMAP.md)（M1 ✅ … M7 ✅，0.1.7 = Postgres，0.1.9 = Redis，0.2.0 = Shared deepening）
 - **结构约定**：下文「仓库结构」与命名约定为权威；**工程治理**（包管理、警告、诊断、版本来源）见下文同名章节
 
 ## 目标

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,13 @@ Stable packages are published to [nuget.org](https://www.nuget.org/profiles/Skym
 | **0.1.7** | Stable release — ninth domain **Postgres** (LISTEN/NOTIFY): `Observables.Postgres.R3` / `.Reactive` (+2 → **18** packages); OBS10xxx; PackVerify / nuget-smoke / Public API baselines. |
 | **0.1.8** | Tag only — Redis release prep on `main`; Publish skipped (`cursor[bot]` not allowlisted). Superseded by **0.1.9**. |
 | **0.1.9** | Stable release — tenth domain **Redis** Pub/Sub: `Observables.Redis.R3` / `.Reactive` (+2 → **20** packages); OBS11xxx; PackVerify / nuget-smoke / Public API baselines. |
+| **0.2.0** | Stable maintenance — Shared proxy domain catalog (Analyzers/CodeFixes); `ProxyRegistrationEmitter` + `IoProxyGeneratorPipeline` for ForAttribute IO domains; still **20** packages. |
 
 Preview builds (`0.1.0-preview*`, `0.1.1-preview*`) were published to NuGet with tags only (no GitHub Release). Details and milestone planning: [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ### Package set
 
-**nuget.org (`0.1.9`)**: twenty packages — ten domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
+**nuget.org (`0.2.0`)**: twenty packages — ten domains, each as `Observables.<Feature>.R3` and `Observables.<Feature>.Reactive`.
 
 | Package ID | Domain |
 |------------|--------|

--- a/Observables.Redis/Observables.Redis.Package/README.Redis.R3.pack.md
+++ b/Observables.Redis/Observables.Redis.Package/README.Redis.R3.pack.md
@@ -5,7 +5,7 @@ Declarative Redis Pub/Sub proxies with Roslyn source generators — annotate int
 ## Install
 
 ```xml
-<PackageReference Include="Observables.Redis.R3" Version="0.1.9" />
+<PackageReference Include="Observables.Redis.R3" Version="0.2.0" />
 <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
 <PackageReference Include="R3" Version="1.3.0" />
 ```

--- a/Observables.Redis/Observables.Redis.Package/README.Redis.Reactive.pack.md
+++ b/Observables.Redis/Observables.Redis.Package/README.Redis.Reactive.pack.md
@@ -5,7 +5,7 @@ Declarative Redis Pub/Sub proxies with Roslyn source generators — annotate int
 ## Install
 
 ```xml
-<PackageReference Include="Observables.Redis.Reactive" Version="0.1.9" />
+<PackageReference Include="Observables.Redis.Reactive" Version="0.2.0" />
 <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
 <PackageReference Include="System.Reactive" Version="6.0.1" />
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ System.Reactive 路径将 `Observables.Events.R3` 换为 `Observables.Events.Rea
 
 ## 功能域
 
-十域均已在主仓提供运行时（按需）、双路源生成器与测试；**`0.1.9`** 将十域 **20 包**（含 **Redis**）发至 nuget.org。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
+十域均已在主仓提供运行时（按需）、双路源生成器与测试；当前稳定版 **`0.2.0`**（**20 包**，含 **Redis**）已发至 nuget.org。共享层另有 `Observables.Core`、`Observables.Analyzers`、`Observables.CodeFixes`。
 
 | 域 | 说明 |
 |----|------|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,16 +1,16 @@
 # Observables 路线图
 
-本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前 nuget.org 稳定版 **`0.1.9`** = 第十域 Redis（20 包））。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
+本文件描述 Observables 从预览版走向 **`0.1.0` 稳定版** 的里程碑规划（M1–M7 已全部完成；当前 nuget.org 稳定版 **`0.2.0`** = Shared IO 生成器加深，仍为 20 包）。它是规划层文档：每个里程碑的工程标准（中央包管理、警告策略、诊断治理等）以 [`AGENTS.md`](../AGENTS.md) 为权威，本文件只排序与拆解。
 
 > 版本号、tag、发版均须维护者明确批准；本文件中的版本号（如 `preview5`）为规划占位，不构成自动发版授权。
 
-## 现状基线（`0.1.9` 已发 nuget.org）
+## 现状基线（`0.2.0` 已发 nuget.org）
 
 | 维度 | 现状 |
 |------|------|
 | 已实现域 | **Events**、**RestAPI**、**SignalR**、**Mqtt**、**WebSocket**、**Grpc**、**Sse**、**Nats**、**Postgres**、**Redis**（运行时 + 双路生成器 + 测试） |
-| 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers` |
-| nuget.org 已发 | **`0.1.9`** — **20 包**（+ Redis R3/Reactive；`v0.1.9` tag + GitHub Release） |
+| 共享层 | `Observables.Core`、`Observables.SourceGenerators.Shared`、`Observables.CodeFixes`、`Observables.Analyzers`；`ProxyDomainTable` / `IoProxyGeneratorPipeline` / `ProxyRegistrationEmitter` |
+| nuget.org 已发 | **`0.2.0`** — **20 包**（`v0.2.0` tag + GitHub Release） |
 | 构建 | 主仓 Nuke `Ci` / `CiPack` / `Publish`；`PackVerify` + `eng/nuget-smoke`（manifest **20** 包） |
 | 示例仓 CI | `Observables.Samples` Nuke `Ci`（对齐库版本；Redis Samples 见跨仓 companion） |
 
@@ -168,6 +168,7 @@ Grpc 两包已于 **`0.1.0`**（`v0.1.0-preview6` tag）发布至 nuget.org 与 
 | `0.1.7` | 稳定版：第九域 **Postgres** LISTEN/NOTIFY（**18 包** + **18 snupkg**；OBS10xxx；ADR-002 §6 mid-trigger） |
 | `0.1.8` | 仅 tag：Redis 发版准备已合入；Publish 因 `cursor[bot]` 不在 allowlist 被跳过；由 **`0.1.9`** 取代 |
 | `0.1.9` | 稳定版：第十域 **Redis** Pub/Sub（**20 包** + **20 snupkg**；OBS11xxx；ADR-002 #2） |
+| `0.2.0` | 稳定维护版：Shared 代理域目录统一 + `ProxyRegistrationEmitter` + `IoProxyGeneratorPipeline`（**20 包** + **20 snupkg**） |
 
 ## Post-1.0 Follow-up（按需，不绑定版本）
 

--- a/eng/Observables.Package.props
+++ b/eng/Observables.Package.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.1.9</Version>
-    <PackageVersion>0.1.9</PackageVersion>
+    <Version>0.2.0</Version>
+    <PackageVersion>0.2.0</PackageVersion>
     <Authors>Skymly</Authors>
     <Copyright>Copyright (c) Skymly. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump `eng/Observables.Package.props` to **0.2.0**.
- Document stable maintenance release: Shared proxy domain catalog + `ProxyRegistrationEmitter` + `IoProxyGeneratorPipeline` (still **20** packages).

## Solution module
- [x] Solution Items / Repository / Docs (release prep, same pattern as 0.1.9)

## Type of change
- [x] Docs / repo metadata only (version bump)

## Test plan
- [ ] CI on this PR
- [ ] After merge: annotated tag `v0.2.0` triggers Publish; GitHub Release for stable

## Breaking changes
- [x] None

Made with [Cursor](https://cursor.com)