### PR TITLE
Fix RestAPI IApiResponse disposing the HTTP response before the caller owns it

### DIFF
--- a/Observables.RestAPI/Observables.RestAPI.Tests/RuntimeTests.cs
+++ b/Observables.RestAPI/Observables.RestAPI.Tests/RuntimeTests.cs
@@ -24,7 +24,7 @@ public sealed class RuntimeTests
         client.BaseAddress = new Uri("https://api.example.com");
 
         var api = RestService.For<IUserApi>(client);
-        User user = await api.GetUser(42);
+        User user = await api.GetUser(42, TestContext.Current.CancellationToken);
 
         Assert.Equal(42, user.Id);
         Assert.Equal("Ada", user.Name);
@@ -58,13 +58,115 @@ public sealed class RuntimeTests
         client.BaseAddress = new Uri("https://api.example.com");
 
         var api = RestService.For<IUserApi>(client);
-        await Assert.ThrowsAsync<ApiException>(() => api.GetUser(404));
+        await Assert.ThrowsAsync<ApiException>(
+            () => api.GetUser(404, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task IApiResponse_does_not_dispose_content_until_caller_disposes()
+    {
+        using var handler = new TrackingJsonHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.com") };
+        var api = RestService.For<IUserApi>(client);
+
+        IApiResponse<User> response = await api.GetUserResponse(1, TestContext.Current.CancellationToken);
+
+        Assert.False(handler.Content.IsDisposed);
+        Assert.True(response.IsSuccessful);
+        Assert.Equal("Ada", response.Content!.Name);
+        Assert.NotNull(response.Headers);
+        Assert.Equal("application/json", response.ContentHeaders?.ContentType?.MediaType);
+
+        response.Dispose();
+        Assert.True(handler.Content.IsDisposed);
+    }
+
+    [Fact]
+    public async Task IApiResponse_caller_cancel_throws_OperationCanceledException()
+    {
+        using var handler = new StallUntilCanceledHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.com") };
+        var api = RestService.For<IUserApi>(client);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        var task = api.GetUserResponse(1, cts.Token);
+        await handler.Started;
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task TaskGet_caller_cancel_throws_OperationCanceledException()
+    {
+        using var handler = new StallUntilCanceledHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.com") };
+        var api = RestService.For<IUserApi>(client);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        var task = api.GetUser(1, cts.Token);
+        await handler.Started;
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task TaskGet_timeout_like_cancel_throws_ApiRequestException()
+    {
+        using var handler = new TimeoutLikeHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.com") };
+        var api = RestService.For<IUserApi>(client);
+
+        var ex = await Assert.ThrowsAsync<ApiRequestException>(
+            () => api.GetUser(1, TestContext.Current.CancellationToken));
+        Assert.IsType<TaskCanceledException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task IApiResponse_timeout_like_cancel_stores_ApiRequestException()
+    {
+        using var handler = new TimeoutLikeHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.com") };
+        var api = RestService.For<IUserApi>(client);
+
+        IApiResponse<User> response = await api.GetUserResponse(1, TestContext.Current.CancellationToken);
+
+        Assert.False(response.IsSuccessful);
+        Assert.True(response.HasRequestError(out var error));
+        Assert.IsType<TaskCanceledException>(error.InnerException);
+    }
+
+    [Fact]
+    public async Task IApiResponse_plain_ExceptionFactory_error_is_coerced()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "https://api.example.com/users/1")
+            .Respond(HttpStatusCode.OK, "application/json", """{"id":1,"name":"Ada"}""");
+
+        var client = mockHttp.ToHttpClient();
+        client.BaseAddress = new Uri("https://api.example.com");
+        var settings = new RestApiSettings
+        {
+            ExceptionFactory = _ => Task.FromResult<Exception?>(new InvalidOperationException("nope")),
+        };
+        var api = RestService.For<IUserApi>(client, settings);
+
+        IApiResponse<User> response = await api.GetUserResponse(1, TestContext.Current.CancellationToken);
+
+        Assert.False(response.IsSuccessful);
+        Assert.IsType<ApiException>(response.Error);
+        Assert.IsType<InvalidOperationException>(response.Error!.InnerException);
+        Assert.Equal("nope", response.Error.InnerException!.Message);
     }
 
     public interface IUserApi
     {
         [Get("/users/{id}")]
-        Task<User> GetUser(int id);
+        Task<User> GetUser(int id, CancellationToken cancellationToken = default);
+
+        [Get("/users/{id}")]
+        Task<IApiResponse<User>> GetUserResponse(int id, CancellationToken cancellationToken = default);
 
         [Get("/users/{id}")]
         Observable<User> GetUserObservable(int id);
@@ -74,5 +176,74 @@ public sealed class RuntimeTests
     {
         public int Id { get; set; }
         public string Name { get; set; } = "";
+    }
+
+    sealed class TrackingJsonHandler : HttpMessageHandler
+    {
+        public TrackingContent Content { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = Content,
+            };
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            return Task.FromResult(response);
+        }
+    }
+
+    sealed class TrackingContent : HttpContent
+    {
+        static readonly byte[] Json = """{"id":1,"name":"Ada"}"""u8.ToArray();
+
+        public bool IsDisposed { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            stream.WriteAsync(Json, 0, Json.Length);
+
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context,
+            CancellationToken cancellationToken) =>
+            stream.WriteAsync(Json, cancellationToken).AsTask();
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Json.Length;
+            return true;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    sealed class StallUntilCanceledHandler : HttpMessageHandler
+    {
+        readonly TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Started => started.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            started.TrySetResult();
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("Unreachable.");
+        }
+    }
+
+    sealed class TimeoutLikeHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromException<HttpResponseMessage>(new TaskCanceledException());
     }
 }

--- a/Observables.RestAPI/Observables.RestAPI/RestApiBridge.cs
+++ b/Observables.RestAPI/Observables.RestAPI/RestApiBridge.cs
@@ -91,6 +91,9 @@ namespace Observables.RestAPI
                 }
                 catch (Exception ex)
                 {
+                    if (IsCallerCancellation(ex, cancellationToken))
+                        throw;
+
                     if (!isApiResponse)
                         throw new ApiRequestException(request, request.Method, settings, ex);
 
@@ -124,6 +127,9 @@ namespace Observables.RestAPI
                     }
                     catch (Exception ex)
                     {
+                        if (IsCallerCancellation(ex, cancellationToken))
+                            throw;
+
                         if (settings.DeserializationExceptionFactory != null)
                             error = await settings
                                 .DeserializationExceptionFactory(response, ex)
@@ -143,12 +149,14 @@ namespace Observables.RestAPI
                         }
                     }
 
+                    // IApiResponse owns the HttpResponseMessage from here.
+                    disposeResponse = false;
                     return ApiResponse.Create<T, TBody>(
                         request,
                         response,
                         body,
                         settings,
-                        error as ApiException
+                        await CoerceToApiExceptionBase(error, request, response, settings).ConfigureAwait(false)
                     );
                 }
                 else if (error != null)
@@ -200,6 +208,10 @@ namespace Observables.RestAPI
                 {
                     response?.Dispose();
                     content?.Dispose();
+                }
+                else if (content is not null && !ReferenceEquals(content, response?.Content))
+                {
+                    content.Dispose();
                 }
             }
         }
@@ -540,6 +552,35 @@ namespace Observables.RestAPI
             deserializedType != typeof(HttpResponseMessage)
             && deserializedType != typeof(HttpContent)
             && deserializedType != typeof(Stream);
+
+        static bool IsCallerCancellation(Exception exception, CancellationToken cancellationToken) =>
+            exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+
+        static async Task<ApiExceptionBase?> CoerceToApiExceptionBase(
+            Exception? error,
+            HttpRequestMessage request,
+            HttpResponseMessage response,
+            RestApiSettings settings)
+        {
+            switch (error)
+            {
+                case null:
+                    return null;
+                case ApiExceptionBase api:
+                    return api;
+                default:
+                    return await ApiException
+                        .Create(
+                            error.Message,
+                            request,
+                            request.Method,
+                            response,
+                            settings,
+                            error
+                        )
+                        .ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// A no-op <see cref="ICustomAttributeProvider"/> that returns no attributes.


### PR DESCRIPTION
## Summary

`IApiResponse` already owns the `HttpResponseMessage` via `IDisposable`, but `RestApiBridge.SendAsync` disposed that response in `finally` before the caller could use it.

This PR transfers ownership when returning the wrapper, rethrows caller cancellation instead of wrapping it as `ApiRequestException`, and coerces non-`ApiExceptionBase` `ExceptionFactory` results so `Error` and `IsSuccessful` stay consistent.

## Related Issue

Fixes #213

Parent map: #212

## Solution module

- [x] RestAPI

## Type of change

- [x] Bug fix

## Test plan

- [x] `dotnet test Observables.RestAPI/Observables.RestAPI.Tests/Observables.RestAPI.Tests.csproj` (net8.0 and net10.0: 9 passed). net9.0 failed locally with a missing `apphost.exe` copy (SDK/obj), unrelated to this change.

## Breaking changes

- [x] None as a version bump. Caller cancellation on `IApiResponse` now throws `OperationCanceledException` instead of returning a wrapper with `Error` (aligned with the existing deserialize path). Timeout-like cancel on `SendAsync` is still `ApiRequestException`. `SendVoidAsync` is unchanged.

## Checklist

- [x] This PR touches **only one** solution module (see [AGENTS.md](AGENTS.md))
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [ ] Design Doc updated if API / diagnostic / implementation changed
- [ ] Observables.Docs / Samples synced if user-visible (separate PRs)
- [x] No documentation changes in this PR — `docs/design/restapi.md` is the Docs module (follow-up from #212)
