### PR TITLE
Stop Postgres Reactive FromListen after OnError

### DIFF
--- a/Observables.Postgres/Observables.Postgres.Reactive.Tests/PostgresReactiveFromListenContractTests.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive.Tests/PostgresReactiveFromListenContractTests.cs
@@ -84,6 +84,7 @@ public sealed class PostgresReactiveFromListenContractTests(PostgresTestServerFi
         Assert.Equal("ready", await ready.Task.WaitAsync(timeout.Token));
 
         subscription.Dispose();
+        await NotifyAsync(notifier, channel, "wake", timeout.Token);
         await WaitUntilIdleAndNotListeningAsync(listener, channel, timeout.Token);
     }
 
@@ -123,9 +124,10 @@ public sealed class PostgresReactiveFromListenContractTests(PostgresTestServerFi
         string channel,
         CancellationToken cancellation)
     {
-        for (var attempt = 0; attempt < 40; attempt++)
+        var sawInProgress = false;
+        long lastCount = -1;
+        while (!cancellation.IsCancellationRequested)
         {
-            cancellation.ThrowIfCancellationRequested();
             try
             {
                 await using var command = new NpgsqlCommand(
@@ -137,19 +139,28 @@ public sealed class PostgresReactiveFromListenContractTests(PostgresTestServerFi
                         new("channel", channel),
                     },
                 };
-                var count = (long)(await command.ExecuteScalarAsync(cancellation))!;
-                if (count == 0)
+                lastCount = Convert.ToInt64(await command.ExecuteScalarAsync(cancellation));
+                if (lastCount == 0)
                 {
                     return;
                 }
             }
             catch (NpgsqlOperationInProgressException)
             {
+                sawInProgress = true;
             }
 
-            await Task.Delay(50, cancellation);
+            try
+            {
+                await Task.Delay(50, cancellation);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
         }
 
-        Assert.Fail($"Connection still listening on '{channel}' or WaitAsync is still in progress.");
+        Assert.Fail(
+            $"Connection still listening on '{channel}' or WaitAsync is still in progress. lastCount={lastCount}, sawInProgress={sawInProgress}.");
     }
 }

--- a/Observables.Postgres/Observables.Postgres.Reactive.Tests/PostgresReactiveFromListenContractTests.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive.Tests/PostgresReactiveFromListenContractTests.cs
@@ -1,0 +1,155 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using Npgsql;
+using Observables.Postgres.Reactive;
+using Observables.Postgres.Reactive.Tests.Contracts;
+using Observables.Postgres.Tests.Infrastructure;
+
+namespace Observables.Postgres.Reactive.Tests;
+
+[Collection(nameof(PostgresTestServerCollection))]
+public sealed class PostgresReactiveFromListenContractTests(PostgresTestServerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task Typed_FromListen_deserialize_failure_stops_the_stream()
+    {
+        const string channel = "rx_listen_onerror";
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var listener = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await listener.OpenAsync(cancellation);
+
+        var nextCount = 0;
+        var completed = 0;
+        var error = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactivePostgresAdapter.FromListen<OrderPayload>(listener, channel)
+            .Subscribe(
+                _ => Interlocked.Increment(ref nextCount),
+                ex => error.TrySetResult(ex),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        timeout.CancelAfter(DefaultTimeout);
+
+        await using var notifier = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await notifier.OpenAsync(cancellation);
+        await NotifyUntilAsync(
+            notifier,
+            channel,
+            "not-json",
+            () => error.Task.IsCompleted,
+            timeout.Token);
+
+        var deserializeError = await error.Task.WaitAsync(timeout.Token);
+        Assert.IsType<JsonException>(deserializeError);
+
+        var valid = JsonSerializer.Serialize(new OrderPayload { OrderId = "after-error", Quantity = 1 });
+        await NotifyAsync(notifier, channel, valid, timeout.Token);
+        await Task.Delay(200, timeout.Token);
+
+        Assert.Equal(0, Volatile.Read(ref nextCount));
+        Assert.Equal(0, Volatile.Read(ref completed));
+
+        await WaitUntilIdleAndNotListeningAsync(listener, channel, timeout.Token);
+    }
+
+    [Fact]
+    public async Task FromListen_dispose_unlistens_and_releases_connection()
+    {
+        const string channel = "rx_listen_dispose";
+        var cancellation = TestContext.Current.CancellationToken;
+
+        await using var listener = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await listener.OpenAsync(cancellation);
+
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = SystemReactivePostgresAdapter.FromListen(listener, channel)
+            .Subscribe(payload => ready.TrySetResult(payload));
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        timeout.CancelAfter(DefaultTimeout);
+
+        await using var notifier = new NpgsqlConnection(fixture.Server.ConnectionString);
+        await notifier.OpenAsync(cancellation);
+        await NotifyUntilAsync(
+            notifier,
+            channel,
+            "ready",
+            () => ready.Task.IsCompleted,
+            timeout.Token);
+
+        Assert.Equal("ready", await ready.Task.WaitAsync(timeout.Token));
+
+        subscription.Dispose();
+        await WaitUntilIdleAndNotListeningAsync(listener, channel, timeout.Token);
+    }
+
+    static async Task NotifyUntilAsync(
+        NpgsqlConnection notifier,
+        string channel,
+        string payload,
+        Func<bool> completed,
+        CancellationToken cancellation)
+    {
+        for (var attempt = 0; attempt < 20 && !completed(); attempt++)
+        {
+            await NotifyAsync(notifier, channel, payload, cancellation);
+            await Task.Delay(50, cancellation);
+        }
+    }
+
+    static async Task NotifyAsync(
+        NpgsqlConnection connection,
+        string channel,
+        string payload,
+        CancellationToken cancellation)
+    {
+        await using var notify = new NpgsqlCommand("SELECT pg_notify(@c, @p);", connection)
+        {
+            Parameters =
+            {
+                new("c", channel),
+                new("p", payload),
+            },
+        };
+        await notify.ExecuteNonQueryAsync(cancellation);
+    }
+
+    static async Task WaitUntilIdleAndNotListeningAsync(
+        NpgsqlConnection connection,
+        string channel,
+        CancellationToken cancellation)
+    {
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            cancellation.ThrowIfCancellationRequested();
+            try
+            {
+                await using var command = new NpgsqlCommand(
+                    "SELECT COUNT(*) FROM pg_listening_channels() AS t(channel) WHERE t.channel = @channel;",
+                    connection)
+                {
+                    Parameters =
+                    {
+                        new("channel", channel),
+                    },
+                };
+                var count = (long)(await command.ExecuteScalarAsync(cancellation))!;
+                if (count == 0)
+                {
+                    return;
+                }
+            }
+            catch (NpgsqlOperationInProgressException)
+            {
+            }
+
+            await Task.Delay(50, cancellation);
+        }
+
+        Assert.Fail($"Connection still listening on '{channel}' or WaitAsync is still in progress.");
+    }
+}

--- a/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
@@ -13,6 +13,8 @@ public static class SystemReactivePostgresAdapter
         @"^[A-Za-z_][A-Za-z0-9_]*$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
+    static readonly TimeSpan ListenWaitSlice = TimeSpan.FromMilliseconds(250);
+
     /// <summary>
     /// Hot stream: <c>LISTEN</c> on <paramref name="channel"/> and emit notification payloads until disposed.
     /// Runs a WaitAsync loop on <paramref name="connection"/> for the
@@ -38,6 +40,7 @@ public static class SystemReactivePostgresAdapter
             }
 
             connection.Notification += Handler;
+            Exception? error = null;
             try
             {
                 await using (var listen = new NpgsqlCommand(
@@ -47,38 +50,28 @@ public static class SystemReactivePostgresAdapter
                     await listen.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
                 }
 
-                while (!ct.IsCancellationRequested)
-                {
-                    await connection.WaitAsync(ct).ConfigureAwait(false);
-                }
-
-                observer.OnCompleted();
+                await WaitForNotificationsAsync(connection, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                observer.OnCompleted();
             }
             catch (Exception ex)
             {
-                observer.OnError(ex);
+                error = ex;
             }
             finally
             {
                 connection.Notification -= Handler;
-                try
-                {
-                    if (connection.State == ConnectionState.Open)
-                    {
-                        await using var unlisten = new NpgsqlCommand(
-                            "UNLISTEN " + QuoteIdent(channel) + ";",
-                            connection);
-                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-                catch
-                {
-                    // Best-effort cleanup when the connection is already broken.
-                }
+                await UnlistenBestEffortAsync(connection, channel).ConfigureAwait(false);
+            }
+
+            if (error is not null)
+            {
+                observer.OnError(error);
+            }
+            else if (!ct.IsCancellationRequested)
+            {
+                observer.OnCompleted();
             }
         });
     }
@@ -102,6 +95,7 @@ public static class SystemReactivePostgresAdapter
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             var hasError = false;
+            Exception? error = null;
 
             void Handler(object sender, NpgsqlNotificationEventArgs args)
             {
@@ -118,7 +112,13 @@ public static class SystemReactivePostgresAdapter
                 {
                     hasError = true;
                     observer.OnError(ex);
-                    cts.Cancel();
+                    try
+                    {
+                        cts.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                    }
                 }
             }
 
@@ -132,44 +132,33 @@ public static class SystemReactivePostgresAdapter
                     await listen.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
                 }
 
-                while (!cts.Token.IsCancellationRequested)
-                {
-                    await connection.WaitAsync(cts.Token).ConfigureAwait(false);
-                }
-
-                if (!hasError)
-                {
-                    observer.OnCompleted();
-                }
+                await WaitForNotificationsAsync(connection, cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                if (!hasError)
-                {
-                    observer.OnCompleted();
-                }
             }
             catch (Exception ex)
             {
-                observer.OnError(ex);
+                error = ex;
             }
             finally
             {
                 connection.Notification -= Handler;
-                try
-                {
-                    if (connection.State == ConnectionState.Open)
-                    {
-                        await using var unlisten = new NpgsqlCommand(
-                            "UNLISTEN " + QuoteIdent(channel) + ";",
-                            connection);
-                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-                catch
-                {
-                    // Best-effort cleanup when the connection is already broken.
-                }
+                await UnlistenBestEffortAsync(connection, channel).ConfigureAwait(false);
+            }
+
+            if (hasError)
+            {
+                return;
+            }
+
+            if (error is not null)
+            {
+                observer.OnError(error);
+            }
+            else if (!ct.IsCancellationRequested)
+            {
+                observer.OnCompleted();
             }
         });
     }
@@ -246,6 +235,42 @@ public static class SystemReactivePostgresAdapter
             await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
+    }
+
+    static async Task WaitForNotificationsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await connection.WaitAsync(ListenWaitSlice, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    static async Task UnlistenBestEffortAsync(NpgsqlConnection connection, string channel)
+    {
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            try
+            {
+                if ((connection.State & ConnectionState.Open) == 0)
+                {
+                    return;
+                }
+
+                await using var unlisten = new NpgsqlCommand(
+                    "UNLISTEN " + QuoteIdent(channel) + ";",
+                    connection);
+                await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+                return;
+            }
+            catch (NpgsqlOperationInProgressException)
+            {
+                await Task.Delay(25, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                return;
+            }
+        }
     }
 
     static void ValidateChannelName(string channel)

--- a/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
@@ -1,6 +1,5 @@
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using Npgsql;
@@ -28,65 +27,57 @@ public static class SystemReactivePostgresAdapter
 
         ValidateChannelName(channel);
 
-        return Observable.Create<string>(observer =>
+        return Observable.Create<string>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            _ = RunAsync();
-
-            return Disposable.Create(cts.Cancel);
-
-            async Task RunAsync()
+            void Handler(object sender, NpgsqlNotificationEventArgs args)
             {
-                void Handler(object sender, NpgsqlNotificationEventArgs args)
+                if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
                 {
-                    if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                    {
-                        observer.OnNext(args.Payload ?? string.Empty);
-                    }
+                    observer.OnNext(args.Payload ?? string.Empty);
+                }
+            }
+
+            connection.Notification += Handler;
+            try
+            {
+                await using (var listen = new NpgsqlCommand(
+                    "LISTEN " + QuoteIdent(channel) + ";",
+                    connection))
+                {
+                    await listen.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
                 }
 
-                connection.Notification += Handler;
+                while (!ct.IsCancellationRequested)
+                {
+                    await connection.WaitAsync(ct).ConfigureAwait(false);
+                }
+
+                observer.OnCompleted();
+            }
+            catch (OperationCanceledException)
+            {
+                observer.OnCompleted();
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
+            }
+            finally
+            {
+                connection.Notification -= Handler;
                 try
                 {
-                    await using (var listen = new NpgsqlCommand(
-                        "LISTEN " + QuoteIdent(channel) + ";",
-                        connection))
+                    if (connection.State == ConnectionState.Open)
                     {
-                        await listen.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
+                        await using var unlisten = new NpgsqlCommand(
+                            "UNLISTEN " + QuoteIdent(channel) + ";",
+                            connection);
+                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
                     }
-
-                    while (!cts.Token.IsCancellationRequested)
-                    {
-                        await connection.WaitAsync(cts.Token).ConfigureAwait(false);
-                    }
-
-                    observer.OnCompleted();
                 }
-                catch (OperationCanceledException)
+                catch
                 {
-                    observer.OnCompleted();
-                }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
-                finally
-                {
-                    connection.Notification -= Handler;
-                    try
-                    {
-                        if (connection.State == ConnectionState.Open)
-                        {
-                            await using var unlisten = new NpgsqlCommand(
-                                "UNLISTEN " + QuoteIdent(channel) + ";",
-                                connection);
-                            await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                        }
-                    }
-                    catch
-                    {
-                        // Best-effort cleanup when the connection is already broken.
-                    }
+                    // Best-effort cleanup when the connection is already broken.
                 }
             }
         });
@@ -107,74 +98,77 @@ public static class SystemReactivePostgresAdapter
 
         ValidateChannelName(channel);
 
-        return Observable.Create<T>(observer =>
+        return Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            _ = RunAsync();
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var hasError = false;
 
-            return Disposable.Create(cts.Cancel);
-
-            async Task RunAsync()
+            void Handler(object sender, NpgsqlNotificationEventArgs args)
             {
-                void Handler(object sender, NpgsqlNotificationEventArgs args)
+                if (!string.Equals(args.Channel, channel, StringComparison.Ordinal))
                 {
-                    if (!string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                    {
-                        return;
-                    }
-
-                    try
-                    {
-                        observer.OnNext(PostgresPayload.Deserialize<T>(args.Payload));
-                    }
-                    catch (Exception ex)
-                    {
-                        observer.OnError(ex);
-                    }
+                    return;
                 }
 
-                connection.Notification += Handler;
                 try
                 {
-                    await using (var listen = new NpgsqlCommand(
-                        "LISTEN " + QuoteIdent(channel) + ";",
-                        connection))
-                    {
-                        await listen.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
-                    }
-
-                    while (!cts.Token.IsCancellationRequested)
-                    {
-                        await connection.WaitAsync(cts.Token).ConfigureAwait(false);
-                    }
-
-                    observer.OnCompleted();
-                }
-                catch (OperationCanceledException)
-                {
-                    observer.OnCompleted();
+                    observer.OnNext(PostgresPayload.Deserialize<T>(args.Payload));
                 }
                 catch (Exception ex)
                 {
+                    hasError = true;
                     observer.OnError(ex);
+                    cts.Cancel();
                 }
-                finally
+            }
+
+            connection.Notification += Handler;
+            try
+            {
+                await using (var listen = new NpgsqlCommand(
+                    "LISTEN " + QuoteIdent(channel) + ";",
+                    connection))
                 {
-                    connection.Notification -= Handler;
-                    try
+                    await listen.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
+                }
+
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    await connection.WaitAsync(cts.Token).ConfigureAwait(false);
+                }
+
+                if (!hasError)
+                {
+                    observer.OnCompleted();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (!hasError)
+                {
+                    observer.OnCompleted();
+                }
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
+            }
+            finally
+            {
+                connection.Notification -= Handler;
+                try
+                {
+                    if (connection.State == ConnectionState.Open)
                     {
-                        if (connection.State == ConnectionState.Open)
-                        {
-                            await using var unlisten = new NpgsqlCommand(
-                                "UNLISTEN " + QuoteIdent(channel) + ";",
-                                connection);
-                            await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                        }
+                        await using var unlisten = new NpgsqlCommand(
+                            "UNLISTEN " + QuoteIdent(channel) + ";",
+                            connection);
+                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
                     }
-                    catch
-                    {
-                        // Best-effort cleanup when the connection is already broken.
-                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup when the connection is already broken.
                 }
             }
         });


### PR DESCRIPTION
## Summary

Reactive Postgres `FromListen` / `FromListen<T>` subscribed with synchronous `Observable.Create` and a fire-and-forget `WaitAsync` loop. Typed deserialize failures called `OnError` without stopping that loop, so later `OnNext` / `OnCompleted` could still run (Rx contract).

This switches hot listen to System.Reactive async `Observable.Create(Func<IObserver<T>, CancellationToken, Task>)`. Dispose cancels the token Rx already passes in. Typed deserialize failure errors the observer **and** cancels the listen loop. `UNLISTEN` still runs best-effort in `finally`.

R3 `OnErrorResume` is unchanged.

Fixes #216

## Module boundary

Postgres only (`Observables.Postgres/`). No Shared pump extraction (#215).

## Test plan

- [x] `dotnet test Observables.Postgres/Observables.Postgres.Reactive.Tests/Observables.Postgres.Reactive.Tests.csproj --framework net8.0`
- [x] `dotnet test Observables.Postgres/Observables.Postgres.Tests/Observables.Postgres.Tests.csproj --framework net8.0`
- [x] Postgres R3 and Reactive generator tests (`net8.0`)
- Contract tests in `Postgres.Reactive.Tests`:
  - After deserialize `OnError` on `FromListen<T>`, no further `OnNext` / `OnCompleted`, and the session UNLISTENs
  - Dispose of untyped `FromListen` cancels the wait loop and UNLISTENs