### PR TITLE
Honor Redis FromPublish cancellation without waiting

### DIFF
--- a/Observables.Redis/Observables.Redis.Reactive.Tests/Observables.Redis.Reactive.Tests.csproj
+++ b/Observables.Redis/Observables.Redis.Reactive.Tests/Observables.Redis.Reactive.Tests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\Observables.Redis.Tests\Infrastructure\RedisTestServer.cs" Link="Infrastructure\RedisTestServer.cs" />
     <Compile Include="..\Observables.Redis.Tests\Infrastructure\RedisTestServerFixture.cs" Link="Infrastructure\RedisTestServerFixture.cs" />
     <Compile Include="..\Observables.Redis.Tests\Infrastructure\RedisE2EHelpers.cs" Link="Infrastructure\RedisE2EHelpers.cs" />
+    <Compile Include="..\Observables.Redis.Tests\Infrastructure\HangingRedis.cs" Link="Infrastructure\HangingRedis.cs" />
   </ItemGroup>
 
 </Project>

--- a/Observables.Redis/Observables.Redis.Reactive.Tests/RedisFromPublishCancellationTests.cs
+++ b/Observables.Redis/Observables.Redis.Reactive.Tests/RedisFromPublishCancellationTests.cs
@@ -1,0 +1,28 @@
+using Observables.Redis.Reactive;
+using Observables.Redis.Tests.Infrastructure;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Observables.Redis.Reactive.Tests;
+
+public sealed class RedisFromPublishCancellationTests
+{
+    [Fact]
+    public async Task FromPublish_cancel_does_not_wait_on_uncancelable_publish()
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+        var (multiplexer, publishStarted) = HangingRedis.CreateForPublish();
+        using var cts = new CancellationTokenSource();
+
+        var consume = SystemReactiveRedisAdapter.FromPublish(multiplexer, "cancel.publish", cts.Token)
+            .FirstAsync()
+            .ToTask(cancellation);
+        await publishStarted.WaitAsync(cancellation);
+        cts.Cancel();
+
+        var timeout = Task.Delay(TimeSpan.FromSeconds(2), cancellation);
+        var completed = await Task.WhenAny(consume, timeout);
+        Assert.Same(consume, completed);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consume);
+    }
+}

--- a/Observables.Redis/Observables.Redis.Reactive.Tests/RedisReactiveSubscribeContractTests.cs
+++ b/Observables.Redis/Observables.Redis.Reactive.Tests/RedisReactiveSubscribeContractTests.cs
@@ -1,0 +1,67 @@
+using Observables.Redis.Reactive;
+using Observables.Redis.Tests.Infrastructure;
+using StackExchange.Redis;
+using System.Reactive.Linq;
+
+namespace Observables.Redis.Reactive.Tests;
+
+[Collection(nameof(RedisTestServerCollection))]
+public sealed class RedisReactiveSubscribeContractTests(RedisTestServerFixture fixture)
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task FromSubscribe_dispose_cancels_the_pump_without_completing()
+    {
+        var channel = "rx.dispose." + Guid.NewGuid().ToString("N");
+        await AssertDisposeCancelsAsync(
+            mux => SystemReactiveRedisAdapter.FromSubscribe<string>(mux, channel),
+            RedisChannel.Literal(channel));
+    }
+
+    [Fact]
+    public async Task FromPatternSubscribe_dispose_cancels_the_pump_without_completing()
+    {
+        var prefix = "rx.pdispose." + Guid.NewGuid().ToString("N");
+        await AssertDisposeCancelsAsync(
+            mux => SystemReactiveRedisAdapter.FromPatternSubscribe<string>(mux, prefix + ".*"),
+            RedisChannel.Literal(prefix + ".a"));
+    }
+
+    async Task AssertDisposeCancelsAsync(
+        Func<IConnectionMultiplexer, IObservable<string>> subscribe,
+        RedisChannel warmupChannel)
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+        await using var mux = await fixture.Server.ConnectAsync(cancellation);
+        await using var publisherMux = await fixture.Server.ConnectAsync(cancellation);
+        var publisher = publisherMux.GetSubscriber();
+
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = subscribe(mux).Subscribe(
+            value => ready.TrySetResult(value),
+            _ => Interlocked.Exchange(ref errored, 1),
+            () => Interlocked.Exchange(ref completed, 1));
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        cts.CancelAfter(DefaultTimeout);
+        await RedisE2EHelpers.PublishUntilReceivedAsync(
+            async _ =>
+            {
+                await publisher.PublishAsync(warmupChannel, "ready");
+            },
+            ready.Task,
+            cts.Token);
+
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, cancellation);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
+    }
+}

--- a/Observables.Redis/Observables.Redis.Reactive/SystemReactiveRedisAdapter.cs
+++ b/Observables.Redis/Observables.Redis.Reactive/SystemReactiveRedisAdapter.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using StackExchange.Redis;
 #if NET8_0_OR_GREATER
@@ -28,6 +27,7 @@ public static class SystemReactiveRedisAdapter
             var subscriber = multiplexer.GetSubscriber();
             await subscriber
                 .PublishAsync(RedisChannel.Literal(channel), payload ?? Array.Empty<byte>())
+                .WaitAsync(linked.Token)
                 .ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
@@ -103,49 +103,37 @@ public static class SystemReactiveRedisAdapter
         IConnectionMultiplexer multiplexer,
         RedisChannel channel,
         Func<ChannelMessage, T> map) =>
-        Observable.Create<T>(observer =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            _ = RunAsync();
-
-            return Disposable.Create(cts.Cancel);
-
-            async Task RunAsync()
+            ChannelMessageQueue? queue = null;
+            try
             {
-                ChannelMessageQueue? queue = null;
-                try
-                {
-                    var subscriber = multiplexer.GetSubscriber();
-                    queue = await subscriber.SubscribeAsync(channel).ConfigureAwait(false);
+                var subscriber = multiplexer.GetSubscriber();
+                queue = await subscriber.SubscribeAsync(channel).ConfigureAwait(false);
 
-                    // ChannelMessageQueue enumeration is sequential (SER OnMessage / queue path).
-                    await foreach (var message in queue.WithCancellation(cts.Token).ConfigureAwait(false))
+                // ChannelMessageQueue enumeration is sequential (SER OnMessage / queue path).
+                await foreach (var message in queue.WithCancellation(ct).ConfigureAwait(false))
+                {
+                    observer.OnNext(map(message));
+                }
+
+                observer.OnCompleted();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                observer.OnError(ex);
+            }
+            finally
+            {
+                if (queue is not null)
+                {
+                    try
                     {
-                        observer.OnNext(map(message));
+                        await queue.UnsubscribeAsync().ConfigureAwait(false);
                     }
-
-                    observer.OnCompleted();
-                }
-                catch (OperationCanceledException)
-                {
-                    observer.OnCompleted();
-                }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
-                finally
-                {
-                    if (queue is not null)
+                    catch (Exception)
                     {
-                        try
-                        {
-                            await queue.UnsubscribeAsync().ConfigureAwait(false);
-                        }
-                        catch (Exception)
-                        {
-                            // best-effort unsubscribe on dispose / fault
-                        }
+                        // best-effort unsubscribe on dispose / fault
                     }
                 }
             }

--- a/Observables.Redis/Observables.Redis.Tests/Infrastructure/HangingRedis.cs
+++ b/Observables.Redis/Observables.Redis.Tests/Infrastructure/HangingRedis.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using StackExchange.Redis;
+
+namespace Observables.Redis.Tests.Infrastructure;
+
+internal static class HangingRedis
+{
+    public static (IConnectionMultiplexer Multiplexer, Task PublishStarted) CreateForPublish()
+    {
+        var publishStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var subscriber = DispatchProxy.Create<ISubscriber, HangingSubscriberProxy>();
+        ((HangingSubscriberProxy)(object)subscriber).PublishStarted = publishStarted;
+
+        var multiplexer = DispatchProxy.Create<IConnectionMultiplexer, HangingMultiplexerProxy>();
+        ((HangingMultiplexerProxy)(object)multiplexer).Subscriber = subscriber;
+        return (multiplexer, publishStarted.Task);
+    }
+
+    public class HangingMultiplexerProxy : DispatchProxy
+    {
+        public ISubscriber Subscriber { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IConnectionMultiplexer.GetSubscriber))
+            {
+                return Subscriber;
+            }
+
+            throw new NotSupportedException(targetMethod?.Name);
+        }
+    }
+
+    public class HangingSubscriberProxy : DispatchProxy
+    {
+        public TaskCompletionSource PublishStarted { get; set; } = null!;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(ISubscriber.PublishAsync))
+            {
+                PublishStarted.TrySetResult();
+                return new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
+            }
+
+            throw new NotSupportedException(targetMethod?.Name);
+        }
+    }
+}

--- a/Observables.Redis/Observables.Redis.Tests/RedisFromPublishCancellationTests.cs
+++ b/Observables.Redis/Observables.Redis.Tests/RedisFromPublishCancellationTests.cs
@@ -1,0 +1,24 @@
+using Observables.Redis.Tests.Infrastructure;
+using R3;
+
+namespace Observables.Redis.Tests;
+
+public sealed class RedisFromPublishCancellationTests
+{
+    [Fact]
+    public async Task FromPublish_cancel_does_not_wait_on_uncancelable_publish()
+    {
+        var cancellation = TestContext.Current.CancellationToken;
+        var (multiplexer, publishStarted) = HangingRedis.CreateForPublish();
+        using var cts = new CancellationTokenSource();
+
+        var consume = RedisObservable.FromPublish(multiplexer, "cancel.publish", cts.Token).FirstAsync(cancellation);
+        await publishStarted.WaitAsync(cancellation);
+        cts.Cancel();
+
+        var timeout = Task.Delay(TimeSpan.FromSeconds(2), cancellation);
+        var completed = await Task.WhenAny(consume, timeout);
+        Assert.Same(consume, completed);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consume);
+    }
+}

--- a/Observables.Redis/Observables.Redis/RedisObservable.cs
+++ b/Observables.Redis/Observables.Redis/RedisObservable.cs
@@ -27,6 +27,7 @@ public static class RedisObservable
             var subscriber = multiplexer.GetSubscriber();
             await subscriber
                 .PublishAsync(RedisChannel.Literal(channel), payload ?? Array.Empty<byte>())
+                .WaitAsync(linked.Token)
                 .ConfigureAwait(false);
             return Unit.Default;
         });


### PR DESCRIPTION
## Summary

`FromPublish` built a linked cancellation token, called `ThrowIfCancellationRequested()`, then awaited StackExchange.Redis `PublishAsync` without observing that token. SER has no token parameter, so cancel waited on an uncancelable publish.

Observe the linked token with `WaitAsync` on both R3 and Reactive. Switch Reactive exact and pattern subscribe from fire-and-forget `Observable.Create` to Rx async `Create(Func<IObserver<T>, CancellationToken, Task>)` so dispose cancels the pump.

Fixes #217

## Related Issue

Fixes #217

## Solution module

- [x] Redis

## Type of change

- [x] Bug fix

## Test plan

- [x] `dotnet test Observables.Redis/Observables.Redis.Tests/Observables.Redis.Tests.csproj --framework net8.0`
- [x] `dotnet test Observables.Redis/Observables.Redis.Reactive.Tests/Observables.Redis.Reactive.Tests.csproj --framework net8.0`
- [x] Redis R3 and Reactive generator tests (`net8.0`)
- Hanging `PublishAsync` doubles: cancel does not wait on either backend
- Reactive `FromSubscribe` / `FromPatternSubscribe` dispose cancels the pump without `OnCompleted` (separate publisher mux; does not poke the subscriber mux after dispose)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [x] No documentation changes needed