### PR TITLE
Fix MQTT hash matching, unsubscribe, and dispose race

### DIFF
--- a/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/MqttClientReactiveE2ETests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.Tests/MqttClientReactiveE2ETests.cs
@@ -1,6 +1,7 @@
 using MQTTnet;
 using MQTTnet.Client;
 using Observables.Mqtt;
+using Observables.Mqtt.Reactive;
 using Observables.Mqtt.Reactive.Tests.Contracts;
 using Observables.Mqtt.Tests.Infrastructure;
 using System.Reactive.Linq;
@@ -53,5 +54,59 @@ public sealed class MqttClientReactiveE2ETests(MqttTestBrokerFixture fixture)
         await pubHub.PublishPing().Timeout(DefaultTimeout).FirstAsync().ToTask();
 
         Assert.Equal(string.Empty, await receive);
+    }
+
+    [Fact]
+    public async Task FromSubscribe_multi_level_wildcard_receives_parent_topic()
+    {
+        await using var session = await fixture.Broker.ConnectAsync(TestContext.Current.CancellationToken);
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        const string topicFilter = "e2e/hash/#";
+
+        var waitSubscription = fixture.Broker.WaitForSubscriptionAsync(
+            session.ClientId,
+            topicFilter,
+            cts.Token);
+        var receive = SystemReactiveMqttAdapter.FromSubscribe<string>(session.Client, topicFilter)
+            .Timeout(DefaultTimeout)
+            .FirstAsync()
+            .ToTask();
+        await waitSubscription;
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic("e2e/hash")
+            .WithPayload("zero"u8.ToArray())
+            .Build();
+        await session.Client.PublishAsync(message, cts.Token);
+
+        Assert.Equal("zero", await receive);
+    }
+
+    [Fact]
+    public async Task FromSubscribe_dispose_unsubscribes_topic_filter()
+    {
+        await using var session = await fixture.Broker.ConnectAsync(TestContext.Current.CancellationToken);
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        const string topicFilter = "e2e/unsub";
+
+        var waitSubscription = fixture.Broker.WaitForSubscriptionAsync(
+            session.ClientId,
+            topicFilter,
+            cts.Token);
+        var subscription = SystemReactiveMqttAdapter.FromSubscribe<string>(session.Client, topicFilter)
+            .Subscribe(_ => { });
+        try
+        {
+            await waitSubscription;
+            var waitUnsubscription = fixture.Broker.WaitForUnsubscriptionAsync(
+                session.ClientId,
+                topicFilter,
+                cts.Token);
+            subscription.Dispose();
+            await waitUnsubscription;
+        }
+        finally
+        {
+            subscription.Dispose();
+        }
     }
 }

--- a/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
@@ -1,7 +1,4 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
@@ -36,63 +33,51 @@ public static class SystemReactiveMqttAdapter
     [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
 #endif
     public static IObservable<T> FromSubscribe<T>(IMqttClient client, string topicFilter) =>
-        Observable.Create<T>(observer =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var gate = new object();
-            Func<MqttApplicationMessageReceivedEventArgs, Task>? handler = null;
-
-            _ = SubscribeAsync();
-
-            return Disposable.Create(() =>
+            async Task Handler(MqttApplicationMessageReceivedEventArgs e)
             {
-                lock (gate)
+                if (!Mqtt.MqttTopicMatcher.Matches(topicFilter, e.ApplicationMessage.Topic))
                 {
-                    if (handler is not null)
-                    {
-                        client.ApplicationMessageReceivedAsync -= handler;
-                        handler = null;
-                    }
+                    return;
                 }
-            });
 
-            async Task SubscribeAsync()
-            {
                 try
                 {
-                    handler = async e =>
-                    {
-                        if (!Mqtt.MqttTopicMatcher.Matches(topicFilter, e.ApplicationMessage.Topic))
-                        {
-                            return;
-                        }
-
-                        try
-                        {
-                            var payload = e.ApplicationMessage.PayloadSegment.Count == 0
-                                ? Array.Empty<byte>()
-                                : e.ApplicationMessage.PayloadSegment.ToArray();
-                            observer.OnNext(MqttPayloadSerializers.Deserialize<T>(payload));
-                        }
-                        catch (Exception ex)
-                        {
-                            observer.OnError(ex);
-                        }
-
-                        await Task.CompletedTask.ConfigureAwait(false);
-                    };
-
-                    lock (gate)
-                    {
-                        client.ApplicationMessageReceivedAsync += handler;
-                    }
-
-                    await client
-                        .SubscribeAsync(new MqttTopicFilterBuilder().WithTopic(topicFilter).Build())
-                        .ConfigureAwait(false);
+                    var payload = e.ApplicationMessage.PayloadSegment.Count == 0
+                        ? Array.Empty<byte>()
+                        : e.ApplicationMessage.PayloadSegment.ToArray();
+                    observer.OnNext(MqttPayloadSerializers.Deserialize<T>(payload));
                 }
                 catch (Exception ex)
                 {
                     observer.OnError(ex);
+                }
+
+                await Task.CompletedTask.ConfigureAwait(false);
+            }
+
+            client.ApplicationMessageReceivedAsync += Handler;
+            try
+            {
+                await client
+                    .SubscribeAsync(
+                        new MqttTopicFilterBuilder().WithTopic(topicFilter).Build(),
+                        ct)
+                    .ConfigureAwait(false);
+
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                client.ApplicationMessageReceivedAsync -= Handler;
+                try
+                {
+                    await client.UnsubscribeAsync(topicFilter).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // best-effort if the client is already down
                 }
             }
         });

--- a/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBroker.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/Infrastructure/MqttTestBroker.cs
@@ -81,6 +81,36 @@ public sealed class MqttTestBroker : IAsyncDisposable
         }
     }
 
+    /// <summary>Waits until the broker accepts an unsubscription for <paramref name="topicFilter"/> from <paramref name="clientId"/>.</summary>
+    public async Task WaitForUnsubscriptionAsync(
+        string clientId,
+        string topicFilter,
+        CancellationToken cancellationToken = default)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task Handler(InterceptingUnsubscriptionEventArgs e)
+        {
+            if (string.Equals(e.ClientId, clientId, StringComparison.Ordinal)
+                && string.Equals(e.Topic, topicFilter, StringComparison.Ordinal))
+            {
+                tcs.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        server.InterceptingUnsubscriptionAsync += Handler;
+        try
+        {
+            await tcs.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            server.InterceptingUnsubscriptionAsync -= Handler;
+        }
+    }
+
     public async Task<MqttClientSession> ConnectAsync(CancellationToken cancellationToken = default)
     {
         var clientId = Guid.NewGuid().ToString("N");

--- a/Observables.Mqtt/Observables.Mqtt.Tests/MqttClientR3E2ETests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/MqttClientR3E2ETests.cs
@@ -53,4 +53,54 @@ public sealed class MqttClientR3E2ETests(MqttTestBrokerFixture fixture)
 
         Assert.Equal(string.Empty, await receive);
     }
+
+    [Fact]
+    public async Task FromSubscribe_multi_level_wildcard_receives_parent_topic()
+    {
+        await using var session = await fixture.Broker.ConnectAsync(TestContext.Current.CancellationToken);
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        const string topicFilter = "e2e/hash/#";
+
+        var waitSubscription = fixture.Broker.WaitForSubscriptionAsync(
+            session.ClientId,
+            topicFilter,
+            cts.Token);
+        var receive = MqttObservable.FromSubscribe<string>(session.Client, topicFilter).FirstAsync(cts.Token);
+        await waitSubscription;
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic("e2e/hash")
+            .WithPayload("zero"u8.ToArray())
+            .Build();
+        await session.Client.PublishAsync(message, cts.Token);
+
+        Assert.Equal("zero", await receive);
+    }
+
+    [Fact]
+    public async Task FromSubscribe_dispose_unsubscribes_topic_filter()
+    {
+        await using var session = await fixture.Broker.ConnectAsync(TestContext.Current.CancellationToken);
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        const string topicFilter = "e2e/unsub";
+
+        var waitSubscription = fixture.Broker.WaitForSubscriptionAsync(
+            session.ClientId,
+            topicFilter,
+            cts.Token);
+        var subscription = MqttObservable.FromSubscribe<string>(session.Client, topicFilter).Subscribe(_ => { });
+        try
+        {
+            await waitSubscription;
+            var waitUnsubscription = fixture.Broker.WaitForUnsubscriptionAsync(
+                session.ClientId,
+                topicFilter,
+                cts.Token);
+            subscription.Dispose();
+            await waitUnsubscription;
+        }
+        finally
+        {
+            subscription.Dispose();
+        }
+    }
 }

--- a/Observables.Mqtt/Observables.Mqtt.Tests/MqttTopicMatcherTests.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Tests/MqttTopicMatcherTests.cs
@@ -1,0 +1,51 @@
+namespace Observables.Mqtt.Tests;
+
+public sealed class MqttTopicMatcherTests
+{
+    [Theory]
+    [InlineData("a/#", "a")]
+    [InlineData("a/#", "a/b")]
+    [InlineData("a/#", "a/b/c")]
+    [InlineData("#", "a")]
+    [InlineData("#", "a/b")]
+    [InlineData("+/b/#", "x/b")]
+    [InlineData("+/b/#", "x/b/c")]
+    [InlineData("sport/tennis/player1/#", "sport/tennis/player1")]
+    [InlineData("sport/tennis/player1/#", "sport/tennis/player1/ranking")]
+    public void Multi_level_wildcard_matches_zero_or_more_remaining_levels(string filter, string topic)
+    {
+        Assert.True(MqttTopicMatcher.Matches(filter, topic));
+    }
+
+    [Theory]
+    [InlineData("a", "a")]
+    [InlineData("a/b", "a/b")]
+    [InlineData("a/+", "a/b")]
+    [InlineData("+/+", "a/b")]
+    [InlineData("a/+/c", "a/b/c")]
+    [InlineData("a/+/c", "a//c")]
+    public void Exact_and_single_level_filters_match(string filter, string topic)
+    {
+        Assert.True(MqttTopicMatcher.Matches(filter, topic));
+    }
+
+    [Theory]
+    [InlineData("a/#", "b")]
+    [InlineData("a/#", "b/a")]
+    [InlineData("a/b/#", "a")]
+    [InlineData("a/+", "a")]
+    [InlineData("a/+", "a/b/c")]
+    [InlineData("a/b", "a/b/c")]
+    [InlineData("a/b", "a")]
+    [InlineData("+/b", "a")]
+    public void Filter_does_not_match_unrelated_topics(string filter, string topic)
+    {
+        Assert.False(MqttTopicMatcher.Matches(filter, topic));
+    }
+
+    [Fact]
+    public void Null_topic_does_not_match()
+    {
+        Assert.False(MqttTopicMatcher.Matches("a/#", null));
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
@@ -78,6 +78,14 @@ public static class MqttObservable
             finally
             {
                 client.ApplicationMessageReceivedAsync -= Handler;
+                try
+                {
+                    await client.UnsubscribeAsync(topicFilter).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // best-effort if the client is already down
+                }
             }
         });
 }

--- a/Observables.Mqtt/Observables.Mqtt/MqttTopicMatcher.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttTopicMatcher.cs
@@ -16,15 +16,15 @@ internal static class MqttTopicMatcher
         var topicParts = topic.Split('/');
         for (var i = 0; i < filterParts.Length; i++)
         {
-            if (i >= topicParts.Length)
-            {
-                return false;
-            }
-
             var fp = filterParts[i];
             if (fp == MultiLevelWildcard)
             {
                 return true;
+            }
+
+            if (i >= topicParts.Length)
+            {
+                return false;
             }
 
             if (fp != SingleLevelWildcard && fp != topicParts[i])

--- a/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
+++ b/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Observables.Mqtt.Reactive" />
+    <InternalsVisibleTo Include="Observables.Mqtt.Tests" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

MQTT subscribe dropped parent topics for `#` filters, never unsubscribed on dispose, and could miss handler detach on Reactive.

- Match `#` against zero remaining levels so `a/#` accepts `a` as well as `a/b`.
- Call `UnsubscribeAsync` on dispose for R3 and Reactive (best-effort if the client is already down).
- Switch Reactive `FromSubscribe` to Rx async `Create` and attach the message handler before `SubscribeAsync`.

## Related Issue

Fixes #218

## Solution module

- [x] Mqtt

## Type of change

- [x] Bug fix

## Test plan

- [x] `dotnet test` (Mqtt.Tests, Mqtt.Reactive.Tests, Mqtt generator tests):
  ```
  dotnet test Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj -f net8.0
  dotnet test Observables.Mqtt/Observables.Mqtt.Tests/Observables.Mqtt.Tests.csproj -f net10.0
  dotnet test Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj -f net8.0
  dotnet test Observables.Mqtt/Observables.Mqtt.Reactive.Tests/Observables.Mqtt.Reactive.Tests.csproj -f net10.0
  dotnet test Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators.Tests/Observables.Mqtt.R3.SourceGenerators.Tests.csproj -f net8.0
  dotnet test Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators.Tests/Observables.Mqtt.Reactive.SourceGenerators.Tests.csproj -f net8.0
  ```

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module (see [AGENTS.md](AGENTS.md))
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [x] No documentation changes needed
