### PR TITLE
Use Rx async Create for Nats Reactive FromSubscribe

### DIFF
--- a/Observables.Nats/Observables.Nats.Reactive.Tests/NatsClientReactiveE2ETests.cs
+++ b/Observables.Nats/Observables.Nats.Reactive.Tests/NatsClientReactiveE2ETests.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core;
 using Observables.Nats;
+using Observables.Nats.Reactive;
 using Observables.Nats.Reactive.Tests.Contracts;
 using Observables.Nats.Tests.Infrastructure;
 using System.Reactive.Linq;
@@ -53,5 +54,40 @@ public sealed class NatsClientReactiveE2ETests(NatsTestServerFixture fixture)
 
         var result = await receive;
         Assert.True(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public async Task FromSubscribe_dispose_cancels_the_pump_without_completing()
+    {
+        await using var subscriber = new NatsConnection(CreateOpts(fixture.Server.Url));
+        await using var publisher = new NatsConnection(CreateOpts(fixture.Server.Url));
+        var subject = "e2e.dispose." + Guid.NewGuid().ToString("N");
+
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactiveNatsAdapter.FromSubscribe<string>(subscriber, subject)
+            .Subscribe(
+                value => ready.TrySetResult(value),
+                _ => Interlocked.Exchange(ref errored, 1),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        await NatsE2EHelpers.PublishUntilReceivedAsync(
+            async ct =>
+            {
+                await publisher.PublishAsync(subject, "ready", cancellationToken: ct);
+            },
+            ready.Task,
+            cts.Token);
+
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, cts.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
     }
 }

--- a/Observables.Nats/Observables.Nats.Reactive/SystemReactiveNatsAdapter.cs
+++ b/Observables.Nats/Observables.Nats.Reactive/SystemReactiveNatsAdapter.cs
@@ -43,29 +43,21 @@ public static class SystemReactiveNatsAdapter
     [RequiresDynamicCode("NATS payload serialization may use reflection.")]
 #endif
     public static IObservable<T> FromSubscribe<T>(INatsConnection connection, string subject) =>
-        Observable.Create<T>(observer =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            _ = SubscribeAsync();
-
-            return () => cts.Cancel();
-
-            async Task SubscribeAsync()
+            try
             {
-                try
+                await foreach (var msg in connection.SubscribeAsync<T>(subject, cancellationToken: ct)
+                                   .ConfigureAwait(false))
                 {
-                    await foreach (var msg in connection.SubscribeAsync<T>(subject, cancellationToken: cts.Token)
-                                       .ConfigureAwait(false))
-                    {
-                        observer.OnNext(msg.Data!);
-                    }
+                    observer.OnNext(msg.Data!);
+                }
 
-                    observer.OnCompleted();
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    observer.OnError(ex);
-                }
+                observer.OnCompleted();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                observer.OnError(ex);
             }
         });
 


### PR DESCRIPTION
## Summary

Reactive `FromSubscribe` used synchronous `Observable.Create` and a fire-and-forget `SubscribeAsync` pump with a private `CancellationTokenSource`. Dispose now cancels through System.Reactive `Observable.Create(Func<IObserver<T>, CancellationToken, Task>)`, the token the subscribe enumeration already awaits. NATS client serde (`SubscribeAsync<T>` / `msg.Data`) is unchanged.

Fixes #219

## Related Issue

Fixes #219

## Solution module

- [x] Nats

## Type of change

- [x] Bug fix

## Test plan

- [x] `dotnet test Observables.Nats/Observables.Nats.Tests/Observables.Nats.Tests.csproj --framework net8.0`
- [x] `dotnet test Observables.Nats/Observables.Nats.Reactive.Tests/Observables.Nats.Reactive.Tests.csproj --framework net8.0`
- [x] Nats R3 and Reactive generator tests (`net8.0`)
- Reactive `FromSubscribe` dispose cancels the pump without `OnCompleted` / `OnError` (separate publisher connection; does not poke the subscriber after dispose)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English** (no AI/agent tooling mentions in commits)
- [x] No version bumps, tags, releases, or NuGet publish steps included unless explicitly requested
- [x] No documentation changes needed