### PR TITLE
Use Rx async Create for Sse Reactive FromEvent

### DIFF
--- a/Observables.Sse/Observables.Sse.Reactive.Tests/SseClientReactiveE2ETests.cs
+++ b/Observables.Sse/Observables.Sse.Reactive.Tests/SseClientReactiveE2ETests.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using Observables.Sse;
+using Observables.Sse.Reactive;
 using Observables.Sse.Reactive.Tests.Contracts;
 using Observables.Sse.Tests.Infrastructure;
 
@@ -43,5 +44,31 @@ public sealed class SseClientReactiveE2ETests(SseTestServerFixture fixture)
         var tick = await feed.Ticks.Timeout(DefaultTimeout).FirstAsync().ToTask();
 
         Assert.Equal(42, tick.Value);
+    }
+
+    [Fact]
+    public async Task FromEvent_dispose_cancels_the_pump_without_completing()
+    {
+        using var http = new HttpClient();
+        var connection = new SseConnection(http, fixture.Server.KeepAliveUri);
+
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactiveSseAdapter.FromEvent<string>(connection, "price")
+            .Subscribe(
+                value => ready.TrySetResult(value),
+                _ => Interlocked.Exchange(ref errored, 1),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, cts.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
     }
 }

--- a/Observables.Sse/Observables.Sse.Reactive/SystemReactiveSseAdapter.cs
+++ b/Observables.Sse/Observables.Sse.Reactive/SystemReactiveSseAdapter.cs
@@ -1,9 +1,7 @@
 using System.IO;
 using System.Net.Http;
-using System.Reactive.Disposables;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Reactive.Linq;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -22,55 +20,46 @@ public static class SystemReactiveSseAdapter
     [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
 #endif
     public static IObservable<T> FromEvent<T>(SseConnection connection, string eventName) =>
-        System.Reactive.Linq.Observable.Create<T>(observer =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-
-            _ = RunAsync();
-
-            return Disposable.Create(() => cts.Cancel());
-
-            async Task RunAsync()
+            try
             {
-                try
-                {
-                    using var request = new HttpRequestMessage(HttpMethod.Get, connection.Endpoint);
-                    request.Headers.Accept.ParseAdd("text/event-stream");
+                using var request = new HttpRequestMessage(HttpMethod.Get, connection.Endpoint);
+                request.Headers.Accept.ParseAdd("text/event-stream");
 
-                    using var response = await connection.HttpClient
-                        .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token)
-                        .ConfigureAwait(false);
-                    response.EnsureSuccessStatusCode();
+                using var response = await connection.HttpClient
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+                    .ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
 
 #if NET8_0_OR_GREATER
-                    using var stream = await response.Content.ReadAsStreamAsync(cts.Token).ConfigureAwait(false);
+                using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
 #else
-                    using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-                    using var reader = new StreamReader(stream, Encoding.UTF8);
+                using var reader = new StreamReader(stream, Encoding.UTF8);
 
-                    while (!cts.IsCancellationRequested)
+                while (!ct.IsCancellationRequested)
+                {
+                    var sseEvent = await SseProtocol.ReadEventAsync(reader).ConfigureAwait(false);
+                    if (sseEvent is null)
                     {
-                        var sseEvent = await SseProtocol.ReadEventAsync(reader).ConfigureAwait(false);
-                        if (sseEvent is null)
-                        {
-                            observer.OnCompleted();
-                            return;
-                        }
+                        observer.OnCompleted();
+                        return;
+                    }
 
-                        if (sseEvent.Value.EventName == eventName)
-                        {
-                            observer.OnNext(SseProtocol.Deserialize<T>(sseEvent.Value.Data));
-                        }
+                    if (sseEvent.Value.EventName == eventName)
+                    {
+                        observer.OnNext(SseProtocol.Deserialize<T>(sseEvent.Value.Data));
                     }
                 }
-                catch (OperationCanceledException)
-                {
-                }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
             }
         });
 }

--- a/Observables.Sse/Observables.Sse.Tests/Infrastructure/SseTestServer.cs
+++ b/Observables.Sse/Observables.Sse.Tests/Infrastructure/SseTestServer.cs
@@ -7,7 +7,7 @@ namespace Observables.Sse.Tests.Infrastructure;
 /// <summary>Minimal in-process <c>text/event-stream</c> server for E2E tests.</summary>
 public sealed class SseTestServer : IAsyncDisposable
 {
-    // One deterministic event block written per request, then the response closes.
+    // `/stream` writes one deterministic event block then closes. `/keepalive` emits one event and holds the response open.
     const string Stream =
         ": comment line\n" +
         "event: price\n" +
@@ -36,6 +36,8 @@ public sealed class SseTestServer : IAsyncDisposable
     public int Port { get; }
 
     public Uri Uri => new($"http://127.0.0.1:{Port}/stream");
+
+    public Uri KeepAliveUri => new($"http://127.0.0.1:{Port}/keepalive");
 
     public static SseTestServer Start()
     {
@@ -78,19 +80,37 @@ public sealed class SseTestServer : IAsyncDisposable
                 return;
             }
 
-            _ = HandleAsync(context);
+            _ = HandleAsync(context, cancellationToken);
         }
     }
 
-    static async Task HandleAsync(HttpListenerContext context)
+    static async Task HandleAsync(HttpListenerContext context, CancellationToken cancellationToken)
     {
         try
         {
             context.Response.ContentType = "text/event-stream";
             context.Response.StatusCode = 200;
+
+            var path = context.Request.Url?.AbsolutePath ?? string.Empty;
+            if (path.Equals("/keepalive", StringComparison.OrdinalIgnoreCase))
+            {
+                context.Response.SendChunked = true;
+                var ready = Encoding.UTF8.GetBytes(
+                    "event: price\n" +
+                    "data: ready\n" +
+                    "\n");
+                await context.Response.OutputStream.WriteAsync(ready, 0, ready.Length).ConfigureAwait(false);
+                await context.Response.OutputStream.FlushAsync().ConfigureAwait(false);
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
             var bytes = Encoding.UTF8.GetBytes(Stream);
             await context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
             await context.Response.OutputStream.FlushAsync().ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
         }
         catch
         {


### PR DESCRIPTION
## Summary

Reactive `FromEvent` subscribed with synchronous `Observable.Create` and fire-and-forget `RunAsync`. Dispose now cancels the token System.Reactive async `Create` already passes into `SendAsync` / the read loop.

Fixes #220

## Module boundary

Sse only. No Shared pump extraction (#215).

## Test plan

- [x] `dotnet test` Sse.Reactive.Tests net8.0
- [x] `dotnet test` Sse.Tests net8.0
- Dispose of an open keepalive stream does not `OnCompleted` / `OnError`