### PR TITLE
Use Rx async Create for WebSocket Reactive FromReceive

### DIFF
--- a/Observables.WebSocket/Observables.WebSocket.Reactive.Tests/WebSocketClientReactiveE2ETests.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.Tests/WebSocketClientReactiveE2ETests.cs
@@ -1,7 +1,9 @@
 using System.Net.WebSockets;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Text;
 using Observables.WebSocket;
+using Observables.WebSocket.Reactive;
 using Observables.WebSocket.Reactive.Tests.Contracts;
 using Observables.WebSocket.Tests.Infrastructure;
 
@@ -77,5 +79,34 @@ public sealed class WebSocketClientReactiveE2ETests(WebSocketTestServerFixture f
         var received = await receiveTask;
         Assert.Equal(expected.Length, received.Length);
         Assert.Equal(expected, received);
+    }
+
+    [Fact]
+    public async Task FromReceive_dispose_cancels_the_pump_without_completing()
+    {
+        using var socket = new ClientWebSocket();
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        await socket.ConnectAsync(fixture.Server.Uri, cts.Token);
+
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactiveWebSocketAdapter.FromReceive<string>(socket)
+            .Subscribe(
+                value => ready.TrySetResult(value),
+                _ => Interlocked.Exchange(ref errored, 1),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        var payload = Encoding.UTF8.GetBytes("ready");
+        await socket.SendAsync(new ArraySegment<byte>(payload), WebSocketMessageType.Text, true, cts.Token);
+
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, cts.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
     }
 }

--- a/Observables.WebSocket/Observables.WebSocket.Reactive/SystemReactiveWebSocketAdapter.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive/SystemReactiveWebSocketAdapter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Net.WebSockets;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
@@ -85,65 +84,44 @@ public static class SystemReactiveWebSocketAdapter
     [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
 #endif
     public static IObservable<T> FromReceive<T>(ClientWebSocket socket) =>
-        System.Reactive.Linq.Observable.Create<T>(observer =>
+        System.Reactive.Linq.Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-
-            _ = ReceiveLoopAsync();
-
-            return Disposable.Create(() => cts.Cancel());
-
-            async Task ReceiveLoopAsync()
+            var buffer = new byte[4096];
+            try
             {
-                var buffer = new byte[4096];
-                try
+                while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
                 {
-                    while (!cts.IsCancellationRequested && socket.State == WebSocketState.Open)
+                    // Assemble potentially fragmented message
+                    using var ms = new MemoryStream();
+                    WebSocketMessageType messageType = WebSocketMessageType.Binary;
+                    WebSocketReceiveResult result;
+                    do
                     {
-                        // Assemble potentially fragmented message
-                        using var ms = new MemoryStream();
-                        WebSocketMessageType messageType = WebSocketMessageType.Binary;
-                        WebSocketReceiveResult result;
-                        try
-                        {
-                            do
-                            {
-                                result = await socket
-                                    .ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token)
-                                    .ConfigureAwait(false);
+                        result = await socket
+                            .ReceiveAsync(new ArraySegment<byte>(buffer), ct)
+                            .ConfigureAwait(false);
 
-                                if (result.MessageType == WebSocketMessageType.Close)
-                                {
-                                    observer.OnCompleted();
-                                    return;
-                                }
-
-                                messageType = result.MessageType;
-                                ms.Write(buffer, 0, result.Count);
-                            }
-                            while (!result.EndOfMessage);
-                        }
-                        catch (OperationCanceledException)
+                        if (result.MessageType == WebSocketMessageType.Close)
                         {
+                            observer.OnCompleted();
                             return;
                         }
 
-                        var payload = ms.ToArray();
-                        try
-                        {
-                            observer.OnNext(DeserializePayload<T>(payload, messageType));
-                        }
-                        catch (Exception ex)
-                        {
-                            observer.OnError(ex);
-                            return;
-                        }
+                        messageType = result.MessageType;
+                        ms.Write(buffer, 0, result.Count);
                     }
+                    while (!result.EndOfMessage);
+
+                    var payload = ms.ToArray();
+                    observer.OnNext(DeserializePayload<T>(payload, messageType));
                 }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
             }
         });
 


### PR DESCRIPTION
## Summary

Reactive `FromReceive` subscribed with synchronous `Observable.Create` and fire-and-forget `ReceiveLoopAsync`. Dispose now cancels the token System.Reactive async `Create` already passes into `ReceiveAsync`.

Fixes #221

## Module boundary

WebSocket only. No Shared pump extraction (#215). One-shot `FromConnect` / `FromClose` / `FromSend` unchanged.

## Test plan

- [x] WebSocket.Reactive.Tests net8.0
- Dispose of an open receive pump does not `OnCompleted` / `OnError`