### PR TITLE
Use Rx async Create for Grpc Reactive streaming

### DIFF
--- a/Observables.Grpc/Observables.Grpc.Reactive.Tests/Contracts/IE2EReactiveHub.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.Tests/Contracts/IE2EReactiveHub.cs
@@ -8,4 +8,7 @@ public interface IE2EReactiveHub
 {
     [GrpcUnary("UnaryEcho")]
     IObservable<EchoReply> UnaryEcho(EchoRequest request, CancellationToken cancellationToken = default);
+
+    [GrpcServerStream("ServerStreamEcho")]
+    IObservable<EchoReply> ServerStreamEcho(EchoRequest request, CancellationToken cancellationToken = default);
 }

--- a/Observables.Grpc/Observables.Grpc.Reactive.Tests/GrpcClientReactiveE2ETests.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.Tests/GrpcClientReactiveE2ETests.cs
@@ -27,4 +27,50 @@ public sealed class GrpcClientReactiveE2ETests(GrpcTestHostFixture fixture)
 
         Assert.Equal("hello-reactive-grpc", reply.Text);
     }
+
+    [Fact]
+    public async Task ServerStreamEcho_emits_multiple_items()
+    {
+        using var channel = GrpcTestChannel.Create(fixture.Host);
+        var client = GrpcService.For<IE2EReactiveHub>(channel.CreateCallInvoker());
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        var replies = await client
+            .ServerStreamEcho(new EchoRequest { Text = "stream" }, cts.Token)
+            .Take(3)
+            .ToArray()
+            .Timeout(DefaultTimeout)
+            .ToTask();
+
+        Assert.Equal(3, replies.Length);
+        Assert.Equal("stream-0", replies[0].Text);
+        Assert.Equal("stream-2", replies[2].Text);
+    }
+
+    [Fact]
+    public async Task FromServerStreaming_dispose_cancels_the_pump_without_completing()
+    {
+        using var channel = GrpcTestChannel.Create(fixture.Host);
+        var client = GrpcService.For<IE2EReactiveHub>(channel.CreateCallInvoker());
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = client
+            .ServerStreamEcho(new EchoRequest { Text = "hang" }, cts.Token)
+            .Subscribe(
+                value => ready.TrySetResult(value.Text),
+                _ => Interlocked.Exchange(ref errored, 1),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, cts.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
+    }
 }

--- a/Observables.Grpc/Observables.Grpc.Reactive.Tests/SystemReactiveGrpcAdapterTests.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.Tests/SystemReactiveGrpcAdapterTests.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using Grpc.Core;
+using Observables.Grpc.Reactive;
+using System.Reactive.Subjects;
+
+namespace Observables.Grpc.Reactive.Tests;
+
+public sealed class SystemReactiveGrpcAdapterTests
+{
+    static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task FromServerStreaming_linked_token_lives_until_dispose()
+    {
+        var reader = new HangingStreamReader<string>("ready");
+        var invoker = new FakeCallInvoker(reader);
+        await AssertLinkedTokenLivesUntilDispose(
+            SystemReactiveGrpcAdapter.FromServerStreaming(
+                invoker,
+                CreateMethod(MethodType.ServerStreaming),
+                "request",
+                TestContext.Current.CancellationToken),
+            invoker,
+            reader);
+    }
+
+    [Fact]
+    public async Task FromDuplexStreaming_linked_token_lives_until_dispose()
+    {
+        var reader = new HangingStreamReader<string>("ready");
+        var writer = new NoopClientStreamWriter<string>();
+        var invoker = new FakeCallInvoker(reader, writer);
+        var requests = new Subject<string>();
+        await AssertLinkedTokenLivesUntilDispose(
+            SystemReactiveGrpcAdapter.FromDuplexStreaming(
+                invoker,
+                CreateMethod(MethodType.DuplexStreaming),
+                requests,
+                TestContext.Current.CancellationToken),
+            invoker,
+            reader);
+    }
+
+    static async Task AssertLinkedTokenLivesUntilDispose(
+        IObservable<string> stream,
+        FakeCallInvoker invoker,
+        HangingStreamReader<string> reader)
+    {
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = stream.Subscribe(
+            value => ready.TrySetResult(value),
+            _ => Interlocked.Exchange(ref errored, 1),
+            () => Interlocked.Exchange(ref completed, 1));
+
+        using var cts = new CancellationTokenSource(DefaultTimeout);
+        Assert.Equal("ready", await ready.Task.WaitAsync(cts.Token));
+        Assert.False(invoker.CallToken.IsCancellationRequested);
+
+        subscription.Dispose();
+        await reader.MoveNextCancelled.Task.WaitAsync(cts.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
+    }
+
+    static Method<string, string> CreateMethod(MethodType type) =>
+        new(
+            type,
+            "test.Service",
+            "Method",
+            Marshallers.Create<string>(Encoding.UTF8.GetBytes, Encoding.UTF8.GetString),
+            Marshallers.Create<string>(Encoding.UTF8.GetBytes, Encoding.UTF8.GetString));
+
+    sealed class HangingStreamReader<T> : IAsyncStreamReader<T>
+        where T : class
+    {
+        readonly T first;
+        int moved;
+
+        public HangingStreamReader(T first) => this.first = first;
+
+        public T Current { get; private set; } = null!;
+
+        public TaskCompletionSource MoveNextCancelled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref moved) == 1)
+            {
+                Current = first;
+                return true;
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                MoveNextCancelled.TrySetResult();
+                throw;
+            }
+        }
+    }
+
+    sealed class NoopClientStreamWriter<T> : IClientStreamWriter<T>
+    {
+        public WriteOptions? WriteOptions { get; set; }
+
+        public Task CompleteAsync() => Task.CompletedTask;
+
+        public Task WriteAsync(T message) => Task.CompletedTask;
+    }
+
+    sealed class FakeCallInvoker : CallInvoker
+    {
+        readonly object reader;
+        readonly object? writer;
+
+        public FakeCallInvoker(object reader, object? writer = null)
+        {
+            this.reader = reader;
+            this.writer = writer;
+        }
+
+        public CancellationToken CallToken { get; private set; }
+
+        public override TResponse BlockingUnaryCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            string? host,
+            CallOptions options,
+            TRequest request) =>
+            throw new NotSupportedException();
+
+        public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            string? host,
+            CallOptions options) =>
+            throw new NotSupportedException();
+
+        public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            string? host,
+            CallOptions options)
+        {
+            CallToken = options.CancellationToken;
+            return new AsyncDuplexStreamingCall<TRequest, TResponse>(
+                (IClientStreamWriter<TRequest>)writer!,
+                (IAsyncStreamReader<TResponse>)reader,
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+
+        public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            string? host,
+            CallOptions options,
+            TRequest request)
+        {
+            CallToken = options.CancellationToken;
+            return new AsyncServerStreamingCall<TResponse>(
+                (IAsyncStreamReader<TResponse>)reader,
+                Task.FromResult(new Metadata()),
+                () => Status.DefaultSuccess,
+                () => new Metadata(),
+                () => { });
+        }
+
+        public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+            Method<TRequest, TResponse> method,
+            string? host,
+            CallOptions options,
+            TRequest request) =>
+            throw new NotSupportedException();
+    }
+}

--- a/Observables.Grpc/Observables.Grpc.Reactive/SystemReactiveGrpcAdapter.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive/SystemReactiveGrpcAdapter.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Grpc.Core;
 
@@ -32,36 +31,30 @@ public static class SystemReactiveGrpcAdapter
         CancellationToken cancellationToken = default)
         where TRequest : class
         where TResponse : class =>
-        Observable.Create<TResponse>(observer =>
+        Observable.Create<TResponse>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
-            _ = PumpAsync();
-
-            return Disposable.Create(() => cts.Cancel());
-
-            async Task PumpAsync()
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
+            try
             {
-                try
-                {
-                    using var call = invoker.AsyncServerStreamingCall(
-                        method,
-                        host: null,
-                        options: new CallOptions(cancellationToken: linked.Token),
-                        request);
+                using var call = invoker.AsyncServerStreamingCall(
+                    method,
+                    host: null,
+                    options: new CallOptions(cancellationToken: linked.Token),
+                    request);
 
-                    while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
-                    {
-                        observer.OnNext(call.ResponseStream.Current);
-                    }
-
-                    observer.OnCompleted();
-                }
-                catch (OperationCanceledException) { }
-                catch (Exception ex)
+                while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
                 {
-                    observer.OnError(ex);
+                    observer.OnNext(call.ResponseStream.Current);
                 }
+
+                observer.OnCompleted();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
             }
         });
 
@@ -99,15 +92,10 @@ public static class SystemReactiveGrpcAdapter
         CancellationToken cancellationToken = default)
         where TRequest : class
         where TResponse : class =>
-        Observable.Create<TResponse>(observer =>
+        Observable.Create<TResponse>(async (observer, ct) =>
         {
-            var cts = new CancellationTokenSource();
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
-            _ = PumpAsync();
-
-            return Disposable.Create(() => cts.Cancel());
-
-            async Task PumpAsync()
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
+            try
             {
                 using var call = invoker.AsyncDuplexStreamingCall(
                     method,
@@ -118,20 +106,19 @@ public static class SystemReactiveGrpcAdapter
                     item => WriteRequest(call.RequestStream, item),
                     () => _ = call.RequestStream.CompleteAsync());
 
-                try
+                while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
                 {
-                    while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
-                    {
-                        observer.OnNext(call.ResponseStream.Current);
-                    }
+                    observer.OnNext(call.ResponseStream.Current);
+                }
 
-                    observer.OnCompleted();
-                }
-                catch (OperationCanceledException) { }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
+                observer.OnCompleted();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
             }
         });
 

--- a/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/EchoServiceImpl.cs
+++ b/Observables.Grpc/Observables.Grpc.Tests/Infrastructure/EchoServiceImpl.cs
@@ -13,6 +13,22 @@ public sealed class EchoServiceImpl : Echo.EchoBase
         IServerStreamWriter<EchoReply> responseStream,
         ServerCallContext context)
     {
+        if (request.Text == "hang")
+        {
+            await responseStream
+                .WriteAsync(new EchoReply { Text = "ready" })
+                .ConfigureAwait(false);
+            try
+            {
+                await Task.Delay(Timeout.Infinite, context.CancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            return;
+        }
+
         for (var i = 0; i < 3; i++)
         {
             await responseStream


### PR DESCRIPTION
## Summary

Reactive `FromServerStreaming` and `FromDuplexStreaming` subscribed with synchronous `Observable.Create` and fire-and-forget `PumpAsync`. The factory `using` disposed the linked CTS when subscribe returned. Dispose now cancels the token System.Reactive async `Create` already awaits.

Fixes #222

## Module boundary

Grpc only. No Shared pump extraction (#215). Duplex write/read overlap unchanged (map item 8). Unary / client-streaming `FromAsync` unchanged.

## Test plan

- [x] `dotnet test` Observables.Grpc.Reactive.Tests net8.0
- [x] `dotnet test` Observables.Grpc.Tests net8.0
- Dispose of an in-flight streaming `MoveNext` does not `OnCompleted` / `OnError`
- Linked CTS remains valid after subscribe returns