### PR TITLE
Keep SignalR Reactive FromInvoke token alive until InvokeAsync completes

### DIFF
--- a/Observables.SignalR/Observables.SignalR.Reactive.Tests/HubConnectionReactiveE2ETests.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive.Tests/HubConnectionReactiveE2ETests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using Observables.SignalR;
 using Observables.SignalR.Reactive.Tests.Contracts;
@@ -55,6 +56,54 @@ public sealed class HubConnectionReactiveE2ETests(SignalRTestServerFixture fixtu
         var message = await receive;
 
         Assert.Equal("hello", message);
+    }
+
+
+    [Fact]
+    public async Task FromInvoke_dispose_cancels_without_ObjectDisposedException()
+    {
+        await using var connection = await ConnectAsync();
+        var error = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactiveSignalRAdapter.FromInvoke<int>(connection, "HoldInvoke", TestContext.Current.CancellationToken)
+            .Subscribe(
+                _ => { },
+                ex => error.TrySetResult(ex),
+                () => { });
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(DefaultTimeout);
+        await Task.Delay(50, timeout.Token);
+        subscription.Dispose();
+
+        var ex = await error.Task.WaitAsync(timeout.Token);
+        Assert.True(ex is OperationCanceledException or HubException, ex.GetType().FullName);
+        Assert.IsNotType<ObjectDisposedException>(ex);
+    }
+
+    [Fact]
+    public async Task FromStream_dispose_cancels_the_pump_without_completing()
+    {
+        await using var connection = await ConnectStreamingAsync();
+        var completed = 0;
+        var errored = 0;
+        var ready = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var subscription = SystemReactiveSignalRAdapter.FromStream<int>(connection, "Hold", TestContext.Current.CancellationToken)
+            .Subscribe(
+                value => ready.TrySetResult(value),
+                _ => Interlocked.Exchange(ref errored, 1),
+                () => Interlocked.Exchange(ref completed, 1));
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(DefaultTimeout);
+        Assert.Equal(0, await ready.Task.WaitAsync(timeout.Token));
+
+        subscription.Dispose();
+        await Task.Delay(200, timeout.Token);
+
+        Assert.Equal(0, Volatile.Read(ref completed));
+        Assert.Equal(0, Volatile.Read(ref errored));
     }
 
     async Task<HubConnection> ConnectAsync() => await StartAsync(fixture.Server.CreateConnection());

--- a/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
@@ -1,8 +1,6 @@
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
+using Observables.SignalR;
 
 namespace Observables.SignalR.Reactive;
 
@@ -20,10 +18,11 @@ public static class SystemReactiveSignalRAdapter
         string methodName,
         object?[] args,
         CancellationToken cancellationToken = default) =>
-        Observable.FromAsync(ct =>
+        Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            return HubConnectionArgs.InvokeAsync<T>(connection, methodName, args, linked.Token);
+            return await HubConnectionArgs.InvokeAsync<T>(connection, methodName, args, linked.Token)
+                .ConfigureAwait(false);
         });
 
     public static IObservable<System.Reactive.Unit> FromSend(
@@ -55,41 +54,33 @@ public static class SystemReactiveSignalRAdapter
         string methodName,
         object?[] args,
         CancellationToken cancellationToken = default) =>
-        Observable.Create<T>(observer =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _ = PumpStreamAsync(connection, methodName, args, observer, cts.Token);
-            return Disposable.Create(cts.Cancel);
-        });
-
-    static async Task PumpStreamAsync<T>(
-        HubConnection connection,
-        string methodName,
-        object?[] args,
-        IObserver<T> observer,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await foreach (var item in HubConnectionArgs
-                               .StreamAsync<T>(connection, methodName, args, cancellationToken)
-                               .ConfigureAwait(false))
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
+            try
             {
-                observer.OnNext(item);
-            }
+                await foreach (var item in HubConnectionArgs
+                                   .StreamAsync<T>(connection, methodName, args, linked.Token)
+                                   .ConfigureAwait(false))
+                {
+                    observer.OnNext(item);
+                }
 
-            observer.OnCompleted();
-        }
-        catch (Exception ex)
-        {
-            observer.OnError(ex);
-        }
-    }
+                observer.OnCompleted();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
+            }
+        });
 
     public static IObservable<T> FromOn<T>(HubConnection connection, string methodName) =>
         Observable.Create<T>(observer =>
         {
             var subscription = connection.On<T>(methodName, observer.OnNext);
-            return Disposable.Create(subscription.Dispose);
+            return System.Reactive.Disposables.Disposable.Create(subscription.Dispose);
         });
 }

--- a/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/E2ETestHub.cs
+++ b/Observables.SignalR/Observables.SignalR.Tests/Infrastructure/E2ETestHub.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Observables.SignalR.Tests.Infrastructure;
@@ -20,4 +21,16 @@ public sealed class E2ETestHub : Hub
 
     public async Task PushNotify(string message) =>
         await Clients.Caller.SendAsync("Notify", message).ConfigureAwait(false);
+
+    public async Task<int> HoldInvoke(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        return 0;
+    }
+
+    public async IAsyncEnumerable<int> Hold([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return 0;
+        await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
## Summary

`FromInvoke` disposed the linked CTS when the `FromAsync` lambda returned the `Task`, not when `InvokeAsync` completed. It now `await`s inside `FromAsync` like `FromSend`. `FromStream` switches to Rx async `Create` so dispose cancels the token the stream already awaits. `FromOn` is unchanged.

Fixes #223

## Module boundary

SignalR only.

## Test plan

- [x] SignalR.Reactive.Tests net8.0
- [x] SignalR.Tests net8.0