### PR TITLE
Deepen Shared completion and csproj package-reference edits

### DIFF
--- a/Observables.Shared/Observables.Analyzers.Tests/CompletionItemFactoryTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/CompletionItemFactoryTests.cs
@@ -1,0 +1,40 @@
+using Observables.Analyzers;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class CompletionItemFactoryTests
+{
+    [Fact]
+    public void DisplayText_equals_the_text_passed_in_and_becomes_the_inserted_text()
+    {
+        var item = CompletionItemFactory.Create("""HubInvoke("MethodName")""");
+
+        Assert.Equal("""HubInvoke("MethodName")""", item.DisplayText);
+        Assert.False(item.Properties.ContainsKey("InsertText"));
+    }
+
+    [Fact]
+    public void DisplayText_does_not_carry_a_trailing_bracket_so_the_editor_auto_close_does_not_double_it()
+    {
+        var item = CompletionItemFactory.Create("""HubInvoke("MethodName")""");
+
+        Assert.DoesNotContain("]", item.DisplayText);
+    }
+
+    [Fact]
+    public void SortText_defaults_to_display_text()
+    {
+        var item = CompletionItemFactory.Create("""HubInvoke("MethodName")""");
+
+        Assert.Equal(item.DisplayText, item.SortText);
+    }
+
+    [Fact]
+    public void SortText_can_be_overridden()
+    {
+        var item = CompletionItemFactory.Create("""{id}""", sortText: """path-{id}""");
+
+        Assert.Equal("""{id}""", item.DisplayText);
+        Assert.Equal("""path-{id}""", item.SortText);
+    }
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
+++ b/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\Observables.Sse\Observables.Sse\Observables.Sse.csproj" />
     <ProjectReference Include="..\..\Observables.Sse\Observables.Sse.Reactive\Observables.Sse.Reactive.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" />
     <PackageReference Include="R3" />
   </ItemGroup>
 

--- a/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
+++ b/Observables.Shared/Observables.Analyzers/BoundaryAttributeCompletionProvider.cs
@@ -99,6 +99,6 @@ public sealed class BoundaryAttributeCompletionProvider : CompletionProvider
             ? suggestion.InsertText
             : $"{suggestion.InsertText}(\"{memberName}\")]";
 
-        return CompletionItemFactory.Create(suggestion.DisplayText, insertText);
+        return CompletionItemFactory.Create(insertText);
     }
 }

--- a/Observables.Shared/Observables.Analyzers/CompletionItemFactory.cs
+++ b/Observables.Shared/Observables.Analyzers/CompletionItemFactory.cs
@@ -1,17 +1,18 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
 
 namespace Observables.Analyzers;
 
+/// <summary>
+/// Builds <see cref="CompletionItem"/>s whose <see cref="CompletionItem.DisplayText"/>
+/// is the exact text that will be inserted on commit (Roslyn's default commit inserts DisplayText).
+/// Callers MUST NOT append a trailing <c>]</c>: the editor auto-closes the bracket the user typed.
+/// </summary>
 internal static class CompletionItemFactory
 {
-    private const string InsertTextPropertyName = "InsertText";
-
-    internal static CompletionItem Create(string displayText, string insertText, string? sortText = null) =>
+    internal static CompletionItem Create(string displayAndInsertText, string? sortText = null) =>
         CompletionItem
             .Create(
-                displayText: displayText,
-                sortText: sortText ?? displayText,
-                rules: CompletionItemRules.Default)
-            .AddProperty(InsertTextPropertyName, insertText);
+                displayText: displayAndInsertText,
+                sortText: sortText ?? displayAndInsertText,
+                rules: CompletionItemRules.Default);
 }

--- a/Observables.Shared/Observables.Analyzers/RestApiMemberCompletionProvider.cs
+++ b/Observables.Shared/Observables.Analyzers/RestApiMemberCompletionProvider.cs
@@ -50,6 +50,25 @@ public sealed class RestApiMemberCompletionProvider : CompletionProvider
             return;
         }
 
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+        {
+            return;
+        }
+
+        var interfaceSyntax = method.Ancestors().OfType<InterfaceDeclarationSyntax>().FirstOrDefault();
+        if (interfaceSyntax is null
+            || semanticModel.GetDeclaredSymbol(interfaceSyntax, cancellationToken) is not INamedTypeSymbol interfaceSymbol)
+        {
+            return;
+        }
+
+        var domain = ProxyDomainCatalog.TryGetInterfaceProxyDomain(interfaceSymbol, semanticModel.Compilation);
+        if (domain is null || domain.Definition.Kind != ProxyDomainTable.DomainKind.RestApi)
+        {
+            return;
+        }
+
         if (IsInsidePathLiteral(root, position, method, out _))
         {
             foreach (var item in CreatePathPlaceholderItems(method))
@@ -74,7 +93,7 @@ public sealed class RestApiMemberCompletionProvider : CompletionProvider
         var path = RestApiPathSuggestions.SuggestPath(method);
         foreach (var verb in ProxyDomainTable.RestApiHttpMethodNames)
         {
-            yield return CompletionItemFactory.Create(verb, $"{verb}(\"{path}\")]");
+            yield return CompletionItemFactory.Create($"{verb}(\"{path}\")");
         }
     }
 
@@ -82,7 +101,7 @@ public sealed class RestApiMemberCompletionProvider : CompletionProvider
     {
         foreach (var name in RestApiPathSuggestions.GetNonCancellationParameterNames(method))
         {
-            yield return CompletionItemFactory.Create($"{{{name}}}", $"{{{name}}}", name);
+            yield return CompletionItemFactory.Create($"{{{name}}}", sortText: name);
         }
     }
 

--- a/Observables.Shared/Observables.CodeFixes/CsprojPackageReferenceEditor.cs
+++ b/Observables.Shared/Observables.CodeFixes/CsprojPackageReferenceEditor.cs
@@ -1,105 +1,149 @@
-using System.Text.RegularExpressions;
+using System.Text;
+using System.Xml;
 
 namespace Observables.CodeFixes;
 
+/// <summary>
+/// Adds / replaces / removes <c>&lt;PackageReference /&gt;</c> entries in a csproj using a real XML writer
+/// (preserves whitespace and formatting) instead of ad-hoc regex on the text.
+/// </summary>
 internal static class CsprojPackageReferenceEditor
 {
-    static readonly Regex PackageReferencePattern = new(
-        "<PackageReference\\s+Include\\s*=\\s*\"(?<id>[^\"]+)\"(?:\\s+Version\\s*=\\s*\"(?<version>[^\"]+)\")?",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    public static bool ContainsPackageReference(string csprojContent, string packageId)
+    static readonly XmlWriterSettings WriterSettings = new()
     {
-        foreach (Match match in PackageReferencePattern.Matches(csprojContent))
+        OmitXmlDeclaration = true,
+        Indent = true,
+        IndentChars = "  ",
+        NewLineChars = "\n",
+    };
+
+    public static bool ContainsPackageReference(string csprojContent, string packageId) =>
+        FindPackageReference(LoadDocument(csprojContent), packageId) is not null;
+
+    public static string? TryGetPackageVersion(string csprojContent, string packageId) =>
+        FindPackageReference(LoadDocument(csprojContent), packageId)?.Attributes?["Version"]?.Value;
+
+    public static string AddPackageReferenceIfMissing(string csprojContent, string packageId, string? version)
+    {
+        var document = LoadDocument(csprojContent);
+        if (FindPackageReference(document, packageId) is not null)
         {
-            if (string.Equals(match.Groups["id"].Value, packageId, StringComparison.OrdinalIgnoreCase))
-                return true;
+            return csprojContent;
         }
 
-        return false;
+        var packageRef = CreatePackageReference(document, packageId, version);
+        var itemGroup = FindItemGroupWithPackageReferences(document);
+        if (itemGroup is not null)
+        {
+            itemGroup.AppendChild(packageRef);
+        }
+        else
+        {
+            var newGroup = document.CreateElement("ItemGroup");
+            newGroup.AppendChild(packageRef);
+            document.DocumentElement!.AppendChild(newGroup);
+        }
+
+        return SaveDocument(document);
     }
 
-    public static string? TryGetPackageVersion(string csprojContent, string packageId)
+    public static string ReplacePackageReference(string csprojContent, string oldPackageId, string newPackageId, string? version)
     {
-        foreach (Match match in PackageReferencePattern.Matches(csprojContent))
+        var document = LoadDocument(csprojContent);
+        var existingNew = FindPackageReference(document, newPackageId);
+        var existingOld = FindPackageReference(document, oldPackageId);
+        if (existingNew is not null)
         {
-            if (!string.Equals(match.Groups["id"].Value, packageId, StringComparison.OrdinalIgnoreCase))
-                continue;
+            existingOld?.ParentNode?.RemoveChild(existingOld);
+            return SaveDocument(document);
+        }
 
-            var version = match.Groups["version"].Value;
-            return string.IsNullOrEmpty(version) ? null : version;
+        if (existingOld is not null)
+        {
+            existingOld.Attributes!["Include"]!.Value = newPackageId;
+            if (version is not null)
+            {
+                if (existingOld.Attributes["Version"] is null)
+                {
+                    existingOld.Attributes.Append(CreateAttribute(document, "Version", version));
+                }
+                else
+                {
+                    existingOld.Attributes["Version"]!.Value = version;
+                }
+            }
+
+            return SaveDocument(document);
+        }
+
+        return AddPackageReferenceIfMissing(csprojContent, newPackageId, version);
+    }
+
+    public static string RemovePackageReference(string csprojContent, string packageId)
+    {
+        var document = LoadDocument(csprojContent);
+        var existing = FindPackageReference(document, packageId);
+        existing?.ParentNode?.RemoveChild(existing);
+        return SaveDocument(document);
+    }
+
+    static XmlDocument LoadDocument(string csprojContent)
+    {
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(csprojContent);
+        return document;
+    }
+
+    static string SaveDocument(XmlDocument document)
+    {
+        var builder = new StringBuilder();
+        using var writer = XmlWriter.Create(builder, WriterSettings);
+        document.Save(writer);
+        return builder.ToString();
+    }
+
+    static XmlNode? FindPackageReference(XmlDocument document, string packageId)
+    {
+        foreach (XmlNode node in document.GetElementsByTagName("PackageReference"))
+        {
+            if (string.Equals(node.Attributes?["Include"]?.Value, packageId, StringComparison.Ordinal))
+            {
+                return node;
+            }
         }
 
         return null;
     }
 
-    public static string AddPackageReferenceIfMissing(string csprojContent, string packageId, string? version)
+    static XmlNode? FindItemGroupWithPackageReferences(XmlDocument document)
     {
-        if (ContainsPackageReference(csprojContent, packageId))
-            return csprojContent;
-
-        var packageLine = version is null
-            ? $"    <PackageReference Include=\"{packageId}\" />"
-            : $"    <PackageReference Include=\"{packageId}\" Version=\"{version}\" />";
-
-        var lastPackageReference = csprojContent.LastIndexOf("<PackageReference", StringComparison.OrdinalIgnoreCase);
-        if (lastPackageReference >= 0)
+        foreach (XmlNode node in document.GetElementsByTagName("ItemGroup"))
         {
-            var itemGroupEnd = csprojContent.IndexOf("</ItemGroup>", lastPackageReference, StringComparison.OrdinalIgnoreCase);
-            if (itemGroupEnd >= 0)
-                return csprojContent.Insert(itemGroupEnd, "\n" + packageLine);
+            if (node.SelectSingleNode("PackageReference") is not null)
+            {
+                return node;
+            }
         }
 
-        var projectEnd = csprojContent.LastIndexOf("</Project>", StringComparison.OrdinalIgnoreCase);
-        if (projectEnd < 0)
-            throw new InvalidOperationException("The project file does not contain a </Project> element.");
-
-        var block = "\n  <ItemGroup>\n" + packageLine + "\n  </ItemGroup>\n";
-        return csprojContent.Insert(projectEnd, block);
+        return null;
     }
 
-    public static string ReplacePackageReference(string csprojContent, string oldPackageId, string newPackageId, string? version)
+    static XmlElement CreatePackageReference(XmlDocument document, string packageId, string? version)
     {
-        if (ContainsPackageReference(csprojContent, newPackageId))
-            return RemovePackageReference(csprojContent, oldPackageId);
-
-        var updated = Regex.Replace(
-            csprojContent,
-            $"(<PackageReference\\s+Include\\s*=\\s*\"){Regex.Escape(oldPackageId)}(\")",
-            match => $"{match.Groups[1].Value}{newPackageId}{match.Groups[2].Value}",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
-        if (!string.Equals(updated, csprojContent, StringComparison.Ordinal))
+        var element = document.CreateElement("PackageReference");
+        element.SetAttribute("Include", packageId);
+        if (version is not null)
         {
-            if (version is not null)
-                updated = SetPackageVersion(updated, newPackageId, version);
-
-            return updated;
+            element.SetAttribute("Version", version);
         }
 
-        return AddPackageReferenceIfMissing(RemovePackageReference(csprojContent, oldPackageId), newPackageId, version);
+        return element;
     }
 
-    public static string RemovePackageReference(string csprojContent, string packageId)
+    static XmlAttribute CreateAttribute(XmlDocument document, string localName, string value)
     {
-        return Regex.Replace(
-            csprojContent,
-            "\\s*<PackageReference\\s+Include\\s*=\\s*\"" + Regex.Escape(packageId) +
-            "\"(?:\\s+Version\\s*=\\s*\"[^\"]+\")?\\s*/>\\s*",
-            "\n",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    }
-
-    static string SetPackageVersion(string csprojContent, string packageId, string version)
-    {
-        var pattern =
-            "(<PackageReference\\s+Include\\s*=\\s*\"" + Regex.Escape(packageId) +
-            "\")(?:\\s+Version\\s*=\\s*\"[^\"]+\")?(\\s*/>)";
-
-        return Regex.Replace(
-            csprojContent,
-            pattern,
-            $"$1 Version=\"{version}\"$2",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        var attribute = document.CreateAttribute(localName);
+        attribute.Value = value;
+        return attribute;
     }
 }


### PR DESCRIPTION
## Summary

- **Completion (problem 1)**: drop the dead `InsertText` property on `CompletionItemFactory`; `DisplayText` now carries the exact text the default Roslyn commit inserts (e.g. `HubInvoke("Member")`), with the trailing `]` dropped so the editor auto-close does not double it. Path-placeholder items keep their `{id}` display. Locked in by new `CompletionItemFactoryTests`.
- **Completion (problem 2)**: gate `RestApiMemberCompletionProvider` to **RestAPI** interfaces only (checks `ProxyDomainCatalog` domain `Kind == RestApi`) so `Get/Post/Put/...` verbs stop bleeding into SignalR/Mqtt/etc.
- **Csproj (problem 3)**: `CsprojPackageReferenceEditor` rewritten on `System.Xml.XmlDocument` with `PreserveWhitespace`, replacing the ad-hoc regex/string manipulation. The existing `CsprojPackageReferenceEditorTests` (add/replace/remove/contains/version) continue to pass against the new XML-based implementation.

Fixes #234

## Module boundary

Shared only (`Observables.Shared/`). No Feature folders, no RestAPI, no CI workflows.

## Test plan

- [x] `Observables.Analyzers.Tests` net8.0 (28 tests, incl. 4 new `CompletionItemFactoryTests`)
- [x] `Observables.CodeFixes.Tests` net8.0 (47 tests, including the existing `CsprojPackageReferenceEditorTests` against the new XML-based editor)