### PR TITLE
Push IO stub parsing into the shared interface walk

### DIFF
--- a/Observables.Grpc/Observables.Grpc.R3.SourceGenerators/GrpcInterfaceStubGenerator.cs
+++ b/Observables.Grpc/Observables.Grpc.R3.SourceGenerators/GrpcInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Grpc.Generators;
 
 namespace Observables.Grpc.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Grpc.GrpcAttribute",
+            domain: ProxyDomainTable.Grpc,
             parse: Parser.GenerateGrpcStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>()),

--- a/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators/GrpcInterfaceStubGenerator.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive.SourceGenerators/GrpcInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Grpc.Generators;
 
 namespace Observables.Grpc.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class GrpcInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Grpc.GrpcAttribute",
+            domain: ProxyDomainTable.Grpc,
             parse: Parser.GenerateGrpcStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>()),

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
@@ -14,7 +14,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateGrpcStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -33,82 +33,62 @@ internal static class Parser
 
         var interfaces = new List<GrpcInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var serviceName = GetServiceName(ifaceSymbol) ?? ifaceSymbol.Name.TrimStart('I');
+            var members = new List<GrpcMemberModel>();
+
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            unaryAttribute,
+                            serverStreamAttribute,
+                            clientStreamAttribute,
+                            duplexAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        if (property.GetAttributes().Length > 0)
+                        {
+                            diagnostics.Add(
+                                Diagnostic.Create(
+                                    DiagnosticDescriptors.InvalidGrpcMember,
+                                    property.Locations.FirstOrDefault(),
+                                    ifaceSymbol.Name,
+                                    property.Name));
+                        }
+
+                        break;
                 }
-
-                if (!HasAttribute(ifaceSymbol, grpcAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var serviceName = GetServiceName(ifaceSymbol) ?? ifaceSymbol.Name.TrimStart('I');
-                var members = new List<GrpcMemberModel>();
-
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                unaryAttribute,
-                                serverStreamAttribute,
-                                clientStreamAttribute,
-                                duplexAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            if (property.GetAttributes().Length > 0)
-                            {
-                                diagnostics.Add(
-                                    Diagnostic.Create(
-                                        DiagnosticDescriptors.InvalidGrpcMember,
-                                        property.Locations.FirstOrDefault(),
-                                        ifaceSymbol.Name,
-                                        property.Name));
-                            }
-
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new GrpcInterfaceModel(
-                        $"{className}.Grpc.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Grpc"),
-                        serviceName,
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new GrpcInterfaceModel(
+                    $"{className}.Grpc.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Grpc"),
+                    serviceName,
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -129,22 +109,22 @@ internal static class Parser
         GrpcBoundaryKind? boundary = null;
         string rpcName = method.Name;
 
-        if (unaryAttribute is not null && HasAttribute(method, unaryAttribute))
+        if (unaryAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, unaryAttribute))
         {
             boundary = GrpcBoundaryKind.Unary;
             rpcName = GetRpcName(method, "GrpcUnaryAttribute") ?? method.Name;
         }
-        else if (serverStreamAttribute is not null && HasAttribute(method, serverStreamAttribute))
+        else if (serverStreamAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, serverStreamAttribute))
         {
             boundary = GrpcBoundaryKind.ServerStream;
             rpcName = GetRpcName(method, "GrpcServerStreamAttribute") ?? method.Name;
         }
-        else if (clientStreamAttribute is not null && HasAttribute(method, clientStreamAttribute))
+        else if (clientStreamAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, clientStreamAttribute))
         {
             boundary = GrpcBoundaryKind.ClientStream;
             rpcName = GetRpcName(method, "GrpcClientStreamAttribute") ?? method.Name;
         }
-        else if (duplexAttribute is not null && HasAttribute(method, duplexAttribute))
+        else if (duplexAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, duplexAttribute))
         {
             boundary = GrpcBoundaryKind.Duplex;
             rpcName = GetRpcName(method, "GrpcDuplexAttribute") ?? method.Name;
@@ -292,18 +272,6 @@ internal static class Parser
         return true;
     }
 
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     static (List<string> declarations, List<string> names, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)

--- a/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/MqttInterfaceStubGenerator.cs
+++ b/Observables.Mqtt/Observables.Mqtt.R3.SourceGenerators/MqttInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Mqtt.Generators;
 
 namespace Observables.Mqtt.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Mqtt.MqttAttribute",
+            domain: ProxyDomainTable.Mqtt,
             parse: Parser.GenerateMqttStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>()),

--- a/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/MqttInterfaceStubGenerator.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive.SourceGenerators/MqttInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Mqtt.Generators;
 
 namespace Observables.Mqtt.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class MqttInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Mqtt.MqttAttribute",
+            domain: ProxyDomainTable.Mqtt,
             parse: Parser.GenerateMqttStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>()),

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
@@ -17,7 +17,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateMqttStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -35,76 +35,56 @@ internal static class Parser
 
         var interfaces = new List<MqttInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<MqttMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            publishAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            compilation,
+                            publishAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasMqttAttribute(ifaceSymbol, mqttAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<MqttMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                publishAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                compilation,
-                                publishAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new MqttInterfaceModel(
-                        $"{className}.Mqtt.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Mqtt"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new MqttInterfaceModel(
+                    $"{className}.Mqtt.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Mqtt"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -121,7 +101,7 @@ internal static class Parser
         List<MqttMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (subscribeAttribute is not null && HasAttribute(method, subscribeAttribute))
+        if (subscribeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, subscribeAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -131,7 +111,7 @@ internal static class Parser
             return;
         }
 
-        if (publishAttribute is null || !HasAttribute(method, publishAttribute))
+        if (publishAttribute is null || !IoProxyInterfaceWalk.HasAttribute(method, publishAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -204,7 +184,7 @@ internal static class Parser
         List<MqttMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (publishAttribute is not null && HasAttribute(property, publishAttribute))
+        if (publishAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, publishAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -214,7 +194,7 @@ internal static class Parser
             return;
         }
 
-        if (subscribeAttribute is null || !HasAttribute(property, subscribeAttribute))
+        if (subscribeAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, subscribeAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -317,32 +297,6 @@ internal static class Parser
         }
 
         return true;
-    }
-
-    static bool HasMqttAttribute(INamedTypeSymbol ifaceSymbol, INamedTypeSymbol mqttAttribute)
-    {
-        foreach (var attribute in ifaceSymbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, mqttAttribute))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     static bool TryGetLiteralTopicTemplate(

--- a/Observables.Nats/Observables.Nats.R3.SourceGenerators/NatsInterfaceStubGenerator.cs
+++ b/Observables.Nats/Observables.Nats.R3.SourceGenerators/NatsInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Nats.Generators;
 
 namespace Observables.Nats.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Nats.NatsAttribute",
+            domain: ProxyDomainTable.Nats,
             parse: Parser.GenerateNatsStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>()),

--- a/Observables.Nats/Observables.Nats.Reactive.SourceGenerators/NatsInterfaceStubGenerator.cs
+++ b/Observables.Nats/Observables.Nats.Reactive.SourceGenerators/NatsInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Nats.Generators;
 
 namespace Observables.Nats.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class NatsInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Nats.NatsAttribute",
+            domain: ProxyDomainTable.Nats,
             parse: Parser.GenerateNatsStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>()),

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
@@ -17,7 +17,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateNatsStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -36,77 +36,57 @@ internal static class Parser
 
         var interfaces = new List<NatsInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<NatsMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            publishAttribute,
+                            requestAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            compilation,
+                            publishAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasNatsAttribute(ifaceSymbol, mqttAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<NatsMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                publishAttribute,
-                                requestAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                compilation,
-                                publishAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new NatsInterfaceModel(
-                        $"{className}.Nats.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Nats"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new NatsInterfaceModel(
+                    $"{className}.Nats.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Nats"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -124,7 +104,7 @@ internal static class Parser
         List<NatsMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (subscribeAttribute is not null && HasAttribute(method, subscribeAttribute))
+        if (subscribeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, subscribeAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -134,8 +114,8 @@ internal static class Parser
             return;
         }
 
-        var hasPublish = publishAttribute is not null && HasAttribute(method, publishAttribute);
-        var hasRequest = requestAttribute is not null && HasAttribute(method, requestAttribute);
+        var hasPublish = publishAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, publishAttribute);
+        var hasRequest = requestAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, requestAttribute);
 
         if (hasPublish && hasRequest)
         {
@@ -233,7 +213,7 @@ internal static class Parser
         List<NatsMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (publishAttribute is not null && HasAttribute(property, publishAttribute))
+        if (publishAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, publishAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -244,7 +224,7 @@ internal static class Parser
         }
 
         if (compilation.GetTypeByMetadataName("Observables.Nats.NatsRequestAttribute") is { } requestAttribute
-            && HasAttribute(property, requestAttribute))
+            && IoProxyInterfaceWalk.HasAttribute(property, requestAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -254,7 +234,7 @@ internal static class Parser
             return;
         }
 
-        if (subscribeAttribute is null || !HasAttribute(property, subscribeAttribute))
+        if (subscribeAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, subscribeAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -434,32 +414,6 @@ internal static class Parser
         }
 
         return true;
-    }
-
-    static bool HasNatsAttribute(INamedTypeSymbol ifaceSymbol, INamedTypeSymbol mqttAttribute)
-    {
-        foreach (var attribute in ifaceSymbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, mqttAttribute))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     static bool TryGetLiteralSubjectTemplate(

--- a/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/PostgresInterfaceStubGenerator.cs
+++ b/Observables.Postgres/Observables.Postgres.R3.SourceGenerators/PostgresInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Postgres.Generators;
 
 namespace Observables.Postgres.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class PostgresInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Postgres.PostgresAttribute",
+            domain: ProxyDomainTable.Postgres,
             parse: Parser.GeneratePostgresStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<PostgresInterfaceModel>()),

--- a/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/PostgresInterfaceStubGenerator.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive.SourceGenerators/PostgresInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Postgres.Generators;
 
 namespace Observables.Postgres.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class PostgresInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Postgres.PostgresAttribute",
+            domain: ProxyDomainTable.Postgres,
             parse: Parser.GeneratePostgresStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<PostgresInterfaceModel>()),

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Parser.cs
@@ -19,7 +19,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GeneratePostgresStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -37,76 +37,56 @@ internal static class Parser
 
         var interfaces = new List<PostgresInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<PostgresMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            notifyAttribute,
+                            listenAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            compilation,
+                            notifyAttribute,
+                            listenAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasAttribute(ifaceSymbol, postgresAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<PostgresMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                notifyAttribute,
-                                listenAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                compilation,
-                                notifyAttribute,
-                                listenAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new PostgresInterfaceModel(
-                        $"{className}.Postgres.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Postgres"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new PostgresInterfaceModel(
+                    $"{className}.Postgres.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Postgres"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -123,7 +103,7 @@ internal static class Parser
         List<PostgresMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (listenAttribute is not null && HasAttribute(method, listenAttribute))
+        if (listenAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, listenAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -133,7 +113,7 @@ internal static class Parser
             return;
         }
 
-        if (notifyAttribute is null || !HasAttribute(method, notifyAttribute))
+        if (notifyAttribute is null || !IoProxyInterfaceWalk.HasAttribute(method, notifyAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -222,7 +202,7 @@ internal static class Parser
         List<PostgresMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (notifyAttribute is not null && HasAttribute(property, notifyAttribute))
+        if (notifyAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, notifyAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -232,7 +212,7 @@ internal static class Parser
             return;
         }
 
-        if (listenAttribute is null || !HasAttribute(property, listenAttribute))
+        if (listenAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, listenAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -338,20 +318,6 @@ internal static class Parser
 
     static bool IsValidChannelName(string channel) =>
         channel.Length is > 0 and <= 63 && ChannelNameRegex.IsMatch(channel);
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     static bool TryGetLiteralChannel(
         ISymbol member,
         string attributeClassName,

--- a/Observables.Redis/Observables.Redis.R3.SourceGenerators/RedisInterfaceStubGenerator.cs
+++ b/Observables.Redis/Observables.Redis.R3.SourceGenerators/RedisInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Redis.Generators;
 
 namespace Observables.Redis.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class RedisInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Redis.RedisAttribute",
+            domain: ProxyDomainTable.Redis,
             parse: Parser.GenerateRedisStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<RedisInterfaceModel>()),

--- a/Observables.Redis/Observables.Redis.Reactive.SourceGenerators/RedisInterfaceStubGenerator.cs
+++ b/Observables.Redis/Observables.Redis.Reactive.SourceGenerators/RedisInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Redis.Generators;
 
 namespace Observables.Redis.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class RedisInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Redis.RedisAttribute",
+            domain: ProxyDomainTable.Redis,
             parse: Parser.GenerateRedisStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<RedisInterfaceModel>()),

--- a/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
@@ -17,7 +17,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateRedisStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -36,77 +36,57 @@ internal static class Parser
 
         var interfaces = new List<RedisInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<RedisMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            publishAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            compilation,
+                            publishAttribute,
+                            subscribeAttribute,
+                            observableType,
+                            redisMessageType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasAttribute(ifaceSymbol, redisAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<RedisMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                publishAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                compilation,
-                                publishAttribute,
-                                subscribeAttribute,
-                                observableType,
-                                redisMessageType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new RedisInterfaceModel(
-                        $"{className}.Redis.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Redis"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new RedisInterfaceModel(
+                    $"{className}.Redis.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Redis"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -123,7 +103,7 @@ internal static class Parser
         List<RedisMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (subscribeAttribute is not null && HasAttribute(method, subscribeAttribute))
+        if (subscribeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, subscribeAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -133,7 +113,7 @@ internal static class Parser
             return;
         }
 
-        var hasPublish = publishAttribute is not null && HasAttribute(method, publishAttribute);
+        var hasPublish = publishAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, publishAttribute);
         if (!hasPublish)
         {
             diagnostics.Add(
@@ -229,7 +209,7 @@ internal static class Parser
         List<RedisMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (publishAttribute is not null && HasAttribute(property, publishAttribute))
+        if (publishAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, publishAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -239,7 +219,7 @@ internal static class Parser
             return;
         }
 
-        if (subscribeAttribute is null || !HasAttribute(property, subscribeAttribute))
+        if (subscribeAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, subscribeAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -398,20 +378,6 @@ internal static class Parser
 
         return true;
     }
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     static bool TryGetLiteralChannelTemplate(
         IMethodSymbol method,
         string attributeClassName,

--- a/Observables.Shared/Observables.Analyzers.Tests/IoProxyPipelineTests.cs
+++ b/Observables.Shared/Observables.Analyzers.Tests/IoProxyPipelineTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Observables.Roslyn.Shared;
+using Observables.SourceGenerators.Shared;
+using Observables.SourceGenerators.Shared.Diagnostics;
+
+namespace Observables.Analyzers.Tests;
+
+public sealed class IoProxyPipelineTests
+{
+    [Fact]
+    public void Catalog_markers_cover_the_eight_IO_stub_domains()
+    {
+        Assert.Equal("Observables.SignalR.HubAttribute", ProxyDomainTable.SignalR.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Mqtt.MqttAttribute", ProxyDomainTable.Mqtt.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.WebSocket.WebSocketAttribute", ProxyDomainTable.WebSocket.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Grpc.GrpcAttribute", ProxyDomainTable.Grpc.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Sse.SseAttribute", ProxyDomainTable.Sse.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Nats.NatsAttribute", ProxyDomainTable.Nats.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Postgres.PostgresAttribute", ProxyDomainTable.Postgres.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.Redis.RedisAttribute", ProxyDomainTable.Redis.InterfaceMarkerMetadataName);
+        Assert.Equal("Observables.RestAPI.RestApiAttribute", ProxyDomainTable.RestApi.InterfaceMarkerMetadataName);
+        Assert.Equal(8, ProxyDomainTable.MemberBoundaryDomains.Count);
+    }
+
+    [Fact]
+    public void Walk_collects_marked_public_members_and_skips_unmarked()
+    {
+        const string source =
+            """
+            using Observables.Mqtt;
+
+            [Mqtt]
+            public interface IWeatherHub
+            {
+                [MqttPublish("sensors/{id}")]
+                void Publish(int id);
+
+                private static int Hidden() => 0;
+            }
+
+            public interface INotMqtt
+            {
+                void Ignored();
+            }
+            """;
+
+        var (compilation, interfaces) = CompileInterfaces(source);
+        var marker = compilation.GetTypeByMetadataName(ProxyDomainTable.Mqtt.InterfaceMarkerMetadataName);
+        Assert.NotNull(marker);
+
+        var marked = IoProxyInterfaceWalk.Collect(compilation, interfaces, marker!, CancellationToken.None);
+        Assert.Single(marked);
+        Assert.Equal("IWeatherHub", marked[0].InterfaceSymbol.Name);
+        Assert.Contains(marked[0].PublicInstanceMembers, static member => member.Name == "Publish");
+        Assert.DoesNotContain(marked[0].PublicInstanceMembers, static member => member.Name == "Hidden");
+    }
+
+    [Fact]
+    public void OBS7004_stays_on_the_Grpc_adapter()
+    {
+        // Shared does not template DiagnosticDescriptors. OBS7004 is the Grpc
+        // member-shape id in the catalog; reporting it belongs in the Grpc
+        // adapter once a concrete mismatch is classified there.
+        Assert.Equal("OBS7004", ProxyDomainTable.Grpc.MemberShapeMismatchDiagnosticId);
+    }
+
+    [Fact]
+    public void ObservableReturnTypeParser_rejects_bare_task()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            public interface ISample
+            {
+                Task<int> Go();
+            }
+            """;
+
+        var (compilation, _) = CompileInterfaces(source);
+        var method = compilation.GetTypeByMetadataName("ISample")!.GetMembers("Go").OfType<IMethodSymbol>().Single();
+        var unsupported = new DiagnosticDescriptor("TEST001", "u", "{0}", "Test", DiagnosticSeverity.Error, true);
+        var missingRx = new DiagnosticDescriptor("TEST002", "r", "{0}", "Test", DiagnosticSeverity.Error, true);
+        var diagnostics = new List<Diagnostic>();
+
+        var ok = ObservableReturnTypeParser.TryParse(
+            method.ReturnType,
+            compilation,
+            reactiveAdapterMetadataName: "Missing.Adapter",
+            expectedObservableType: null,
+            unitType: null,
+            requiresUnitPayload: false,
+            unsupportedReturnType: unsupported,
+            systemReactiveNotReferenced: missingRx,
+            location: method.Locations[0],
+            diagnostics: diagnostics,
+            resultTypeDisplay: out _,
+            returnTypeDisplay: out _);
+
+        Assert.False(ok);
+        Assert.Contains(diagnostics, static diagnostic => diagnostic.Id == "TEST001");
+    }
+
+    static (CSharpCompilation compilation, ImmutableArray<InterfaceDeclarationSyntax> interfaces) CompileInterfaces(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "WalkTests",
+            [tree],
+            AnalyzerTestHarness.GetPlatformReferencesExcludingObservables()
+                .Append(AnalyzerTestHarness.CreateReference<global::Observables.Mqtt.MqttAttribute>()),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var interfaces = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InterfaceDeclarationSyntax>()
+            .ToImmutableArray();
+        return (compilation, interfaces);
+    }
+}

--- a/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
+++ b/Observables.Shared/Observables.Analyzers.Tests/Observables.Analyzers.Tests.csproj
@@ -15,6 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Observables.SourceGenerators.Shared\IoProxyInterfaceWalk.cs" Link="Shared/IoProxyInterfaceWalk.cs" />
+    <Compile Include="..\Observables.SourceGenerators.Shared\Nullability.cs" Link="Shared/Nullability.cs" />
+    <Compile Include="..\Observables.SourceGenerators.Shared\BackendTokens.cs" Link="Shared/BackendTokens.cs" />
+    <Compile Include="..\Observables.SourceGenerators.Shared\Diagnostics\ObservableReturnTypeParser.cs" Link="Shared/ObservableReturnTypeParser.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Observables.Analyzers\Observables.Analyzers.csproj" />
     <ProjectReference Include="..\..\Observables.SignalR\Observables.SignalR\Observables.SignalR.csproj" />
     <ProjectReference Include="..\..\Observables.SignalR\Observables.SignalR.Reactive\Observables.SignalR.Reactive.csproj" />

--- a/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs
@@ -16,8 +16,8 @@ internal static class IoProxyGeneratorPipeline
 {
     internal static void RegisterForAttributeInterfaces<TContextModel, TInterfaceModel>(
         IncrementalGeneratorInitializationContext context,
-        string interfaceMarkerMetadataName,
-        Func<CSharpCompilation, ImmutableArray<InterfaceDeclarationSyntax>, CancellationToken, (List<Diagnostic> diagnostics, TContextModel model)> parse,
+        Observables.Roslyn.Shared.ProxyDomainTable.ProxyDomainDefinition domain,
+        Func<CSharpCompilation, ImmutableArray<MarkedInterfaceContext>, CancellationToken, (List<Diagnostic> diagnostics, TContextModel model)> parse,
         DiagnosticDescriptor internalErrorDescriptor,
         Func<TContextModel> emptyModelFactory,
         Func<TContextModel, IEnumerable<TInterfaceModel>> getInterfaces,
@@ -27,7 +27,7 @@ internal static class IoProxyGeneratorPipeline
         Action<TContextModel, Action<string, SourceText>> emitModuleInitializers)
     {
         var candidateInterfaces = context.SyntaxProvider.ForAttributeWithMetadataName(
-            interfaceMarkerMetadataName,
+            domain.InterfaceMarkerMetadataName,
             static (node, _) => node is InterfaceDeclarationSyntax,
             static (ctx, _) => (InterfaceDeclarationSyntax)ctx.TargetNode);
 
@@ -39,7 +39,15 @@ internal static class IoProxyGeneratorPipeline
         var parseStep = collected.Select(
             (input, ct) =>
                 GeneratorFailSafe.ExecuteParse(
-                    () => parse((CSharpCompilation)input.Right, input.Left, ct),
+                    () =>
+                    {
+                        var compilation = (CSharpCompilation)input.Right;
+                        var marker = compilation.GetTypeByMetadataName(domain.InterfaceMarkerMetadataName);
+                        var marked = marker is null
+                            ? ImmutableArray<MarkedInterfaceContext>.Empty
+                            : IoProxyInterfaceWalk.Collect(compilation, input.Left, marker, ct);
+                        return parse(compilation, marked, ct);
+                    },
                     internalErrorDescriptor,
                     emptyModelFactory));
 

--- a/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyInterfaceWalk.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyInterfaceWalk.cs
@@ -1,0 +1,83 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Shared marked-interface walk for IO stub generators.
+/// Feature adapters only classify the public members collected here.
+/// </summary>
+internal readonly record struct MarkedInterfaceContext(
+    INamedTypeSymbol InterfaceSymbol,
+    InterfaceDeclarationSyntax Syntax,
+    SemanticModel SemanticModel,
+    Nullability Nullability,
+    ImmutableArray<ISymbol> PublicInstanceMembers);
+
+internal static class IoProxyInterfaceWalk
+{
+    internal static ImmutableArray<MarkedInterfaceContext> Collect(
+        CSharpCompilation compilation,
+        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        INamedTypeSymbol markerAttribute,
+        CancellationToken cancellationToken)
+    {
+        if (candidateInterfaces.IsDefaultOrEmpty)
+        {
+            return ImmutableArray<MarkedInterfaceContext>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<MarkedInterfaceContext>();
+        foreach (var group in candidateInterfaces.GroupBy(static syntax => syntax.SyntaxTree))
+        {
+            var semanticModel = compilation.GetSemanticModel(group.Key);
+            foreach (var interfaceSyntax in group)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (semanticModel.GetDeclaredSymbol(interfaceSyntax, cancellationToken) is not INamedTypeSymbol interfaceSymbol)
+                {
+                    continue;
+                }
+
+                if (!HasAttribute(interfaceSymbol, markerAttribute))
+                {
+                    continue;
+                }
+
+                var nullability = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
+                    || semanticModel.GetNullableContext(interfaceSyntax.SpanStart) == NullableContext.Enabled
+                        ? Nullability.Enabled
+                        : Nullability.Disabled;
+
+                var members = interfaceSymbol.GetMembers()
+                    .Where(static member => member.DeclaredAccessibility == Accessibility.Public && !member.IsStatic)
+                    .ToImmutableArray();
+
+                builder.Add(
+                    new MarkedInterfaceContext(
+                        interfaceSymbol,
+                        interfaceSyntax,
+                        semanticModel,
+                        nullability,
+                        members));
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    internal static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/HubInterfaceStubGenerator.cs
+++ b/Observables.SignalR/Observables.SignalR.R3.SourceGenerators/HubInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.SignalR.Generators;
 
 namespace Observables.SignalR.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.SignalR.HubAttribute",
+            domain: ProxyDomainTable.SignalR,
             parse: Parser.GenerateHubStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>()),

--- a/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/HubInterfaceStubGenerator.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive.SourceGenerators/HubInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.SignalR.Generators;
 
 namespace Observables.SignalR.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class HubInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.SignalR.HubAttribute",
+            domain: ProxyDomainTable.SignalR,
             parse: Parser.GenerateHubStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>()),

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
@@ -14,7 +14,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateHubStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -34,86 +34,66 @@ internal static class Parser
 
         var interfaces = new List<HubInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            if (string.Equals(compilation.AssemblyName, "GeneratorTests", StringComparison.Ordinal)
+                && marked.Syntax.Identifier.ValueText == "IInternalErrorProbe")
             {
-                if (string.Equals(compilation.AssemblyName, "GeneratorTests", StringComparison.Ordinal)
-                    && ifaceSyntax.Identifier.ValueText == "IInternalErrorProbe")
-                {
-                    throw new InvalidOperationException("fail-safe probe");
-                }
-
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
-                {
-                    continue;
-                }
-
-                if (!HasHubAttribute(ifaceSymbol, hubAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<HubMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                invokeAttribute,
-                                sendAttribute,
-                                streamAttribute,
-                                onAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                compilation,
-                                invokeAttribute,
-                                sendAttribute,
-                                streamAttribute,
-                                onAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new HubInterfaceModel(
-                        $"{className}.SignalR.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.SignalR"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
+                throw new InvalidOperationException("fail-safe probe");
             }
+
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<HubMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
+            {
+
+                switch (member)
+                {
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            invokeAttribute,
+                            sendAttribute,
+                            streamAttribute,
+                            onAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            compilation,
+                            invokeAttribute,
+                            sendAttribute,
+                            streamAttribute,
+                            onAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
+                }
+            }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new HubInterfaceModel(
+                    $"{className}.SignalR.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.SignalR"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -132,7 +112,7 @@ internal static class Parser
         List<HubMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (onAttribute is not null && HasAttribute(method, onAttribute))
+        if (onAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, onAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -231,7 +211,7 @@ internal static class Parser
             return;
         }
 
-        if (onAttribute is null || !HasAttribute(property, onAttribute))
+        if (onAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, onAttribute))
         {
             if (property.GetAttributes().Length > 0 || property.Name is not "Hub")
             {
@@ -293,48 +273,22 @@ internal static class Parser
         INamedTypeSymbol? sendAttribute,
         INamedTypeSymbol? streamAttribute)
     {
-        if (invokeAttribute is not null && HasAttribute(method, invokeAttribute))
+        if (invokeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, invokeAttribute))
         {
             return HubBoundaryKind.Invoke;
         }
 
-        if (sendAttribute is not null && HasAttribute(method, sendAttribute))
+        if (sendAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, sendAttribute))
         {
             return HubBoundaryKind.Send;
         }
 
-        if (streamAttribute is not null && HasAttribute(method, streamAttribute))
+        if (streamAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, streamAttribute))
         {
             return HubBoundaryKind.Stream;
         }
 
         return null;
-    }
-
-    static bool HasHubAttribute(INamedTypeSymbol ifaceSymbol, INamedTypeSymbol hubAttribute)
-    {
-        foreach (var attribute in ifaceSymbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, hubAttribute))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     static bool TryGetLiteralMethodName(
@@ -417,9 +371,9 @@ internal static class Parser
         INamedTypeSymbol? invokeAttribute,
         INamedTypeSymbol? sendAttribute,
         INamedTypeSymbol? streamAttribute) =>
-        (invokeAttribute is not null && HasAttribute(property, invokeAttribute))
-        || (sendAttribute is not null && HasAttribute(property, sendAttribute))
-        || (streamAttribute is not null && HasAttribute(property, streamAttribute));
+        (invokeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, invokeAttribute))
+        || (sendAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, sendAttribute))
+        || (streamAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, streamAttribute));
 
     static (List<string> declarations, List<string> names, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)

--- a/Observables.SourceGenerators.SharedSource.props
+++ b/Observables.SourceGenerators.SharedSource.props
@@ -52,6 +52,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs">
       <Link>Shared/IoProxyGeneratorPipeline.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyInterfaceWalk.cs">
+      <Link>Shared/IoProxyInterfaceWalk.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.Roslyn.Shared/ProxyDomainTable.cs">
+      <Link>Shared/ProxyDomainTable.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <!-- Global using to avoid qualifying shared types -->

--- a/Observables.Sse/Observables.Sse.R3.SourceGenerators/SseInterfaceStubGenerator.cs
+++ b/Observables.Sse/Observables.Sse.R3.SourceGenerators/SseInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Sse.Generators;
 
 namespace Observables.Sse.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Sse.SseAttribute",
+            domain: ProxyDomainTable.Sse,
             parse: Parser.GenerateSseStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>()),

--- a/Observables.Sse/Observables.Sse.Reactive.SourceGenerators/SseInterfaceStubGenerator.cs
+++ b/Observables.Sse/Observables.Sse.Reactive.SourceGenerators/SseInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.Sse.Generators;
 
 namespace Observables.Sse.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class SseInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.Sse.SseAttribute",
+            domain: ProxyDomainTable.Sse,
             parse: Parser.GenerateSseStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>()),

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
@@ -14,7 +14,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateSseStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -30,67 +30,47 @@ internal static class Parser
 
         var interfaces = new List<SseInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<SseMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(method, ifaceSymbol, eventAttribute, diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            ifaceSymbol,
+                            compilation,
+                            eventAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasAttribute(ifaceSymbol, sseAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<SseMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(method, ifaceSymbol, eventAttribute, diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                ifaceSymbol,
-                                compilation,
-                                eventAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new SseInterfaceModel(
-                        $"{className}.Sse.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.Sse"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new SseInterfaceModel(
+                    $"{className}.Sse.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.Sse"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -102,7 +82,7 @@ internal static class Parser
         INamedTypeSymbol? eventAttribute,
         List<Diagnostic> diagnostics)
     {
-        if (eventAttribute is not null && HasAttribute(method, eventAttribute))
+        if (eventAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, eventAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -129,7 +109,7 @@ internal static class Parser
         List<SseMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (eventAttribute is null || !HasAttribute(property, eventAttribute))
+        if (eventAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, eventAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -192,16 +172,4 @@ internal static class Parser
         return null;
     }
 
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/WebSocketInterfaceStubGenerator.cs
+++ b/Observables.WebSocket/Observables.WebSocket.R3.SourceGenerators/WebSocketInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.WebSocket.Generators;
 
 namespace Observables.WebSocket.R3.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.WebSocket.WebSocketAttribute",
+            domain: ProxyDomainTable.WebSocket,
             parse: Parser.GenerateWebSocketStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>()),

--- a/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/WebSocketInterfaceStubGenerator.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive.SourceGenerators/WebSocketInterfaceStubGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Observables.SourceGenerators.Shared;
+using Observables.Roslyn.Shared;
 using Observables.WebSocket.Generators;
 
 namespace Observables.WebSocket.Reactive.SourceGenerators;
@@ -12,7 +13,7 @@ public sealed class WebSocketInterfaceStubGenerator : IIncrementalGenerator
     {
         IoProxyGeneratorPipeline.RegisterForAttributeInterfaces(
             context,
-            interfaceMarkerMetadataName: "Observables.WebSocket.WebSocketAttribute",
+            domain: ProxyDomainTable.WebSocket,
             parse: Parser.GenerateWebSocketStubs,
             internalErrorDescriptor: DiagnosticDescriptors.InternalGeneratorError,
             emptyModelFactory: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>()),

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
@@ -14,7 +14,7 @@ internal static class Parser
 
     public static (List<Diagnostic> diagnostics, ContextGenerationModel model) GenerateWebSocketStubs(
         CSharpCompilation compilation,
-        ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
         var diagnostics = new List<Diagnostic>();
@@ -34,81 +34,61 @@ internal static class Parser
 
         var interfaces = new List<WebSocketInterfaceModel>();
 
-        foreach (var group in candidateInterfaces.GroupBy(static i => i.SyntaxTree))
+        foreach (var marked in markedInterfaces)
         {
-            var semanticModel = compilation.GetSemanticModel(group.Key);
-            foreach (var ifaceSyntax in group)
+            var ifaceSymbol = marked.InterfaceSymbol;
+            var nullable = marked.Nullability;
+
+            var members = new List<WebSocketMemberModel>();
+            foreach (var member in marked.PublicInstanceMembers)
             {
-                if (semanticModel.GetDeclaredSymbol(ifaceSyntax, cancellationToken) is not INamedTypeSymbol ifaceSymbol)
+
+                switch (member)
                 {
-                    continue;
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        TryAddMethod(
+                            method,
+                            ifaceSymbol,
+                            compilation,
+                            sendAttribute,
+                            receiveAttribute,
+                            connectAttribute,
+                            closeAttribute,
+                            observableType,
+                            unitType,
+                            members,
+                            diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        TryAddProperty(
+                            property,
+                            ifaceSymbol,
+                            compilation,
+                            sendAttribute,
+                            receiveAttribute,
+                            connectAttribute,
+                            closeAttribute,
+                            observableType,
+                            members,
+                            diagnostics);
+                        break;
                 }
-
-                if (!HasAttribute(ifaceSymbol, wsAttribute))
-                {
-                    continue;
-                }
-
-                var nullable = compilation.Options.NullableContextOptions == NullableContextOptions.Enable
-                    || semanticModel.GetNullableContext(ifaceSyntax.SpanStart) == NullableContext.Enabled
-                        ? Nullability.Enabled
-                        : Nullability.Disabled;
-
-                var members = new List<WebSocketMemberModel>();
-                foreach (var member in ifaceSymbol.GetMembers())
-                {
-                    if (member.DeclaredAccessibility != Accessibility.Public || member.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    switch (member)
-                    {
-                        case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                            TryAddMethod(
-                                method,
-                                ifaceSymbol,
-                                compilation,
-                                sendAttribute,
-                                receiveAttribute,
-                                connectAttribute,
-                                closeAttribute,
-                                observableType,
-                                unitType,
-                                members,
-                                diagnostics);
-                            break;
-                        case IPropertySymbol property:
-                            TryAddProperty(
-                                property,
-                                ifaceSymbol,
-                                compilation,
-                                sendAttribute,
-                                receiveAttribute,
-                                connectAttribute,
-                                closeAttribute,
-                                observableType,
-                                members,
-                                diagnostics);
-                            break;
-                    }
-                }
-
-                if (members.Count == 0)
-                {
-                    continue;
-                }
-
-                var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-                interfaces.Add(
-                    new WebSocketInterfaceModel(
-                        $"{className}.WebSocket.g.cs",
-                        className,
-                        ifaceSymbol.ToDisplayString(DisplayFormat),
-                        BackendTokens.QualifyGeneratedNamespace("Observables.WebSocket"),
-                        members.ToImmutableEquatableArray(),
-                        nullable));
             }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
+            interfaces.Add(
+                new WebSocketInterfaceModel(
+                    $"{className}.WebSocket.g.cs",
+                    className,
+                    ifaceSymbol.ToDisplayString(DisplayFormat),
+                    BackendTokens.QualifyGeneratedNamespace("Observables.WebSocket"),
+                    members.ToImmutableEquatableArray(),
+                    nullable));
         }
 
         return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
@@ -127,7 +107,7 @@ internal static class Parser
         List<WebSocketMemberModel> members,
         List<Diagnostic> diagnostics)
     {
-        if (receiveAttribute is not null && HasAttribute(method, receiveAttribute))
+        if (receiveAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, receiveAttribute))
         {
             diagnostics.Add(
                 Diagnostic.Create(
@@ -139,15 +119,15 @@ internal static class Parser
 
         WebSocketBoundaryKind? boundary = null;
 
-        if (sendAttribute is not null && HasAttribute(method, sendAttribute))
+        if (sendAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, sendAttribute))
         {
             boundary = WebSocketBoundaryKind.Send;
         }
-        else if (connectAttribute is not null && HasAttribute(method, connectAttribute))
+        else if (connectAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, connectAttribute))
         {
             boundary = WebSocketBoundaryKind.Connect;
         }
-        else if (closeAttribute is not null && HasAttribute(method, closeAttribute))
+        else if (closeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(method, closeAttribute))
         {
             boundary = WebSocketBoundaryKind.Close;
         }
@@ -253,7 +233,7 @@ internal static class Parser
             return;
         }
 
-        if (receiveAttribute is null || !HasAttribute(property, receiveAttribute))
+        if (receiveAttribute is null || !IoProxyInterfaceWalk.HasAttribute(property, receiveAttribute))
         {
             if (property.GetAttributes().Length > 0)
             {
@@ -302,23 +282,9 @@ internal static class Parser
         INamedTypeSymbol? sendAttribute,
         INamedTypeSymbol? connectAttribute,
         INamedTypeSymbol? closeAttribute) =>
-        (sendAttribute is not null && HasAttribute(property, sendAttribute))
-        || (connectAttribute is not null && HasAttribute(property, connectAttribute))
-        || (closeAttribute is not null && HasAttribute(property, closeAttribute));
-
-    static bool HasAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
-    {
-        foreach (var attribute in symbol.GetAttributes())
-        {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
+        (sendAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, sendAttribute))
+        || (connectAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, connectAttribute))
+        || (closeAttribute is not null && IoProxyInterfaceWalk.HasAttribute(property, closeAttribute));
     static (List<string> declarations, List<string> names, bool hasCancellationToken) BuildParameters(
         IMethodSymbol method)
     {


### PR DESCRIPTION
## Summary

`0.2.0` extracted incremental wiring onto `IoProxyGeneratorPipeline`, but eight Feature Parsers still cloned the marked-interface walk (`GroupBy` / `GetSemanticModel` / marker scan / nullability / public members / `HasAttribute`).

This PR concentrates that walk in Shared:

- `IoProxyInterfaceWalk` collects marked public members once.
- Feature Parsers become member-classification adapters.
- Stub generators read interface markers from `ProxyDomainTable` instead of hard-coded strings.
- Shared tests cover the walk, catalog markers, and `ObservableReturnTypeParser`.
- RestAPI stays on `CreateSyntaxProvider` (C2). Events stay off this pipeline.
- OBS7004 remains a Grpc adapter diagnostic (descriptors are not templated). Documented in Shared tests.

## Related Issue

Fixes #236

## Solution module

- [x] Shared (walk, pipeline, catalog wiring, tests)
- Feature Parser/stub call sites are the required adapters for the Shared walk.

## Type of change

- [x] Source generator / diagnostic change
- [x] Refactor (no behavior change)

## Test plan

- [x] `dotnet test` net8.0: Analyzers.Tests (32)
- [x] Feature R3 generator tests: Mqtt, SignalR, Grpc, Sse, Nats, WebSocket, Postgres, Redis

## Breaking changes

- [x] None

## Checklist

- [x] Commit messages are in English
- [x] No version bumps, tags, or publish
- [x] Events / RestAPI generators not migrated onto the IO pipeline