### PR TITLE
Collapse *Service.For onto a shared factory registry

### DIFF
--- a/Observables.Grpc/Observables.Grpc/GrpcService.cs
+++ b/Observables.Grpc/Observables.Grpc/GrpcService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using Grpc.Core;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.Grpc;
 /// <summary>Creates source-generated gRPC proxy implementations.</summary>
 public static class GrpcService
 {
-    static readonly ConcurrentDictionary<Type, Func<CallInvoker, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated gRPC proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,23 +16,12 @@ public static class GrpcService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type grpcInterfaceType,
-        Func<CallInvoker, object> factory)
+        Func<CallInvoker, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<CallInvoker>.Register(grpcInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type grpcInterfaceType, Func<CallInvoker, object> factory)
+    public static void RegisterGeneratedFactory(Type grpcInterfaceType, Func<CallInvoker, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<CallInvoker>.Register(grpcInterfaceType, factory);
 #endif
-    {
-        if (grpcInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(grpcInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[grpcInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -62,17 +48,9 @@ public static class GrpcService
             throw new ArgumentNullException(nameof(grpcInterfaceType));
         }
 
-        if (invoker is null)
-        {
-            throw new ArgumentNullException(nameof(invoker));
-        }
-
-        if (GeneratedFactories.TryGetValue(grpcInterfaceType, out var factory))
-        {
-            return factory(invoker);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<CallInvoker>.Create(
+            grpcInterfaceType,
+            invoker,
             grpcInterfaceType.Name
             + " does not have a generated gRPC proxy. Ensure the interface is marked with [Grpc], "
             + "Observables.Grpc source generators are referenced, and the project was rebuilt.");

--- a/Observables.Grpc/Observables.Grpc/Observables.Grpc.csproj
+++ b/Observables.Grpc/Observables.Grpc/Observables.Grpc.csproj
@@ -12,5 +12,9 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>
 

--- a/Observables.Grpc/Observables.Grpc/loc/zh-Hans/Observables.Grpc.xml
+++ b/Observables.Grpc/Observables.Grpc/loc/zh-Hans/Observables.Grpc.xml
@@ -46,5 +46,8 @@
         <member name="M:Observables.Grpc.GrpcService.RegisterGeneratedFactory(System.Type,System.Func{Grpc.Core.CallInvoker,System.Object})">
             <summary>注册源生成的 gRPC 代理工厂。</summary>
         </member>
+            <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>

--- a/Observables.Mqtt/Observables.Mqtt/MqttService.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using MQTTnet.Client;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.Mqtt;
 /// <summary>Creates source-generated MQTT topic proxy implementations.</summary>
 public static class MqttService
 {
-    static readonly ConcurrentDictionary<Type, Func<IMqttClient, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated topic proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,23 +16,12 @@ public static class MqttService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type mqttInterfaceType,
-        Func<IMqttClient, object> factory)
+        Func<IMqttClient, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<IMqttClient>.Register(mqttInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type mqttInterfaceType, Func<IMqttClient, object> factory)
+    public static void RegisterGeneratedFactory(Type mqttInterfaceType, Func<IMqttClient, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<IMqttClient>.Register(mqttInterfaceType, factory);
 #endif
-    {
-        if (mqttInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(mqttInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[mqttInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -62,17 +48,9 @@ public static class MqttService
             throw new ArgumentNullException(nameof(mqttInterfaceType));
         }
 
-        if (client is null)
-        {
-            throw new ArgumentNullException(nameof(client));
-        }
-
-        if (GeneratedFactories.TryGetValue(mqttInterfaceType, out var factory))
-        {
-            return factory(client);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<IMqttClient>.Create(
+            mqttInterfaceType,
+            client,
             mqttInterfaceType.Name
             + " does not have a generated MQTT proxy. Ensure the interface is marked with [Mqtt], "
             + "Observables.Mqtt source generators are referenced, and the project was rebuilt.");

--- a/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
+++ b/Observables.Mqtt/Observables.Mqtt/Observables.Mqtt.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.Mqtt/Observables.Mqtt/loc/zh-Hans/Observables.Mqtt.xml
+++ b/Observables.Mqtt/Observables.Mqtt/loc/zh-Hans/Observables.Mqtt.xml
@@ -121,5 +121,8 @@
         <member name="T:Observables.Mqtt.PrimitiveMqttPayloadSerializer">
             <summary>用于原始 <see cref="T:System.Byte"/>[] 与 UTF-8 <see cref="T:System.String"/> 负载的内置序列化器。</summary>
         </member>
+            <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>

--- a/Observables.Nats/Observables.Nats/NatsService.cs
+++ b/Observables.Nats/Observables.Nats/NatsService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using NATS.Client.Core;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.Nats;
 /// <summary>Creates source-generated NATS subject proxy implementations.</summary>
 public static class NatsService
 {
-    static readonly ConcurrentDictionary<Type, Func<INatsConnection, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated subject proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,23 +16,12 @@ public static class NatsService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type natsInterfaceType,
-        Func<INatsConnection, object> factory)
+        Func<INatsConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<INatsConnection>.Register(natsInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type natsInterfaceType, Func<INatsConnection, object> factory)
+    public static void RegisterGeneratedFactory(Type natsInterfaceType, Func<INatsConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<INatsConnection>.Register(natsInterfaceType, factory);
 #endif
-    {
-        if (natsInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(natsInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[natsInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -62,17 +48,9 @@ public static class NatsService
             throw new ArgumentNullException(nameof(natsInterfaceType));
         }
 
-        if (connection is null)
-        {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        if (GeneratedFactories.TryGetValue(natsInterfaceType, out var factory))
-        {
-            return factory(connection);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<INatsConnection>.Create(
+            natsInterfaceType,
+            connection,
             natsInterfaceType.Name
             + " does not have a generated NATS proxy. Ensure the interface is marked with [Nats], "
             + "Observables.Nats source generators are referenced, and the project was rebuilt.");

--- a/Observables.Nats/Observables.Nats/Observables.Nats.csproj
+++ b/Observables.Nats/Observables.Nats/Observables.Nats.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.Nats/Observables.Nats/loc/zh-Hans/Observables.Nats.xml
+++ b/Observables.Nats/Observables.Nats/loc/zh-Hans/Observables.Nats.xml
@@ -127,5 +127,8 @@
         <member name="T:Observables.Nats.PrimitiveNatsPayloadSerializer">
             <summary>用于原始 <see cref="T:System.Byte"/>[] 与 UTF-8 <see cref="T:System.String"/> 负载的内置序列化器。</summary>
         </member>
+            <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>

--- a/Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj
+++ b/Observables.Postgres/Observables.Postgres/Observables.Postgres.csproj
@@ -17,4 +17,8 @@
     <InternalsVisibleTo Include="Observables.Postgres.Reactive" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.Postgres/Observables.Postgres/PostgresService.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Npgsql;
@@ -8,28 +7,14 @@ namespace Observables.Postgres;
 /// <summary>Creates source-generated PostgreSQL LISTEN/NOTIFY proxy implementations.</summary>
 public static class PostgresService
 {
-    static readonly ConcurrentDictionary<Type, Func<NpgsqlConnection, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated channel proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterGeneratedFactory(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type postgresInterfaceType,
-        Func<NpgsqlConnection, object> factory)
-    {
-        if (postgresInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(postgresInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[postgresInterfaceType] = factory;
-    }
+        Func<NpgsqlConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<NpgsqlConnection>.Register(postgresInterfaceType, factory);
 
     /// <summary>
     /// Creates a generated proxy for <typeparamref name="T"/> using a dedicated, non-pooled
@@ -55,17 +40,9 @@ public static class PostgresService
             throw new ArgumentNullException(nameof(postgresInterfaceType));
         }
 
-        if (connection is null)
-        {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        if (GeneratedFactories.TryGetValue(postgresInterfaceType, out var factory))
-        {
-            return factory(connection);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<NpgsqlConnection>.Create(
+            postgresInterfaceType,
+            connection,
             postgresInterfaceType.Name
             + " does not have a generated Postgres proxy. Ensure the interface is marked with [Postgres], "
             + "Observables.Postgres source generators are referenced, and the project was rebuilt.");

--- a/Observables.Redis/Observables.Redis/Observables.Redis.csproj
+++ b/Observables.Redis/Observables.Redis/Observables.Redis.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.Redis/Observables.Redis/RedisService.cs
+++ b/Observables.Redis/Observables.Redis/RedisService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using StackExchange.Redis;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.Redis;
 /// <summary>Creates source-generated Redis Pub/Sub proxy implementations.</summary>
 public static class RedisService
 {
-    static readonly ConcurrentDictionary<Type, Func<IConnectionMultiplexer, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated Pub/Sub proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,23 +16,12 @@ public static class RedisService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type redisInterfaceType,
-        Func<IConnectionMultiplexer, object> factory)
+        Func<IConnectionMultiplexer, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<IConnectionMultiplexer>.Register(redisInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type redisInterfaceType, Func<IConnectionMultiplexer, object> factory)
+    public static void RegisterGeneratedFactory(Type redisInterfaceType, Func<IConnectionMultiplexer, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<IConnectionMultiplexer>.Register(redisInterfaceType, factory);
 #endif
-    {
-        if (redisInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(redisInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[redisInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -62,17 +48,9 @@ public static class RedisService
             throw new ArgumentNullException(nameof(redisInterfaceType));
         }
 
-        if (multiplexer is null)
-        {
-            throw new ArgumentNullException(nameof(multiplexer));
-        }
-
-        if (GeneratedFactories.TryGetValue(redisInterfaceType, out var factory))
-        {
-            return factory(multiplexer);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<IConnectionMultiplexer>.Create(
+            redisInterfaceType,
+            multiplexer,
             redisInterfaceType.Name
             + " does not have a generated Redis proxy. Ensure the interface is marked with [Redis], "
             + "Observables.Redis source generators are referenced, and the project was rebuilt.");

--- a/Observables.Shared/Observables.Core/GeneratedProxyFactoryRegistry.cs
+++ b/Observables.Shared/Observables.Core/GeneratedProxyFactoryRegistry.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+
+namespace Observables;
+
+/// <summary>
+/// Shared generated-proxy factory registry used by Feature <c>*Service.For</c> adapters.
+/// </summary>
+internal static class GeneratedProxyFactoryRegistry<TClient>
+    where TClient : class
+{
+    static readonly ConcurrentDictionary<Type, Func<TClient, object>> Factories = new();
+
+    internal static void Register(Type interfaceType, Func<TClient, object> factory)
+    {
+        if (interfaceType is null)
+        {
+            throw new ArgumentNullException(nameof(interfaceType));
+        }
+
+        if (factory is null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
+        Factories[interfaceType] = factory;
+    }
+
+    internal static object Create(Type interfaceType, TClient client, string missingFactoryMessage)
+    {
+        if (interfaceType is null)
+        {
+            throw new ArgumentNullException(nameof(interfaceType));
+        }
+
+        if (client is null)
+        {
+            throw new ArgumentNullException(nameof(client));
+        }
+
+        if (Factories.TryGetValue(interfaceType, out var factory))
+        {
+            return factory(client);
+        }
+
+        throw new InvalidOperationException(missingFactoryMessage);
+    }
+}

--- a/Observables.SignalR/Observables.SignalR/HubService.cs
+++ b/Observables.SignalR/Observables.SignalR/HubService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using Microsoft.AspNetCore.SignalR.Client;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.SignalR;
 /// <summary>Creates source-generated hub proxy implementations.</summary>
 public static class HubService
 {
-    static readonly ConcurrentDictionary<Type, Func<HubConnection, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated hub proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,22 +16,12 @@ public static class HubService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type hubInterfaceType,
-        Func<HubConnection, object> factory)
+        Func<HubConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<HubConnection>.Register(hubInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type hubInterfaceType, Func<HubConnection, object> factory)
+    public static void RegisterGeneratedFactory(Type hubInterfaceType, Func<HubConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<HubConnection>.Register(hubInterfaceType, factory);
 #endif
-    {
-        if (hubInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(hubInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-        GeneratedFactories[hubInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -61,17 +48,9 @@ public static class HubService
             throw new ArgumentNullException(nameof(hubInterfaceType));
         }
 
-        if (connection is null)
-        {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        if (GeneratedFactories.TryGetValue(hubInterfaceType, out var factory))
-        {
-            return factory(connection);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<HubConnection>.Create(
+            hubInterfaceType,
+            connection,
             hubInterfaceType.Name
             + " does not have a generated hub proxy. Ensure the interface is marked with [Hub], "
             + "Observables.SignalR source generators are referenced, and the project was rebuilt.");

--- a/Observables.SignalR/Observables.SignalR/Observables.SignalR.csproj
+++ b/Observables.SignalR/Observables.SignalR/Observables.SignalR.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.SignalR/Observables.SignalR/loc/zh-Hans/Observables.SignalR.xml
+++ b/Observables.SignalR/Observables.SignalR/loc/zh-Hans/Observables.SignalR.xml
@@ -46,5 +46,8 @@
         <member name="T:Observables.SignalR.SignalRObservable">
             <summary>将 SignalR 客户端 API 桥接到 R3 <see cref="T:R3.Observable`1"/>。</summary>
         </member>
+            <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>

--- a/Observables.Sse/Observables.Sse/Observables.Sse.csproj
+++ b/Observables.Sse/Observables.Sse/Observables.Sse.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.Sse/Observables.Sse/SseService.cs
+++ b/Observables.Sse/Observables.Sse/SseService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -9,8 +8,6 @@ namespace Observables.Sse;
 /// <summary>Creates source-generated SSE proxy implementations.</summary>
 public static class SseService
 {
-    static readonly ConcurrentDictionary<Type, Func<SseConnection, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated SSE proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -18,23 +15,12 @@ public static class SseService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type sseInterfaceType,
-        Func<SseConnection, object> factory)
+        Func<SseConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<SseConnection>.Register(sseInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type sseInterfaceType, Func<SseConnection, object> factory)
+    public static void RegisterGeneratedFactory(Type sseInterfaceType, Func<SseConnection, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<SseConnection>.Register(sseInterfaceType, factory);
 #endif
-    {
-        if (sseInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(sseInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[sseInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -61,17 +47,9 @@ public static class SseService
             throw new ArgumentNullException(nameof(sseInterfaceType));
         }
 
-        if (connection is null)
-        {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        if (GeneratedFactories.TryGetValue(sseInterfaceType, out var factory))
-        {
-            return factory(connection);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<SseConnection>.Create(
+            sseInterfaceType,
+            connection,
             sseInterfaceType.Name
             + " does not have a generated SSE proxy. Ensure the interface is marked with [Sse], "
             + "Observables.Sse source generators are referenced, and the project was rebuilt.");

--- a/Observables.Sse/Observables.Sse/loc/zh-Hans/Observables.Sse.xml
+++ b/Observables.Sse/Observables.Sse/loc/zh-Hans/Observables.Sse.xml
@@ -70,5 +70,8 @@
         <member name="M:Observables.Sse.SseService.RegisterGeneratedFactory(System.Type,System.Func{Observables.Sse.SseConnection,System.Object})">
             <summary>注册源生成的 SSE 代理工厂。</summary>
         </member>
+        <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>

--- a/Observables.WebSocket/Observables.WebSocket/Observables.WebSocket.csproj
+++ b/Observables.WebSocket/Observables.WebSocket/Observables.WebSocket.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="R3" />
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Compile Include="..\..\Observables.Shared\Observables.Core\GeneratedProxyFactoryRegistry.cs" Link="Shared/GeneratedProxyFactoryRegistry.cs" />
+  </ItemGroup>
 </Project>

--- a/Observables.WebSocket/Observables.WebSocket/WebSocketService.cs
+++ b/Observables.WebSocket/Observables.WebSocket/WebSocketService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Net.WebSockets;
 #if NET8_0_OR_GREATER
@@ -10,8 +9,6 @@ namespace Observables.WebSocket;
 /// <summary>Creates source-generated WebSocket proxy implementations.</summary>
 public static class WebSocketService
 {
-    static readonly ConcurrentDictionary<Type, Func<ClientWebSocket, object>> GeneratedFactories = new();
-
     /// <summary>Registers a source-generated WebSocket proxy factory.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -19,23 +16,12 @@ public static class WebSocketService
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties
         )] Type wsInterfaceType,
-        Func<ClientWebSocket, object> factory)
+        Func<ClientWebSocket, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<ClientWebSocket>.Register(wsInterfaceType, factory);
 #else
-    public static void RegisterGeneratedFactory(Type wsInterfaceType, Func<ClientWebSocket, object> factory)
+    public static void RegisterGeneratedFactory(Type wsInterfaceType, Func<ClientWebSocket, object> factory) =>
+        global::Observables.GeneratedProxyFactoryRegistry<ClientWebSocket>.Register(wsInterfaceType, factory);
 #endif
-    {
-        if (wsInterfaceType is null)
-        {
-            throw new ArgumentNullException(nameof(wsInterfaceType));
-        }
-
-        if (factory is null)
-        {
-            throw new ArgumentNullException(nameof(factory));
-        }
-
-        GeneratedFactories[wsInterfaceType] = factory;
-    }
 
 #if NET8_0_OR_GREATER
     public static T For<
@@ -62,17 +48,9 @@ public static class WebSocketService
             throw new ArgumentNullException(nameof(wsInterfaceType));
         }
 
-        if (socket is null)
-        {
-            throw new ArgumentNullException(nameof(socket));
-        }
-
-        if (GeneratedFactories.TryGetValue(wsInterfaceType, out var factory))
-        {
-            return factory(socket);
-        }
-
-        throw new InvalidOperationException(
+        return global::Observables.GeneratedProxyFactoryRegistry<ClientWebSocket>.Create(
+            wsInterfaceType,
+            socket,
             wsInterfaceType.Name
             + " does not have a generated WebSocket proxy. Ensure the interface is marked with [WebSocket], "
             + "Observables.WebSocket source generators are referenced, and the project was rebuilt.");

--- a/Observables.WebSocket/Observables.WebSocket/loc/zh-Hans/Observables.WebSocket.xml
+++ b/Observables.WebSocket/Observables.WebSocket/loc/zh-Hans/Observables.WebSocket.xml
@@ -34,5 +34,8 @@
         <member name="M:Observables.WebSocket.WebSocketService.RegisterGeneratedFactory(System.Type,System.Func{System.Net.WebSockets.ClientWebSocket,System.Object})">
             <summary>注册源生成的 WebSocket 代理工厂。</summary>
         </member>
+            <member name="T:Observables.GeneratedProxyFactoryRegistry`1">
+            <summary>各 Feature *Service.For 共用的生成代理工厂登记表。</summary>
+        </member>
     </members>
 </doc>


### PR DESCRIPTION
## Summary

Eight Feature `*Service` types cloned the same `RegisterGeneratedFactory` + `ConcurrentDictionary` + `For<T>` implementation. The public Feature interfaces stay put; the registry now lives once in Core and each `*Service` is a thin adapter.

RestAPI `RestService` is unchanged (different factory shape). Public `For<T>` signatures are unchanged.

## Related Issue

Fixes #237

## Solution module

- [x] Shared / Core (registry)
- Feature `*Service` files are the required adapters.

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] `dotnet build` all eight Feature runtimes (0 warnings, PublicAPI green)
- [x] `Observables.Mqtt.Tests` net8.0 (38)
- [x] `Observables.SignalR.R3.SourceGenerators.Tests` net8.0 (10)

## Breaking changes

- [x] None

## Checklist

- [x] Commit messages are in English
- [x] No version bumps, tags, or publish
- [x] RestAPI `RestService` out of scope