### PR TITLE
Absorb leftover IO parser and emitter ceremony into Shared

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,3 +19,11 @@ _Avoid_: generator host, stub framework
 **Proxy registration emitter**:
 The shared emitter of ModuleInitializer factory registration for single-client `*Service.RegisterGeneratedFactory` Features.
 _Avoid_: module initializer helper (when meaning this registration template)
+
+**Feature protocol bridge**:
+The Feature-local subscribe / unsubscribe / cancel / dispose / payload-map module that both R3 and System.Reactive adapters sit on.
+_Avoid_: shared pump, subscribe pump (when meaning this Feature-local module)
+
+**Proxy class emitter**:
+The shared emitter of the sealed generated proxy class shell for single-client IO Features.
+_Avoid_: class template, proxy shell helper (when meaning this shared emitter)

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Emitter.cs
@@ -26,53 +26,30 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(GrpcInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
+    public static SourceText EmitInterface(GrpcInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::Grpc.Core.CallInvoker",
+                "_invoker",
+                "invoker"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "gRPC proxy uses reflection for message marshalling and method invocation. Preserve required members when trimming.",
+                "gRPC proxy uses reflection for message marshalling and method invocation."),
+            emitBeforeMembers: writer =>
             {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("gRPC proxy uses reflection for message marshalling and method invocation. Preserve required members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("gRPC proxy uses reflection for message marshalling and method invocation.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
+                foreach (var member in model.Members.AsArray())
                 {
-                    private readonly global::Grpc.Core.CallInvoker _invoker;
-
-                    public {{model.ClassName}}(global::Grpc.Core.CallInvoker invoker)
-                    {
-                        _invoker = invoker;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMethodField(writer, member, model.ServiceName);
-        }
-
-        writer.WriteLine(string.Empty);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
+                    EmitMethodField(writer, member, model.ServiceName);
                 }
-            }
-            #pragma warning restore
-            """);
 
-        return writer.ToSourceText();
-    }
+                writer.WriteLine(string.Empty);
+            });
 
     static void EmitMethodField(SourceWriter writer, GrpcMemberModel member, string serviceName)
     {

--- a/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Grpc/Observables.Grpc.SourceGenerators.Shared/Parser.cs
@@ -17,81 +17,51 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var grpcAttribute = compilation.GetTypeByMetadataName("Observables.Grpc.GrpcAttribute");
-        if (grpcAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.GrpcCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>()));
-        }
-
         var unaryAttribute = compilation.GetTypeByMetadataName("Observables.Grpc.GrpcUnaryAttribute");
         var serverStreamAttribute = compilation.GetTypeByMetadataName("Observables.Grpc.GrpcServerStreamAttribute");
         var clientStreamAttribute = compilation.GetTypeByMetadataName("Observables.Grpc.GrpcClientStreamAttribute");
         var duplexAttribute = compilation.GetTypeByMetadataName("Observables.Grpc.GrpcDuplexAttribute");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
 
-        var interfaces = new List<GrpcInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var serviceName = GetServiceName(ifaceSymbol) ?? ifaceSymbol.Name.TrimStart('I');
-            var members = new List<GrpcMemberModel>();
-
-            foreach (var member in marked.PublicInstanceMembers)
+        return IoProxyModelAssembly.Parse<GrpcMemberModel, GrpcInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: grpcAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.GrpcCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<GrpcInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                unaryAttribute,
+                serverStreamAttribute,
+                clientStreamAttribute,
+                duplexAttribute,
+                observableType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) =>
             {
-
-                switch (member)
+                if (property.GetAttributes().Length > 0)
                 {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            unaryAttribute,
-                            serverStreamAttribute,
-                            clientStreamAttribute,
-                            duplexAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        if (property.GetAttributes().Length > 0)
-                        {
-                            diagnostics.Add(
-                                Diagnostic.Create(
-                                    DiagnosticDescriptors.InvalidGrpcMember,
-                                    property.Locations.FirstOrDefault(),
-                                    ifaceSymbol.Name,
-                                    property.Name));
-                        }
-
-                        break;
+                    diagnostics.Add(
+                        Diagnostic.Create(
+                            DiagnosticDescriptors.InvalidGrpcMember,
+                            property.Locations.FirstOrDefault(),
+                            marked.InterfaceSymbol.Name,
+                            property.Name));
                 }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new GrpcInterfaceModel(
-                    $"{className}.Grpc.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Grpc"),
-                    serviceName,
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+            },
+            createInterface: static (marked, className, members) => new GrpcInterfaceModel(
+                $"{className}.Grpc.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Grpc"),
+                GetServiceName(marked.InterfaceSymbol) ?? marked.InterfaceSymbol.Name.TrimStart('I'),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Emitter.cs
@@ -26,46 +26,21 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(MqttInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("MQTT payload serialization uses reflection. Preserve payload type members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("MQTT payload serialization uses reflection.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::MQTTnet.Client.IMqttClient _client;
-
-                    public {{model.ClassName}}(global::MQTTnet.Client.IMqttClient client)
-                    {
-                        _client = client;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(MqttInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::MQTTnet.Client.IMqttClient",
+                "_client",
+                "client"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "MQTT payload serialization uses reflection. Preserve payload type members when trimming.",
+                "MQTT payload serialization uses reflection."));
 
     static void EmitMember(SourceWriter writer, MqttMemberModel member)
     {

--- a/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Mqtt/Observables.Mqtt.SourceGenerators.Shared/Parser.cs
@@ -20,74 +20,44 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var mqttAttribute = compilation.GetTypeByMetadataName("Observables.Mqtt.MqttAttribute");
-        if (mqttAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.MqttCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>()));
-        }
-
         var publishAttribute = compilation.GetTypeByMetadataName("Observables.Mqtt.MqttPublishAttribute");
         var subscribeAttribute = compilation.GetTypeByMetadataName("Observables.Mqtt.MqttSubscribeAttribute");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<MqttInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<MqttMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            publishAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            compilation,
-                            publishAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new MqttInterfaceModel(
-                    $"{className}.Mqtt.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Mqtt"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<MqttMemberModel, MqttInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: mqttAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.MqttCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<MqttInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                publishAttribute,
+                subscribeAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                compilation,
+                publishAttribute,
+                subscribeAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new MqttInterfaceModel(
+                $"{className}.Mqtt.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Mqtt"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Emitter.cs
@@ -26,46 +26,21 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(NatsInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("NATS payload serialization uses reflection. Preserve payload type members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("NATS payload serialization uses reflection.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::NATS.Client.Core.INatsConnection _connection;
-
-                    public {{model.ClassName}}(global::NATS.Client.Core.INatsConnection connection)
-                    {
-                        _connection = connection;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(NatsInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::NATS.Client.Core.INatsConnection",
+                "_connection",
+                "connection"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "NATS payload serialization uses reflection. Preserve payload type members when trimming.",
+                "NATS payload serialization uses reflection."));
 
     static void EmitMember(SourceWriter writer, NatsMemberModel member)
     {

--- a/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Nats/Observables.Nats.SourceGenerators.Shared/Parser.cs
@@ -20,76 +20,46 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var mqttAttribute = compilation.GetTypeByMetadataName("Observables.Nats.NatsAttribute");
-        if (mqttAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.NatsCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>()));
-        }
-
         var publishAttribute = compilation.GetTypeByMetadataName("Observables.Nats.NatsPublishAttribute");
         var requestAttribute = compilation.GetTypeByMetadataName("Observables.Nats.NatsRequestAttribute");
         var subscribeAttribute = compilation.GetTypeByMetadataName("Observables.Nats.NatsSubscribeAttribute");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<NatsInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<NatsMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            publishAttribute,
-                            requestAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            compilation,
-                            publishAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new NatsInterfaceModel(
-                    $"{className}.Nats.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Nats"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<NatsMemberModel, NatsInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: mqttAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.NatsCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<NatsInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                publishAttribute,
+                requestAttribute,
+                subscribeAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                compilation,
+                publishAttribute,
+                subscribeAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new NatsInterfaceModel(
+                $"{className}.Nats.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Nats"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Emitter.cs
@@ -25,42 +25,18 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(PostgresInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::Npgsql.NpgsqlConnection _connection;
-
-                    public {{model.ClassName}}(global::Npgsql.NpgsqlConnection connection)
-                    {
-                        _connection = connection;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(PostgresInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::Npgsql.NpgsqlConnection",
+                "_connection",
+                "connection"),
+            model.Members.AsArray(),
+            EmitMember);
 
     static void EmitMember(SourceWriter writer, PostgresMemberModel member)
     {

--- a/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Postgres/Observables.Postgres.SourceGenerators.Shared/Parser.cs
@@ -22,74 +22,44 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var postgresAttribute = compilation.GetTypeByMetadataName("Observables.Postgres.PostgresAttribute");
-        if (postgresAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.PostgresCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<PostgresInterfaceModel>()));
-        }
-
         var notifyAttribute = compilation.GetTypeByMetadataName("Observables.Postgres.NotifyAttribute");
         var listenAttribute = compilation.GetTypeByMetadataName("Observables.Postgres.ListenAttribute");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<PostgresInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<PostgresMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            notifyAttribute,
-                            listenAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            compilation,
-                            notifyAttribute,
-                            listenAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new PostgresInterfaceModel(
-                    $"{className}.Postgres.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Postgres"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<PostgresMemberModel, PostgresInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: postgresAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.PostgresCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<PostgresInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                notifyAttribute,
+                listenAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                compilation,
+                notifyAttribute,
+                listenAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new PostgresInterfaceModel(
+                $"{className}.Postgres.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Postgres"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Emitter.cs
@@ -26,46 +26,21 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(RedisInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Redis payload serialization uses reflection. Preserve payload type members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Redis payload serialization uses reflection.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::StackExchange.Redis.IConnectionMultiplexer _multiplexer;
-
-                    public {{model.ClassName}}(global::StackExchange.Redis.IConnectionMultiplexer multiplexer)
-                    {
-                        _multiplexer = multiplexer;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(RedisInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::StackExchange.Redis.IConnectionMultiplexer",
+                "_multiplexer",
+                "multiplexer"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "Redis payload serialization uses reflection. Preserve payload type members when trimming.",
+                "Redis payload serialization uses reflection."));
 
     static void EmitMember(SourceWriter writer, RedisMemberModel member)
     {

--- a/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Redis/Observables.Redis.SourceGenerators.Shared/Parser.cs
@@ -20,76 +20,46 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var redisAttribute = compilation.GetTypeByMetadataName("Observables.Redis.RedisAttribute");
-        if (redisAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.RedisCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<RedisInterfaceModel>()));
-        }
-
         var publishAttribute = compilation.GetTypeByMetadataName("Observables.Redis.RedisPublishAttribute");
         var subscribeAttribute = compilation.GetTypeByMetadataName("Observables.Redis.RedisSubscribeAttribute");
         var redisMessageType = compilation.GetTypeByMetadataName("Observables.Redis.RedisMessage`1");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<RedisInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<RedisMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            publishAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            compilation,
-                            publishAttribute,
-                            subscribeAttribute,
-                            observableType,
-                            redisMessageType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new RedisInterfaceModel(
-                    $"{className}.Redis.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Redis"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<RedisMemberModel, RedisInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: redisAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.RedisCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<RedisInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                publishAttribute,
+                subscribeAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                compilation,
+                publishAttribute,
+                subscribeAttribute,
+                observableType,
+                redisMessageType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new RedisInterfaceModel(
+                $"{className}.Redis.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Redis"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyModelAssembly.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/IoProxyModelAssembly.cs
@@ -1,0 +1,69 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Shared proxy-model assembly for IO stub generators.
+/// Feature parsers keep member classification (<c>TryAdd*</c>) as adapters.
+/// </summary>
+internal static class IoProxyModelAssembly
+{
+    internal static string GeneratedProxyClassName(INamedTypeSymbol iface) =>
+        $"{iface.Name.TrimStart('I')}GeneratedProxy";
+
+    internal static (List<Diagnostic> diagnostics, TContextModel model) Parse<TMember, TInterfaceModel, TContextModel>(
+        ImmutableArray<MarkedInterfaceContext> markedInterfaces,
+        CancellationToken cancellationToken,
+        bool coreReferenced,
+        DiagnosticDescriptor coreNotReferenced,
+        Func<TContextModel> emptyModel,
+        Action<MarkedInterfaceContext, IMethodSymbol, List<TMember>, List<Diagnostic>> tryAddMethod,
+        Action<MarkedInterfaceContext, IPropertySymbol, List<TMember>, List<Diagnostic>>? tryAddProperty,
+        Func<MarkedInterfaceContext, string, ImmutableEquatableArray<TMember>, TInterfaceModel> createInterface,
+        Func<ImmutableEquatableArray<TInterfaceModel>, TContextModel> createContext,
+        Action<MarkedInterfaceContext>? onMarkedInterface = null)
+        where TMember : IEquatable<TMember>
+        where TInterfaceModel : IEquatable<TInterfaceModel>
+    {
+        var diagnostics = new List<Diagnostic>();
+        if (!coreReferenced)
+        {
+            diagnostics.Add(Diagnostic.Create(coreNotReferenced, null));
+            return (diagnostics, emptyModel());
+        }
+
+        var interfaces = new List<TInterfaceModel>();
+        foreach (var marked in markedInterfaces)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            onMarkedInterface?.Invoke(marked);
+            var members = new List<TMember>();
+            foreach (var member in marked.PublicInstanceMembers)
+            {
+                switch (member)
+                {
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        tryAddMethod(marked, method, members, diagnostics);
+                        break;
+                    case IPropertySymbol property:
+                        tryAddProperty?.Invoke(marked, property, members, diagnostics);
+                        break;
+                }
+            }
+
+            if (members.Count == 0)
+            {
+                continue;
+            }
+
+            interfaces.Add(
+                createInterface(
+                    marked,
+                    GeneratedProxyClassName(marked.InterfaceSymbol),
+                    members.ToImmutableEquatableArray()));
+        }
+
+        return (diagnostics, createContext(interfaces.ToImmutableEquatableArray()));
+    }
+}

--- a/Observables.Shared/Observables.SourceGenerators.Shared/ProxyClassEmitter.cs
+++ b/Observables.Shared/Observables.SourceGenerators.Shared/ProxyClassEmitter.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace Observables.SourceGenerators.Shared;
+
+/// <summary>
+/// Emits the sealed generated proxy class shell for single-client IO Features.
+/// Feature emitters keep <c>EmitMember</c> / bridge type as adapters.
+/// RestAPI (HTTP request construction, two-arg factory) is out of scope.
+/// </summary>
+internal static class ProxyClassEmitter
+{
+    internal readonly struct ClientField
+    {
+        internal ClientField(string typeMetadataName, string fieldName, string parameterName)
+        {
+            TypeMetadataName = typeMetadataName;
+            FieldName = fieldName;
+            ParameterName = parameterName;
+        }
+
+        internal string TypeMetadataName { get; }
+        internal string FieldName { get; }
+        internal string ParameterName { get; }
+    }
+
+    internal readonly struct TrimWarnings
+    {
+        internal TrimWarnings(string unreferencedCode, string dynamicCode)
+        {
+            UnreferencedCode = unreferencedCode;
+            DynamicCode = dynamicCode;
+        }
+
+        internal string UnreferencedCode { get; }
+        internal string DynamicCode { get; }
+    }
+
+    internal static SourceText Emit<TMember>(
+        Nullability nullability,
+        string generatedNamespace,
+        string className,
+        string interfaceDisplayName,
+        ClientField client,
+        IReadOnlyList<TMember> members,
+        Action<SourceWriter, TMember> emitMember,
+        TrimWarnings? trim = null,
+        Action<SourceWriter>? emitBeforeMembers = null)
+    {
+        var writer = new SourceWriter();
+        GeneratedSourceHeader.WritePrefix(writer, nullability);
+
+        writer.WriteLine(
+            $$"""
+            namespace {{generatedNamespace}}
+            {
+                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+            """);
+
+        if (trim is { } warnings)
+        {
+            writer.WriteLine(
+                $$"""
+            #if NET8_0_OR_GREATER
+                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("{{warnings.UnreferencedCode}}")]
+                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("{{warnings.DynamicCode}}")]
+            #endif
+            """);
+        }
+
+        writer.WriteLine(
+            $$"""
+                internal sealed class {{className}} : {{interfaceDisplayName}}
+                {
+                    private readonly {{client.TypeMetadataName}} {{client.FieldName}};
+
+                    public {{className}}({{client.TypeMetadataName}} {{client.ParameterName}})
+                    {
+                        {{client.FieldName}} = {{client.ParameterName}};
+                    }
+
+            """);
+
+        emitBeforeMembers?.Invoke(writer);
+
+        foreach (var member in members)
+        {
+            emitMember(writer, member);
+        }
+
+        writer.WriteLine(
+            """
+                }
+            }
+            #pragma warning restore
+            """);
+
+        return writer.ToSourceText();
+    }
+}

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Emitter.cs
@@ -26,46 +26,21 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(HubInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SignalR hub proxy uses reflection for method invocation and serialization. Preserve required members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("SignalR hub proxy uses reflection for method invocation and serialization.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::Microsoft.AspNetCore.SignalR.Client.HubConnection _connection;
-
-                    public {{model.ClassName}}(global::Microsoft.AspNetCore.SignalR.Client.HubConnection connection)
-                    {
-                        _connection = connection;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(HubInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::Microsoft.AspNetCore.SignalR.Client.HubConnection",
+                "_connection",
+                "connection"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "SignalR hub proxy uses reflection for method invocation and serialization. Preserve required members when trimming.",
+                "SignalR hub proxy uses reflection for method invocation and serialization."));
 
     static void EmitMember(SourceWriter writer, HubMemberModel member)
     {

--- a/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
+++ b/Observables.SignalR/Observables.SignalR.SourceGenerators.Shared/Parser.cs
@@ -17,14 +17,7 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var hubAttribute = compilation.GetTypeByMetadataName("Observables.SignalR.HubAttribute");
-        if (hubAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.SignalRCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>()));
-        }
-
         var invokeAttribute = compilation.GetTypeByMetadataName("Observables.SignalR.HubInvokeAttribute");
         var sendAttribute = compilation.GetTypeByMetadataName("Observables.SignalR.HubSendAttribute");
         var streamAttribute = compilation.GetTypeByMetadataName("Observables.SignalR.HubStreamAttribute");
@@ -32,71 +25,50 @@ internal static class Parser
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<HubInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            if (string.Equals(compilation.AssemblyName, "GeneratorTests", StringComparison.Ordinal)
-                && marked.Syntax.Identifier.ValueText == "IInternalErrorProbe")
+        return IoProxyModelAssembly.Parse<HubMemberModel, HubInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: hubAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.SignalRCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<HubInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                invokeAttribute,
+                sendAttribute,
+                streamAttribute,
+                onAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                compilation,
+                invokeAttribute,
+                sendAttribute,
+                streamAttribute,
+                onAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new HubInterfaceModel(
+                $"{className}.SignalR.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.SignalR"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces),
+            onMarkedInterface: marked =>
             {
-                throw new InvalidOperationException("fail-safe probe");
-            }
-
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<HubMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
+                if (string.Equals(compilation.AssemblyName, "GeneratorTests", StringComparison.Ordinal)
+                    && marked.Syntax.Identifier.ValueText == "IInternalErrorProbe")
                 {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            invokeAttribute,
-                            sendAttribute,
-                            streamAttribute,
-                            onAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            compilation,
-                            invokeAttribute,
-                            sendAttribute,
-                            streamAttribute,
-                            onAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
+                    throw new InvalidOperationException("fail-safe probe");
                 }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new HubInterfaceModel(
-                    $"{className}.SignalR.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.SignalR"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+            });
     }
 
     static void TryAddMethod(

--- a/Observables.SourceGenerators.SharedSource.props
+++ b/Observables.SourceGenerators.SharedSource.props
@@ -49,11 +49,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/ProxyRegistrationEmitter.cs">
       <Link>Shared/ProxyRegistrationEmitter.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/ProxyClassEmitter.cs">
+      <Link>Shared/ProxyClassEmitter.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyGeneratorPipeline.cs">
       <Link>Shared/IoProxyGeneratorPipeline.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyInterfaceWalk.cs">
       <Link>Shared/IoProxyInterfaceWalk.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.SourceGenerators.Shared/IoProxyModelAssembly.cs">
+      <Link>Shared/IoProxyModelAssembly.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Observables.Shared/Observables.Roslyn.Shared/ProxyDomainTable.cs">
       <Link>Shared/ProxyDomainTable.cs</Link>

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Emitter.cs
@@ -26,50 +26,25 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(SseInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("SSE payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("SSE payload deserialization uses System.Text.Json reflection.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::Observables.Sse.SseConnection _connection;
-
-                    public {{model.ClassName}}(global::Observables.Sse.SseConnection connection)
-                    {
-                        _connection = connection;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            writer.WriteLine(
+    public static SourceText EmitInterface(SseInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::Observables.Sse.SseConnection",
+                "_connection",
+                "connection"),
+            model.Members.AsArray(),
+            (writer, member) => writer.WriteLine(
                 $$"""
                     private {{member.ReturnTypeDisplay}}? _{{member.MemberName}};
                     public {{member.ReturnTypeDisplay}} {{member.MemberName}} =>
                         _{{member.MemberName}} ??= {{BridgeType}}.FromEvent<{{member.ResultTypeDisplay}}>(_connection, "{{member.EventName}}");
 
-                """);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+                """),
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "SSE payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.",
+                "SSE payload deserialization uses System.Text.Json reflection."));
 }

--- a/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
+++ b/Observables.Sse/Observables.Sse.SourceGenerators.Shared/Parser.cs
@@ -17,63 +17,34 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var sseAttribute = compilation.GetTypeByMetadataName("Observables.Sse.SseAttribute");
-        if (sseAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.SseCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>()));
-        }
-
         var eventAttribute = compilation.GetTypeByMetadataName("Observables.Sse.SseEventAttribute");
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
 
-        var interfaces = new List<SseInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<SseMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(method, ifaceSymbol, eventAttribute, diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            ifaceSymbol,
-                            compilation,
-                            eventAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new SseInterfaceModel(
-                    $"{className}.Sse.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.Sse"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<SseMemberModel, SseInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: sseAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.SseCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<SseInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) =>
+                TryAddMethod(method, marked.InterfaceSymbol, eventAttribute, diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                marked.InterfaceSymbol,
+                compilation,
+                eventAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new SseInterfaceModel(
+                $"{className}.Sse.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.Sse"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Emitter.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Emitter.cs
@@ -26,46 +26,21 @@ internal static class Emitter
                     m.ClassName)).ToArray(),
             addSource);
     }
-    public static SourceText EmitInterface(WebSocketInterfaceModel model)
-    {
-        var writer = new SourceWriter();
-        GeneratedSourceHeader.WritePrefix(writer, model.Nullability);
-
-        writer.WriteLine(
-            $$"""
-            namespace {{model.GeneratedNamespace}}
-            {
-                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-            #if NET8_0_OR_GREATER
-                [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WebSocket payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-                [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("WebSocket payload serialization uses System.Text.Json reflection.")]
-            #endif
-                internal sealed class {{model.ClassName}} : {{model.InterfaceDisplayName}}
-                {
-                    private readonly global::System.Net.WebSockets.ClientWebSocket _socket;
-
-                    public {{model.ClassName}}(global::System.Net.WebSockets.ClientWebSocket socket)
-                    {
-                        _socket = socket;
-                    }
-
-            """);
-
-        foreach (var member in model.Members.AsArray())
-        {
-            EmitMember(writer, member);
-        }
-
-        writer.WriteLine(
-            """
-                }
-            }
-            #pragma warning restore
-            """);
-
-        return writer.ToSourceText();
-    }
+    public static SourceText EmitInterface(WebSocketInterfaceModel model) =>
+        ProxyClassEmitter.Emit(
+            model.Nullability,
+            model.GeneratedNamespace,
+            model.ClassName,
+            model.InterfaceDisplayName,
+            new ProxyClassEmitter.ClientField(
+                "global::System.Net.WebSockets.ClientWebSocket",
+                "_socket",
+                "socket"),
+            model.Members.AsArray(),
+            EmitMember,
+            trim: new ProxyClassEmitter.TrimWarnings(
+                "WebSocket payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.",
+                "WebSocket payload serialization uses System.Text.Json reflection."));
 
     static void EmitMember(SourceWriter writer, WebSocketMemberModel member)
     {

--- a/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
+++ b/Observables.WebSocket/Observables.WebSocket.SourceGenerators.Shared/Parser.cs
@@ -17,14 +17,7 @@ internal static class Parser
         ImmutableArray<MarkedInterfaceContext> markedInterfaces,
         CancellationToken cancellationToken)
     {
-        var diagnostics = new List<Diagnostic>();
         var wsAttribute = compilation.GetTypeByMetadataName("Observables.WebSocket.WebSocketAttribute");
-        if (wsAttribute is null)
-        {
-            diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.WebSocketCoreNotReferenced, null));
-            return (diagnostics, new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>()));
-        }
-
         var sendAttribute = compilation.GetTypeByMetadataName("Observables.WebSocket.WebSocketSendAttribute");
         var receiveAttribute = compilation.GetTypeByMetadataName("Observables.WebSocket.WebSocketReceiveAttribute");
         var connectAttribute = compilation.GetTypeByMetadataName("Observables.WebSocket.WebSocketConnectAttribute");
@@ -32,66 +25,43 @@ internal static class Parser
         var observableType = compilation.GetTypeByMetadataName(BackendTokens.ObservableMetadataName);
         var unitType = compilation.GetTypeByMetadataName(BackendTokens.UnitMetadataName);
 
-        var interfaces = new List<WebSocketInterfaceModel>();
-
-        foreach (var marked in markedInterfaces)
-        {
-            var ifaceSymbol = marked.InterfaceSymbol;
-            var nullable = marked.Nullability;
-
-            var members = new List<WebSocketMemberModel>();
-            foreach (var member in marked.PublicInstanceMembers)
-            {
-
-                switch (member)
-                {
-                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                        TryAddMethod(
-                            method,
-                            ifaceSymbol,
-                            compilation,
-                            sendAttribute,
-                            receiveAttribute,
-                            connectAttribute,
-                            closeAttribute,
-                            observableType,
-                            unitType,
-                            members,
-                            diagnostics);
-                        break;
-                    case IPropertySymbol property:
-                        TryAddProperty(
-                            property,
-                            ifaceSymbol,
-                            compilation,
-                            sendAttribute,
-                            receiveAttribute,
-                            connectAttribute,
-                            closeAttribute,
-                            observableType,
-                            members,
-                            diagnostics);
-                        break;
-                }
-            }
-
-            if (members.Count == 0)
-            {
-                continue;
-            }
-
-            var className = $"{ifaceSymbol.Name.TrimStart('I')}GeneratedProxy";
-            interfaces.Add(
-                new WebSocketInterfaceModel(
-                    $"{className}.WebSocket.g.cs",
-                    className,
-                    ifaceSymbol.ToDisplayString(DisplayFormat),
-                    BackendTokens.QualifyGeneratedNamespace("Observables.WebSocket"),
-                    members.ToImmutableEquatableArray(),
-                    nullable));
-        }
-
-        return (diagnostics, new ContextGenerationModel(interfaces.ToImmutableEquatableArray()));
+        return IoProxyModelAssembly.Parse<WebSocketMemberModel, WebSocketInterfaceModel, ContextGenerationModel>(
+            markedInterfaces,
+            cancellationToken,
+            coreReferenced: wsAttribute is not null,
+            coreNotReferenced: DiagnosticDescriptors.WebSocketCoreNotReferenced,
+            emptyModel: static () => new ContextGenerationModel(ImmutableEquatableArray.Empty<WebSocketInterfaceModel>()),
+            tryAddMethod: (marked, method, members, diagnostics) => TryAddMethod(
+                method,
+                marked.InterfaceSymbol,
+                compilation,
+                sendAttribute,
+                receiveAttribute,
+                connectAttribute,
+                closeAttribute,
+                observableType,
+                unitType,
+                members,
+                diagnostics),
+            tryAddProperty: (marked, property, members, diagnostics) => TryAddProperty(
+                property,
+                marked.InterfaceSymbol,
+                compilation,
+                sendAttribute,
+                receiveAttribute,
+                connectAttribute,
+                closeAttribute,
+                observableType,
+                members,
+                diagnostics),
+            createInterface: static (marked, className, members) => new WebSocketInterfaceModel(
+                $"{className}.WebSocket.g.cs",
+                className,
+                marked.InterfaceSymbol.ToDisplayString(DisplayFormat),
+                BackendTokens.QualifyGeneratedNamespace("Observables.WebSocket"),
+                members,
+                marked.Nullability),
+            createContext: static interfaces => new ContextGenerationModel(interfaces));
     }
 
     static void TryAddMethod(


### PR DESCRIPTION
## Summary

Absorb the eight IO `Generate*Stubs` loops and sealed proxy class shells into Shared (`IoProxyModelAssembly`, `ProxyClassEmitter`). Feature parsers/emitters keep `TryAdd*` / `EmitMember` adapters. RestAPI and Events stay off these extracts.

## Related Issue

Closes #249
Closes #250
Parent: https://github.com/Skymly/Observables/issues/243

## Solution module

- [x] Shared

## Type of change

- [x] Source generator / diagnostic change
- [x] Refactor (no behavior change)

## Test plan

- [x] `dotnet test` (R3 generator tests): Mqtt 7, SignalR 10, Grpc 6, Sse 9, WebSocket 13, Nats 7, Postgres 10, Redis 14
- [x] RestAPI GeneratorTests 25 (unchanged)

## Breaking changes

- [x] None

## Checklist

- [x] This PR owns Shared deepening; Feature `SourceGenerators.Shared` Parser/Emitter files are the required adapters
- [x] Commit messages are in **English**
- [x] No version bumps, tags, releases, or NuGet publish steps
- [x] No documentation changes needed (glossary in CONTEXT.md)
