### PR TITLE
Concentrate Redis Pub/Sub protocol behind thin R3/Reactive adapters

### DIFF
--- a/Observables.Redis/Observables.Redis.Reactive/Observables.Redis.Reactive.csproj
+++ b/Observables.Redis/Observables.Redis.Reactive/Observables.Redis.Reactive.csproj
@@ -13,4 +13,9 @@
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Observables.Redis\RedisProtocol.cs" Link="RedisProtocol.cs" />
+    <Compile Include="..\Observables.Redis\RedisTrimAnnotations.cs" Link="RedisTrimAnnotations.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Observables.Redis/Observables.Redis.Reactive/SystemReactiveRedisAdapter.cs
+++ b/Observables.Redis/Observables.Redis.Reactive/SystemReactiveRedisAdapter.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using Observables.Redis;
 using StackExchange.Redis;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -23,18 +24,13 @@ public static class SystemReactiveRedisAdapter
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            linked.Token.ThrowIfCancellationRequested();
-            var subscriber = multiplexer.GetSubscriber();
-            await subscriber
-                .PublishAsync(RedisChannel.Literal(channel), payload ?? Array.Empty<byte>())
-                .WaitAsync(linked.Token)
-                .ConfigureAwait(false);
+            await RedisProtocol.PublishAsync(multiplexer, channel, payload, linked.Token).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static IObservable<System.Reactive.Unit> FromPublish<T>(
         IConnectionMultiplexer multiplexer,
@@ -44,22 +40,22 @@ public static class SystemReactiveRedisAdapter
         FromPublish(multiplexer, channel, RedisPayloadSerializers.Serialize(payload), cancellationToken);
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static IObservable<T> FromSubscribe<T>(IConnectionMultiplexer multiplexer, string channel) =>
-        CreateSubscribe(multiplexer, RedisChannel.Literal(channel), static message => DeserializePayload<T>(message));
+        CreateSubscribe(multiplexer, RedisChannel.Literal(channel), static message => RedisProtocol.DeserializePayload<T>(message));
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static IObservable<T> FromPatternSubscribe<T>(IConnectionMultiplexer multiplexer, string pattern) =>
-        CreateSubscribe(multiplexer, RedisChannel.Pattern(pattern), static message => DeserializePayload<T>(message));
+        CreateSubscribe(multiplexer, RedisChannel.Pattern(pattern), static message => RedisProtocol.DeserializePayload<T>(message));
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static IObservable<RedisMessage<T>> FromSubscribeMessage<T>(
         IConnectionMultiplexer multiplexer,
@@ -67,11 +63,11 @@ public static class SystemReactiveRedisAdapter
         CreateSubscribe(
             multiplexer,
             RedisChannel.Literal(channel),
-            static message => ToRedisMessage<T>(message));
+            static message => RedisProtocol.ToRedisMessage<T>(message));
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static IObservable<RedisMessage<T>> FromPatternSubscribeMessage<T>(
         IConnectionMultiplexer multiplexer,
@@ -79,25 +75,11 @@ public static class SystemReactiveRedisAdapter
         CreateSubscribe(
             multiplexer,
             RedisChannel.Pattern(pattern),
-            static message => ToRedisMessage<T>(message));
+            static message => RedisProtocol.ToRedisMessage<T>(message));
 
 #if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
-#endif
-    static T DeserializePayload<T>(ChannelMessage message) =>
-        RedisPayloadSerializers.Deserialize<T>((byte[]?)message.Message ?? Array.Empty<byte>());
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
-#endif
-    static RedisMessage<T> ToRedisMessage<T>(ChannelMessage message) =>
-        new(message.Channel.ToString(), DeserializePayload<T>(message));
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     static IObservable<T> CreateSubscribe<T>(
         IConnectionMultiplexer multiplexer,
@@ -105,37 +87,15 @@ public static class SystemReactiveRedisAdapter
         Func<ChannelMessage, T> map) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            ChannelMessageQueue? queue = null;
             try
             {
-                var subscriber = multiplexer.GetSubscriber();
-                queue = await subscriber.SubscribeAsync(channel).ConfigureAwait(false);
-
-                // ChannelMessageQueue enumeration is sequential (SER OnMessage / queue path).
-                await foreach (var message in queue.WithCancellation(ct).ConfigureAwait(false))
-                {
-                    observer.OnNext(map(message));
-                }
-
-                observer.OnCompleted();
+                await RedisProtocol
+                    .SubscribeAsync(multiplexer, channel, map, observer.OnNext, observer.OnCompleted, ct)
+                    .ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 observer.OnError(ex);
-            }
-            finally
-            {
-                if (queue is not null)
-                {
-                    try
-                    {
-                        await queue.UnsubscribeAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        // best-effort unsubscribe on dispose / fault
-                    }
-                }
             }
         });
 }

--- a/Observables.Redis/Observables.Redis/RedisObservable.cs
+++ b/Observables.Redis/Observables.Redis/RedisObservable.cs
@@ -23,12 +23,7 @@ public static class RedisObservable
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            linked.Token.ThrowIfCancellationRequested();
-            var subscriber = multiplexer.GetSubscriber();
-            await subscriber
-                .PublishAsync(RedisChannel.Literal(channel), payload ?? Array.Empty<byte>())
-                .WaitAsync(linked.Token)
-                .ConfigureAwait(false);
+            await RedisProtocol.PublishAsync(multiplexer, channel, payload, linked.Token).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -48,14 +43,14 @@ public static class RedisObservable
     [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static Observable<T> FromSubscribe<T>(IConnectionMultiplexer multiplexer, string channel) =>
-        CreateSubscribe(multiplexer, RedisChannel.Literal(channel), static message => DeserializePayload<T>(message));
+        CreateSubscribe(multiplexer, RedisChannel.Literal(channel), static message => RedisProtocol.DeserializePayload<T>(message));
 
 #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
     [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
 #endif
     public static Observable<T> FromPatternSubscribe<T>(IConnectionMultiplexer multiplexer, string pattern) =>
-        CreateSubscribe(multiplexer, RedisChannel.Pattern(pattern), static message => DeserializePayload<T>(message));
+        CreateSubscribe(multiplexer, RedisChannel.Pattern(pattern), static message => RedisProtocol.DeserializePayload<T>(message));
 
 #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
@@ -67,7 +62,7 @@ public static class RedisObservable
         CreateSubscribe(
             multiplexer,
             RedisChannel.Literal(channel),
-            static message => ToRedisMessage<T>(message));
+            static message => RedisProtocol.ToRedisMessage<T>(message));
 
 #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
@@ -79,21 +74,7 @@ public static class RedisObservable
         CreateSubscribe(
             multiplexer,
             RedisChannel.Pattern(pattern),
-            static message => ToRedisMessage<T>(message));
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
-    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
-#endif
-    static T DeserializePayload<T>(ChannelMessage message) =>
-        RedisPayload.Deserialize<T>((byte[]?)message.Message ?? Array.Empty<byte>());
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
-    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
-#endif
-    static RedisMessage<T> ToRedisMessage<T>(ChannelMessage message) =>
-        new(message.Channel.ToString(), DeserializePayload<T>(message));
+            static message => RedisProtocol.ToRedisMessage<T>(message));
 
 #if NET8_0_OR_GREATER
     [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
@@ -105,37 +86,15 @@ public static class RedisObservable
         Func<ChannelMessage, T> map) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            ChannelMessageQueue? queue = null;
             try
             {
-                var subscriber = multiplexer.GetSubscriber();
-                queue = await subscriber.SubscribeAsync(channel).ConfigureAwait(false);
-
-                // ChannelMessageQueue enumeration is sequential (SER OnMessage / queue path).
-                await foreach (var message in queue.WithCancellation(ct).ConfigureAwait(false))
-                {
-                    observer.OnNext(map(message));
-                }
-
-                observer.OnCompleted();
+                await RedisProtocol
+                    .SubscribeAsync(multiplexer, channel, map, observer.OnNext, observer.OnCompleted, ct)
+                    .ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 observer.OnErrorResume(ex);
-            }
-            finally
-            {
-                if (queue is not null)
-                {
-                    try
-                    {
-                        await queue.UnsubscribeAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception)
-                    {
-                        // best-effort unsubscribe on dispose / fault
-                    }
-                }
             }
         });
 }

--- a/Observables.Redis/Observables.Redis/RedisProtocol.cs
+++ b/Observables.Redis/Observables.Redis/RedisProtocol.cs
@@ -4,8 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 
 namespace Observables.Redis;
-
-/// <summary>Feature protocol bridge for Redis Pub/Sub (subscribe / unsubscribe / publish / payload map).</summary>
 internal static class RedisProtocol
 {
     internal static async Task PublishAsync(

--- a/Observables.Redis/Observables.Redis/RedisProtocol.cs
+++ b/Observables.Redis/Observables.Redis/RedisProtocol.cs
@@ -1,0 +1,80 @@
+using StackExchange.Redis;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Observables.Redis;
+
+/// <summary>Feature protocol bridge for Redis Pub/Sub (subscribe / unsubscribe / publish / payload map).</summary>
+internal static class RedisProtocol
+{
+    internal static async Task PublishAsync(
+        IConnectionMultiplexer multiplexer,
+        string channel,
+        byte[] payload,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var subscriber = multiplexer.GetSubscriber();
+        await subscriber
+            .PublishAsync(RedisChannel.Literal(channel), payload ?? Array.Empty<byte>())
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
+#endif
+    internal static T DeserializePayload<T>(ChannelMessage message) =>
+        RedisPayloadSerializers.Deserialize<T>((byte[]?)message.Message ?? Array.Empty<byte>());
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
+#endif
+    internal static RedisMessage<T> ToRedisMessage<T>(ChannelMessage message) =>
+        new(message.Channel.ToString(), DeserializePayload<T>(message));
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode(RedisTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(RedisTrimAnnotations.JsonPayload)]
+#endif
+    internal static async Task SubscribeAsync<T>(
+        IConnectionMultiplexer multiplexer,
+        RedisChannel channel,
+        Func<ChannelMessage, T> map,
+        Action<T> onNext,
+        Action onCompleted,
+        CancellationToken cancellationToken)
+    {
+        ChannelMessageQueue? queue = null;
+        try
+        {
+            var subscriber = multiplexer.GetSubscriber();
+            queue = await subscriber.SubscribeAsync(channel).ConfigureAwait(false);
+
+            // ChannelMessageQueue enumeration is sequential (SER OnMessage / queue path).
+            await foreach (var message in queue.WithCancellation(cancellationToken).ConfigureAwait(false))
+            {
+                onNext(map(message));
+            }
+
+            onCompleted();
+        }
+        finally
+        {
+            if (queue is not null)
+            {
+                try
+                {
+                    await queue.UnsubscribeAsync().ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // best-effort unsubscribe on dispose / fault
+                }
+            }
+        }
+    }
+}

--- a/Observables.Redis/Observables.Redis/RedisProtocol.cs
+++ b/Observables.Redis/Observables.Redis/RedisProtocol.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 
 namespace Observables.Redis;
+
 internal static class RedisProtocol
 {
     internal static async Task PublishAsync(


### PR DESCRIPTION
## Summary

Move Redis subscribe/unsubscribe/publish/payload map into internal `RedisProtocol`. R3 and Reactive adapters only map observer contracts. Linked the helper into Reactive (InternalsVisibleTo leaked Polyfill).

## Related Issue

Closes #248
Parent: https://github.com/Skymly/Observables/issues/243

## Solution module

- [x] Redis (Observables.Redis)

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] Redis.Tests 8, Redis.Reactive.Tests 8, R3 generator 14, Reactive generator 6 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
