### PR TITLE
Concentrate MQTT protocol behind thin R3/Reactive adapters

### DIFF
--- a/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
+++ b/Observables.Mqtt/Observables.Mqtt.Reactive/SystemReactiveMqttAdapter.cs
@@ -1,7 +1,6 @@
 using System.Reactive.Linq;
-using MQTTnet;
 using MQTTnet.Client;
-using MQTTnet.Protocol;
+using Observables.Mqtt;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -11,7 +10,6 @@ namespace Observables.Mqtt.Reactive;
 /// <summary>Bridges MQTT client APIs to <see cref="IObservable{T}"/>.</summary>
 public static class SystemReactiveMqttAdapter
 {
-
     public static IObservable<System.Reactive.Unit> FromPublish(
         IMqttClient client,
         string topic,
@@ -19,12 +17,7 @@ public static class SystemReactiveMqttAdapter
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic(topic)
-                .WithPayload(Array.Empty<byte>())
-                .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
-                .Build();
-            await client.PublishAsync(message, linked.Token).ConfigureAwait(false);
+            await MqttProtocol.PublishAsync(client, topic, Array.Empty<byte>(), linked.Token).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
@@ -35,50 +28,8 @@ public static class SystemReactiveMqttAdapter
     public static IObservable<T> FromSubscribe<T>(IMqttClient client, string topicFilter) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            async Task Handler(MqttApplicationMessageReceivedEventArgs e)
-            {
-                if (!Mqtt.MqttTopicMatcher.Matches(topicFilter, e.ApplicationMessage.Topic))
-                {
-                    return;
-                }
-
-                try
-                {
-                    var payload = e.ApplicationMessage.PayloadSegment.Count == 0
-                        ? Array.Empty<byte>()
-                        : e.ApplicationMessage.PayloadSegment.ToArray();
-                    observer.OnNext(MqttPayloadSerializers.Deserialize<T>(payload));
-                }
-                catch (Exception ex)
-                {
-                    observer.OnError(ex);
-                }
-
-                await Task.CompletedTask.ConfigureAwait(false);
-            }
-
-            client.ApplicationMessageReceivedAsync += Handler;
-            try
-            {
-                await client
-                    .SubscribeAsync(
-                        new MqttTopicFilterBuilder().WithTopic(topicFilter).Build(),
-                        ct)
-                    .ConfigureAwait(false);
-
-                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                client.ApplicationMessageReceivedAsync -= Handler;
-                try
-                {
-                    await client.UnsubscribeAsync(topicFilter).ConfigureAwait(false);
-                }
-                catch (Exception)
-                {
-                    // best-effort if the client is already down
-                }
-            }
+            await MqttProtocol
+                .SubscribeAsync<T>(client, topicFilter, observer.OnNext, observer.OnError, ct)
+                .ConfigureAwait(false);
         });
 }

--- a/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttObservable.cs
@@ -1,6 +1,4 @@
-using MQTTnet;
 using MQTTnet.Client;
-using MQTTnet.Protocol;
 using R3;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -11,7 +9,6 @@ namespace Observables.Mqtt;
 /// <summary>Bridges MQTT client APIs to R3 <see cref="Observable{T}"/>.</summary>
 public static class MqttObservable
 {
-
     public static Observable<Unit> FromPublish(
         IMqttClient client,
         string topic,
@@ -26,12 +23,7 @@ public static class MqttObservable
         Observable.FromAsync(async ct =>
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var message = new MqttApplicationMessageBuilder()
-                .WithTopic(topic)
-                .WithPayload(payload ?? Array.Empty<byte>())
-                .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
-                .Build();
-            await client.PublishAsync(message, linked.Token).ConfigureAwait(false);
+            await MqttProtocol.PublishAsync(client, topic, payload, linked.Token).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -42,50 +34,8 @@ public static class MqttObservable
     public static Observable<T> FromSubscribe<T>(IMqttClient client, string topicFilter) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            async Task Handler(MqttApplicationMessageReceivedEventArgs e)
-            {
-                if (!MqttTopicMatcher.Matches(topicFilter, e.ApplicationMessage.Topic))
-                {
-                    return;
-                }
-
-                try
-                {
-                    var payload = e.ApplicationMessage.PayloadSegment.Count == 0
-                        ? Array.Empty<byte>()
-                        : e.ApplicationMessage.PayloadSegment.ToArray();
-                    observer.OnNext(MqttPayload.Deserialize<T>(payload));
-                }
-                catch (Exception ex)
-                {
-                    observer.OnErrorResume(ex);
-                }
-
-                await Task.CompletedTask.ConfigureAwait(false);
-            }
-
-            client.ApplicationMessageReceivedAsync += Handler;
-            try
-            {
-                await client
-                    .SubscribeAsync(
-                        new MqttTopicFilterBuilder().WithTopic(topicFilter).Build(),
-                        ct)
-                    .ConfigureAwait(false);
-
-                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                client.ApplicationMessageReceivedAsync -= Handler;
-                try
-                {
-                    await client.UnsubscribeAsync(topicFilter).ConfigureAwait(false);
-                }
-                catch (Exception)
-                {
-                    // best-effort if the client is already down
-                }
-            }
+            await MqttProtocol
+                .SubscribeAsync<T>(client, topicFilter, observer.OnNext, observer.OnErrorResume, ct)
+                .ConfigureAwait(false);
         });
 }

--- a/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
@@ -1,0 +1,93 @@
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace Observables.Mqtt;
+
+/// <summary>Feature protocol bridge for MQTT (subscribe / unsubscribe / publish / payload map).</summary>
+internal static class MqttProtocol
+{
+    internal static async Task PublishAsync(
+        IMqttClient client,
+        string topic,
+        byte[] payload,
+        CancellationToken cancellationToken)
+    {
+        var message = new MqttApplicationMessageBuilder()
+            .WithTopic(topic)
+            .WithPayload(payload ?? Array.Empty<byte>())
+            .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+            .Build();
+        await client.PublishAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+#endif
+    internal static T DeserializePayload<T>(MqttApplicationMessageReceivedEventArgs e)
+    {
+        var payload = e.ApplicationMessage.PayloadSegment.Count == 0
+            ? Array.Empty<byte>()
+            : e.ApplicationMessage.PayloadSegment.ToArray();
+        return MqttPayloadSerializers.Deserialize<T>(payload);
+    }
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON payload serialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [RequiresDynamicCode("JSON payload serialization uses System.Text.Json reflection.")]
+#endif
+    internal static async Task SubscribeAsync<T>(
+        IMqttClient client,
+        string topicFilter,
+        Action<T> onNext,
+        Action<Exception> onError,
+        CancellationToken cancellationToken)
+    {
+        async Task Handler(MqttApplicationMessageReceivedEventArgs e)
+        {
+            if (!MqttTopicMatcher.Matches(topicFilter, e.ApplicationMessage.Topic))
+            {
+                return;
+            }
+
+            try
+            {
+                onNext(DeserializePayload<T>(e));
+            }
+            catch (Exception ex)
+            {
+                onError(ex);
+            }
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        client.ApplicationMessageReceivedAsync += Handler;
+        try
+        {
+            await client
+                .SubscribeAsync(
+                    new MqttTopicFilterBuilder().WithTopic(topicFilter).Build(),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            client.ApplicationMessageReceivedAsync -= Handler;
+            try
+            {
+                await client.UnsubscribeAsync(topicFilter).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // best-effort if the client is already down
+            }
+        }
+    }
+}

--- a/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
@@ -6,8 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 
 namespace Observables.Mqtt;
-
-/// <summary>Feature protocol bridge for MQTT (subscribe / unsubscribe / publish / payload map).</summary>
 internal static class MqttProtocol
 {
     internal static async Task PublishAsync(

--- a/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
+++ b/Observables.Mqtt/Observables.Mqtt/MqttProtocol.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 
 namespace Observables.Mqtt;
+
 internal static class MqttProtocol
 {
     internal static async Task PublishAsync(


### PR DESCRIPTION
## Summary

Internal `MqttProtocol` owns publish/subscribe/unsubscribe/payload map. Keep R3 `FromPublish(byte[])` as the existing public-surface divergence.

## Related Issue

Closes #251

## Solution module

- [x] Mqtt

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] Mqtt.Tests 38, Reactive.Tests 4, R3 generator 7, Reactive generator 4 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
