### PR TITLE
Concentrate SSE subscribe pump on SseProtocol

### DIFF
--- a/Observables.Sse/Observables.Sse.Reactive/SystemReactiveSseAdapter.cs
+++ b/Observables.Sse/Observables.Sse.Reactive/SystemReactiveSseAdapter.cs
@@ -1,7 +1,5 @@
-using System.IO;
-using System.Net.Http;
-using System.Text;
 using System.Reactive.Linq;
+using Observables.Sse;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -24,35 +22,9 @@ public static class SystemReactiveSseAdapter
         {
             try
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, connection.Endpoint);
-                request.Headers.Accept.ParseAdd("text/event-stream");
-
-                using var response = await connection.HttpClient
-                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+                await SseProtocol
+                    .SubscribeAsync<T>(connection, eventName, observer.OnNext, observer.OnCompleted, ct)
                     .ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
-
-#if NET8_0_OR_GREATER
-                using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-#else
-                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#endif
-                using var reader = new StreamReader(stream, Encoding.UTF8);
-
-                while (!ct.IsCancellationRequested)
-                {
-                    var sseEvent = await SseProtocol.ReadEventAsync(reader).ConfigureAwait(false);
-                    if (sseEvent is null)
-                    {
-                        observer.OnCompleted();
-                        return;
-                    }
-
-                    if (sseEvent.Value.EventName == eventName)
-                    {
-                        observer.OnNext(SseProtocol.Deserialize<T>(sseEvent.Value.Data));
-                    }
-                }
             }
             catch (OperationCanceledException)
             {

--- a/Observables.Sse/Observables.Sse/Observables.Sse.csproj
+++ b/Observables.Sse/Observables.Sse/Observables.Sse.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Observables.Sse.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="R3" />
   </ItemGroup>
 

--- a/Observables.Sse/Observables.Sse/SseObservable.cs
+++ b/Observables.Sse/Observables.Sse/SseObservable.cs
@@ -1,6 +1,3 @@
-using System.IO;
-using System.Net.Http;
-using System.Text;
 using R3;
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -24,35 +21,9 @@ public static class SseObservable
         {
             try
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, connection.Endpoint);
-                request.Headers.Accept.ParseAdd("text/event-stream");
-
-                using var response = await connection.HttpClient
-                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+                await SseProtocol
+                    .SubscribeAsync<T>(connection, eventName, observer.OnNext, observer.OnCompleted, ct)
                     .ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
-
-#if NET8_0_OR_GREATER
-                using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-#else
-                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#endif
-                using var reader = new StreamReader(stream, Encoding.UTF8);
-
-                while (!ct.IsCancellationRequested)
-                {
-                    var sseEvent = await SseProtocol.ReadEventAsync(reader).ConfigureAwait(false);
-                    if (sseEvent is null)
-                    {
-                        observer.OnCompleted();
-                        return;
-                    }
-
-                    if (sseEvent.Value.EventName == eventName)
-                    {
-                        observer.OnNext(SseProtocol.Deserialize<T>(sseEvent.Value.Data));
-                    }
-                }
             }
             catch (OperationCanceledException)
             {

--- a/Observables.Sse/Observables.Sse/SseProtocol.cs
+++ b/Observables.Sse/Observables.Sse/SseProtocol.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net.Http;
 using System.Text;
 #if NETSTANDARD2_0
 #else
@@ -145,5 +146,47 @@ public static class SseProtocol
         }
 
         return new SseEvent(string.IsNullOrEmpty(eventName) ? "message" : eventName!, payload, id);
+    }
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
+#endif
+    internal static async Task SubscribeAsync<T>(
+        SseConnection connection,
+        string eventName,
+        Action<T> onNext,
+        Action onCompleted,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, connection.Endpoint);
+        request.Headers.Accept.ParseAdd("text/event-stream");
+
+        using var response = await connection.HttpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+#if NET8_0_OR_GREATER
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var sseEvent = await ReadEventAsync(reader).ConfigureAwait(false);
+            if (sseEvent is null)
+            {
+                onCompleted();
+                return;
+            }
+
+            if (sseEvent.Value.EventName == eventName)
+            {
+                onNext(Deserialize<T>(sseEvent.Value.Data));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

The SSE wire parser was already shared. Move the HTTP subscribe loop onto `SseProtocol` and add InternalsVisibleTo for Reactive.

## Related Issue

Closes #252

## Solution module

- [x] Sse (Observables.Sse)

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] Sse.Tests 3, Reactive.Tests 4, R3 generator 9, Reactive generator 5 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
