### PR TITLE
Concentrate SignalR invoke/send/stream/On behind thin adapters

### DIFF
--- a/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
+++ b/Observables.SignalR/Observables.SignalR.Reactive/SystemReactiveSignalRAdapter.cs
@@ -19,11 +19,7 @@ public static class SystemReactiveSignalRAdapter
         object?[] args,
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            return await HubConnectionArgs.InvokeAsync<T>(connection, methodName, args, linked.Token)
-                .ConfigureAwait(false);
-        });
+            await SignalRProtocol.InvokeAsync<T>(connection, methodName, args, cancellationToken, ct).ConfigureAwait(false));
 
     public static IObservable<System.Reactive.Unit> FromSend(
         HubConnection connection,
@@ -38,8 +34,7 @@ public static class SystemReactiveSignalRAdapter
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await HubConnectionArgs.SendAsync(connection, methodName, args, linked.Token).ConfigureAwait(false);
+            await SignalRProtocol.SendAsync(connection, methodName, args, cancellationToken, ct).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
@@ -56,17 +51,11 @@ public static class SystemReactiveSignalRAdapter
         CancellationToken cancellationToken = default) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
             try
             {
-                await foreach (var item in HubConnectionArgs
-                                   .StreamAsync<T>(connection, methodName, args, linked.Token)
-                                   .ConfigureAwait(false))
-                {
-                    observer.OnNext(item);
-                }
-
-                observer.OnCompleted();
+                await SignalRProtocol
+                    .StreamAsync<T>(connection, methodName, args, observer.OnNext, observer.OnCompleted, cancellationToken, ct)
+                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -80,7 +69,7 @@ public static class SystemReactiveSignalRAdapter
     public static IObservable<T> FromOn<T>(HubConnection connection, string methodName) =>
         Observable.Create<T>(observer =>
         {
-            var subscription = connection.On<T>(methodName, observer.OnNext);
+            var subscription = SignalRProtocol.SubscribeOn<T>(connection, methodName, observer.OnNext);
             return System.Reactive.Disposables.Disposable.Create(subscription.Dispose);
         });
 }

--- a/Observables.SignalR/Observables.SignalR/Observables.SignalR.csproj
+++ b/Observables.SignalR/Observables.SignalR/Observables.SignalR.csproj
@@ -8,6 +8,10 @@
 
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Observables.SignalR.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="R3" />
   </ItemGroup>

--- a/Observables.SignalR/Observables.SignalR/SignalRObservable.cs
+++ b/Observables.SignalR/Observables.SignalR/SignalRObservable.cs
@@ -18,12 +18,7 @@ public static class SignalRObservable
         object?[] args,
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            return await HubConnectionArgs
-                .InvokeAsync<T>(connection, methodName, args, linked.Token)
-                .ConfigureAwait(false);
-        });
+            await SignalRProtocol.InvokeAsync<T>(connection, methodName, args, cancellationToken, ct).ConfigureAwait(false));
 
     public static Observable<Unit> FromSend(
         HubConnection connection,
@@ -38,8 +33,7 @@ public static class SignalRObservable
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await HubConnectionArgs.SendAsync(connection, methodName, args, linked.Token).ConfigureAwait(false);
+            await SignalRProtocol.SendAsync(connection, methodName, args, cancellationToken, ct).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -56,28 +50,15 @@ public static class SignalRObservable
         CancellationToken cancellationToken = default) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await foreach (var item in HubConnectionArgs
-                               .StreamAsync<T>(connection, methodName, args, linked.Token)
-                               .ConfigureAwait(false))
-            {
-                observer.OnNext(item);
-            }
-
-            observer.OnCompleted();
+            await SignalRProtocol
+                .StreamAsync<T>(connection, methodName, args, observer.OnNext, observer.OnCompleted, cancellationToken, ct)
+                .ConfigureAwait(false);
         });
 
     public static Observable<T> FromOn<T>(HubConnection connection, string methodName) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            var subscription = connection.On<T>(methodName, observer.OnNext);
-            try
-            {
-                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                subscription.Dispose();
-            }
+            using var subscription = SignalRProtocol.SubscribeOn<T>(connection, methodName, observer.OnNext);
+            await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
         });
 }

--- a/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
+++ b/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace Observables.SignalR;
+
 internal static class SignalRProtocol
 {
     internal static async Task<T> InvokeAsync<T>(

--- a/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
+++ b/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Observables.SignalR;
+
+/// <summary>Feature protocol bridge for SignalR (invoke / send / stream / On).</summary>
+internal static class SignalRProtocol
+{
+    internal static async Task<T> InvokeAsync<T>(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        return await HubConnectionArgs.InvokeAsync<T>(connection, methodName, args, linked.Token).ConfigureAwait(false);
+    }
+
+    internal static async Task SendAsync(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await HubConnectionArgs.SendAsync(connection, methodName, args, linked.Token).ConfigureAwait(false);
+    }
+
+    internal static async Task StreamAsync<T>(
+        HubConnection connection,
+        string methodName,
+        object?[] args,
+        Action<T> onNext,
+        Action onCompleted,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await foreach (var item in HubConnectionArgs
+                           .StreamAsync<T>(connection, methodName, args, linked.Token)
+                           .ConfigureAwait(false))
+        {
+            onNext(item);
+        }
+
+        onCompleted();
+    }
+
+    internal static IDisposable SubscribeOn<T>(HubConnection connection, string methodName, Action<T> onNext) =>
+        connection.On<T>(methodName, onNext);
+}

--- a/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
+++ b/Observables.SignalR/Observables.SignalR/SignalRProtocol.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace Observables.SignalR;
-
-/// <summary>Feature protocol bridge for SignalR (invoke / send / stream / On).</summary>
 internal static class SignalRProtocol
 {
     internal static async Task<T> InvokeAsync<T>(


### PR DESCRIPTION
## Summary

`HubConnectionArgs` already shared overloads. Move linked-CTS invoke/send, stream enumeration, and On subscription into `SignalRProtocol`. R3 `FromStream` still has no OnErrorResume.

## Related Issue

Closes #253

## Solution module

- [x] SignalR

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] SignalR.Tests 5, Reactive.Tests 6, R3 generator 10, Reactive generator 5 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
