### PR TITLE
Concentrate WebSocket connect/send/receive behind thin adapters

### DIFF
--- a/Observables.WebSocket/Observables.WebSocket.Reactive/SystemReactiveWebSocketAdapter.cs
+++ b/Observables.WebSocket/Observables.WebSocket.Reactive/SystemReactiveWebSocketAdapter.cs
@@ -1,14 +1,8 @@
-using System;
-using System.IO;
 using System.Net.WebSockets;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-#if NETSTANDARD2_0
-#else
+using Observables.WebSocket;
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 #endif
 
 namespace Observables.WebSocket.Reactive;
@@ -16,31 +10,22 @@ namespace Observables.WebSocket.Reactive;
 /// <summary>Bridges <see cref="ClientWebSocket"/> APIs to <see cref="IObservable{T}"/>.</summary>
 public static class SystemReactiveWebSocketAdapter
 {
-#if NETSTANDARD2_0
-#else
-    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-#endif
-
     public static IObservable<System.Reactive.Unit> FromConnect(
         ClientWebSocket socket,
         Uri uri,
         CancellationToken cancellationToken = default) =>
-        System.Reactive.Linq.Observable.FromAsync(async ct =>
+        Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
+            await WebSocketProtocol.ConnectAsync(socket, uri, cancellationToken, ct).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
     public static IObservable<System.Reactive.Unit> FromClose(
         ClientWebSocket socket,
         CancellationToken cancellationToken = default) =>
-        System.Reactive.Linq.Observable.FromAsync(async ct =>
+        Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket
-                .CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", linked.Token)
-                .ConfigureAwait(false);
+            await WebSocketProtocol.CloseAsync(socket, cancellationToken, ct).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
@@ -48,15 +33,10 @@ public static class SystemReactiveWebSocketAdapter
         ClientWebSocket socket,
         byte[] payload,
         CancellationToken cancellationToken = default) =>
-        System.Reactive.Linq.Observable.FromAsync(async ct =>
+        Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket
-                .SendAsync(
-                    new ArraySegment<byte>(payload),
-                    WebSocketMessageType.Binary,
-                    true,
-                    linked.Token)
+            await WebSocketProtocol
+                .SendAsync(socket, payload, WebSocketMessageType.Binary, cancellationToken, ct)
                 .ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
@@ -65,17 +45,9 @@ public static class SystemReactiveWebSocketAdapter
         ClientWebSocket socket,
         string text,
         CancellationToken cancellationToken = default) =>
-        System.Reactive.Linq.Observable.FromAsync(async ct =>
+        Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var payload = Encoding.UTF8.GetBytes(text);
-            await socket
-                .SendAsync(
-                    new ArraySegment<byte>(payload),
-                    WebSocketMessageType.Text,
-                    true,
-                    linked.Token)
-                .ConfigureAwait(false);
+            await WebSocketProtocol.SendTextAsync(socket, text, cancellationToken, ct).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
 
@@ -84,36 +56,20 @@ public static class SystemReactiveWebSocketAdapter
     [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
 #endif
     public static IObservable<T> FromReceive<T>(ClientWebSocket socket) =>
-        System.Reactive.Linq.Observable.Create<T>(async (observer, ct) =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            var buffer = new byte[4096];
             try
             {
                 while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
                 {
-                    // Assemble potentially fragmented message
-                    using var ms = new MemoryStream();
-                    WebSocketMessageType messageType = WebSocketMessageType.Binary;
-                    WebSocketReceiveResult result;
-                    do
+                    var message = await WebSocketProtocol.ReceiveMessageAsync(socket, ct).ConfigureAwait(false);
+                    if (message is null)
                     {
-                        result = await socket
-                            .ReceiveAsync(new ArraySegment<byte>(buffer), ct)
-                            .ConfigureAwait(false);
-
-                        if (result.MessageType == WebSocketMessageType.Close)
-                        {
-                            observer.OnCompleted();
-                            return;
-                        }
-
-                        messageType = result.MessageType;
-                        ms.Write(buffer, 0, result.Count);
+                        observer.OnCompleted();
+                        return;
                     }
-                    while (!result.EndOfMessage);
 
-                    var payload = ms.ToArray();
-                    observer.OnNext(DeserializePayload<T>(payload, messageType));
+                    observer.OnNext(WebSocketProtocol.DeserializePayload<T>(message.Value.Payload, message.Value.MessageType));
                 }
             }
             catch (OperationCanceledException)
@@ -124,35 +80,4 @@ public static class SystemReactiveWebSocketAdapter
                 observer.OnError(ex);
             }
         });
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
-#endif
-    static T DeserializePayload<T>(byte[] payload, WebSocketMessageType messageType)
-    {
-        if (typeof(T) == typeof(byte[]))
-        {
-            return (T)(object)payload;
-        }
-
-        if (typeof(T) == typeof(string))
-        {
-            return (T)(object)Encoding.UTF8.GetString(payload);
-        }
-
-#if NETSTANDARD2_0
-        throw new NotSupportedException(
-            "Deserializing WebSocket payloads to types other than byte[] or string requires net8.0 or later.");
-#else
-        var json = Encoding.UTF8.GetString(payload);
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        if (value is null)
-        {
-            throw new InvalidOperationException("WebSocket payload deserialized to null.");
-        }
-
-        return value;
-#endif
-    }
 }

--- a/Observables.WebSocket/Observables.WebSocket/Observables.WebSocket.csproj
+++ b/Observables.WebSocket/Observables.WebSocket/Observables.WebSocket.csproj
@@ -8,6 +8,10 @@
 
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Observables.WebSocket.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="R3" />
   </ItemGroup>
 

--- a/Observables.WebSocket/Observables.WebSocket/WebSocketObservable.cs
+++ b/Observables.WebSocket/Observables.WebSocket/WebSocketObservable.cs
@@ -1,10 +1,8 @@
 using System.Net.WebSockets;
 using System.Text;
 using R3;
-#if NETSTANDARD2_0
-#else
+#if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 #endif
 
 namespace Observables.WebSocket;
@@ -12,19 +10,13 @@ namespace Observables.WebSocket;
 /// <summary>Bridges <see cref="ClientWebSocket"/> APIs to R3 <see cref="Observable{T}"/>.</summary>
 public static class WebSocketObservable
 {
-#if NETSTANDARD2_0
-#else
-    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
-#endif
-
     public static Observable<Unit> FromConnect(
         ClientWebSocket socket,
         Uri uri,
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
+            await WebSocketProtocol.ConnectAsync(socket, uri, cancellationToken, ct).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -33,10 +25,7 @@ public static class WebSocketObservable
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket
-                .CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", linked.Token)
-                .ConfigureAwait(false);
+            await WebSocketProtocol.CloseAsync(socket, cancellationToken, ct).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -46,13 +35,8 @@ public static class WebSocketObservable
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await socket
-                .SendAsync(
-                    new ArraySegment<byte>(payload),
-                    WebSocketMessageType.Binary,
-                    true,
-                    linked.Token)
+            await WebSocketProtocol
+                .SendAsync(socket, payload, WebSocketMessageType.Binary, cancellationToken, ct)
                 .ConfigureAwait(false);
             return Unit.Default;
         });
@@ -63,15 +47,7 @@ public static class WebSocketObservable
         CancellationToken cancellationToken = default) =>
         Observable.FromAsync(async ct =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var payload = Encoding.UTF8.GetBytes(text);
-            await socket
-                .SendAsync(
-                    new ArraySegment<byte>(payload),
-                    WebSocketMessageType.Text,
-                    true,
-                    linked.Token)
-                .ConfigureAwait(false);
+            await WebSocketProtocol.SendTextAsync(socket, text, cancellationToken, ct).ConfigureAwait(false);
             return Unit.Default;
         });
 
@@ -82,34 +58,18 @@ public static class WebSocketObservable
     public static Observable<T> FromReceive<T>(ClientWebSocket socket) =>
         Observable.Create<T>(async (observer, ct) =>
         {
-            var buffer = new byte[4096];
             while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
             {
                 try
                 {
-                    // Assemble potentially fragmented message
-                    using var ms = new System.IO.MemoryStream();
-                    WebSocketMessageType messageType = WebSocketMessageType.Binary;
-                    WebSocketReceiveResult result;
-                    do
+                    var message = await WebSocketProtocol.ReceiveMessageAsync(socket, ct).ConfigureAwait(false);
+                    if (message is null)
                     {
-                        result = await socket
-                            .ReceiveAsync(new ArraySegment<byte>(buffer), ct)
-                            .ConfigureAwait(false);
-
-                        if (result.MessageType == WebSocketMessageType.Close)
-                        {
-                            observer.OnCompleted();
-                            return;
-                        }
-
-                        messageType = result.MessageType;
-                        ms.Write(buffer, 0, result.Count);
+                        observer.OnCompleted();
+                        return;
                     }
-                    while (!result.EndOfMessage);
 
-                    var payload = ms.ToArray();
-                    observer.OnNext(DeserializePayload<T>(payload, messageType));
+                    observer.OnNext(WebSocketProtocol.DeserializePayload<T>(message.Value.Payload, message.Value.MessageType));
                 }
                 catch (OperationCanceledException)
                 {
@@ -121,35 +81,4 @@ public static class WebSocketObservable
                 }
             }
         });
-
-#if NET8_0_OR_GREATER
-    [RequiresUnreferencedCode("JSON payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
-    [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
-#endif
-    internal static T DeserializePayload<T>(byte[] payload, WebSocketMessageType messageType)
-    {
-        if (typeof(T) == typeof(byte[]))
-        {
-            return (T)(object)payload;
-        }
-
-        if (typeof(T) == typeof(string))
-        {
-            return (T)(object)Encoding.UTF8.GetString(payload);
-        }
-
-#if NETSTANDARD2_0
-        throw new NotSupportedException(
-            "Deserializing WebSocket payloads to types other than byte[] or string requires net8.0 or later.");
-#else
-        var json = Encoding.UTF8.GetString(payload);
-        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
-        if (value is null)
-        {
-            throw new InvalidOperationException("WebSocket payload deserialized to null.");
-        }
-
-        return value;
-#endif
-    }
 }

--- a/Observables.WebSocket/Observables.WebSocket/WebSocketProtocol.cs
+++ b/Observables.WebSocket/Observables.WebSocket/WebSocketProtocol.cs
@@ -20,8 +20,6 @@ internal readonly struct WebSocketReceivedMessage
     internal byte[] Payload { get; }
     internal WebSocketMessageType MessageType { get; }
 }
-
-/// <summary>Feature protocol bridge for WebSocket (connect / close / send / receive / payload map).</summary>
 internal static class WebSocketProtocol
 {
 #if NETSTANDARD2_0
@@ -69,8 +67,6 @@ internal static class WebSocketProtocol
         CancellationToken userToken,
         CancellationToken pumpToken) =>
         SendAsync(socket, Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, userToken, pumpToken);
-
-    /// <summary>Reads one assembled message, or <see langword="null"/> on close.</summary>
     internal static async Task<WebSocketReceivedMessage?> ReceiveMessageAsync(
         ClientWebSocket socket,
         CancellationToken cancellationToken)

--- a/Observables.WebSocket/Observables.WebSocket/WebSocketProtocol.cs
+++ b/Observables.WebSocket/Observables.WebSocket/WebSocketProtocol.cs
@@ -1,0 +1,131 @@
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+#if NETSTANDARD2_0
+#else
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+#endif
+
+namespace Observables.WebSocket;
+
+internal readonly struct WebSocketReceivedMessage
+{
+    internal WebSocketReceivedMessage(byte[] payload, WebSocketMessageType messageType)
+    {
+        Payload = payload;
+        MessageType = messageType;
+    }
+
+    internal byte[] Payload { get; }
+    internal WebSocketMessageType MessageType { get; }
+}
+
+/// <summary>Feature protocol bridge for WebSocket (connect / close / send / receive / payload map).</summary>
+internal static class WebSocketProtocol
+{
+#if NETSTANDARD2_0
+#else
+    static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+#endif
+
+    internal static async Task ConnectAsync(
+        ClientWebSocket socket,
+        Uri uri,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await socket.ConnectAsync(uri, linked.Token).ConfigureAwait(false);
+    }
+
+    internal static async Task CloseAsync(
+        ClientWebSocket socket,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await socket
+            .CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", linked.Token)
+            .ConfigureAwait(false);
+    }
+
+    internal static async Task SendAsync(
+        ClientWebSocket socket,
+        byte[] payload,
+        WebSocketMessageType messageType,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await socket
+            .SendAsync(new ArraySegment<byte>(payload), messageType, true, linked.Token)
+            .ConfigureAwait(false);
+    }
+
+    internal static Task SendTextAsync(
+        ClientWebSocket socket,
+        string text,
+        CancellationToken userToken,
+        CancellationToken pumpToken) =>
+        SendAsync(socket, Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, userToken, pumpToken);
+
+    /// <summary>Reads one assembled message, or <see langword="null"/> on close.</summary>
+    internal static async Task<WebSocketReceivedMessage?> ReceiveMessageAsync(
+        ClientWebSocket socket,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[4096];
+        using var ms = new MemoryStream();
+        WebSocketMessageType messageType = WebSocketMessageType.Binary;
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket
+                .ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            messageType = result.MessageType;
+            ms.Write(buffer, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+
+        return new WebSocketReceivedMessage(ms.ToArray(), messageType);
+    }
+
+#if NET8_0_OR_GREATER
+    [RequiresUnreferencedCode("JSON payload deserialization uses System.Text.Json reflection. Preserve payload type members when trimming.")]
+    [RequiresDynamicCode("JSON payload deserialization uses System.Text.Json reflection.")]
+#endif
+    internal static T DeserializePayload<T>(byte[] payload, WebSocketMessageType messageType)
+    {
+        if (typeof(T) == typeof(byte[]))
+        {
+            return (T)(object)payload;
+        }
+
+        if (typeof(T) == typeof(string))
+        {
+            return (T)(object)Encoding.UTF8.GetString(payload);
+        }
+
+#if NETSTANDARD2_0
+        throw new NotSupportedException(
+            "Deserializing WebSocket payloads to types other than byte[] or string requires net8.0 or later.");
+#else
+        var json = Encoding.UTF8.GetString(payload);
+        var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+        if (value is null)
+        {
+            throw new InvalidOperationException("WebSocket payload deserialized to null.");
+        }
+
+        return value;
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

Internal `WebSocketProtocol` owns connect/close/send/one-message receive/deserialize. R3 `FromReceive` still resumes per message; Reactive still stops the loop on error.

## Related Issue

Closes #255

## Solution module

- [x] WebSocket

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] WebSocket.Tests 4, Reactive.Tests 5, R3 generator 13, Reactive generator 10 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
