### PR TITLE
Concentrate gRPC unary and server-stream pumps behind thin adapters

### DIFF
--- a/Observables.Grpc/Observables.Grpc.Reactive/SystemReactiveGrpcAdapter.cs
+++ b/Observables.Grpc/Observables.Grpc.Reactive/SystemReactiveGrpcAdapter.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using Grpc.Core;
+using Observables.Grpc;
 
 namespace Observables.Grpc.Reactive;
 
@@ -14,15 +15,7 @@ public static class SystemReactiveGrpcAdapter
         where TRequest : class
         where TResponse : class =>
         Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var call = invoker.AsyncUnaryCall(
-                method,
-                host: null,
-                options: new CallOptions(cancellationToken: linked.Token),
-                request);
-            return await call.ResponseAsync.ConfigureAwait(false);
-        });
+            await GrpcProtocol.UnaryAsync(invoker, method, request, cancellationToken, ct).ConfigureAwait(false));
 
     public static IObservable<TResponse> FromServerStreaming<TRequest, TResponse>(
         CallInvoker invoker,
@@ -33,21 +26,11 @@ public static class SystemReactiveGrpcAdapter
         where TResponse : class =>
         Observable.Create<TResponse>(async (observer, ct) =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
             try
             {
-                using var call = invoker.AsyncServerStreamingCall(
-                    method,
-                    host: null,
-                    options: new CallOptions(cancellationToken: linked.Token),
-                    request);
-
-                while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
-                {
-                    observer.OnNext(call.ResponseStream.Current);
-                }
-
-                observer.OnCompleted();
+                await GrpcProtocol
+                    .ReadServerStreamAsync(invoker, method, request, observer.OnNext, observer.OnCompleted, cancellationToken, ct)
+                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/Observables.Grpc/Observables.Grpc/GrpcObservable.cs
+++ b/Observables.Grpc/Observables.Grpc/GrpcObservable.cs
@@ -14,15 +14,7 @@ public static class GrpcObservable
         where TRequest : class
         where TResponse : class =>
         Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var call = invoker.AsyncUnaryCall(
-                method,
-                host: null,
-                options: new CallOptions(cancellationToken: linked.Token),
-                request);
-            return await call.ResponseAsync.ConfigureAwait(false);
-        });
+            await GrpcProtocol.UnaryAsync(invoker, method, request, cancellationToken, ct).ConfigureAwait(false));
 
     public static Observable<TResponse> FromServerStreaming<TRequest, TResponse>(
         CallInvoker invoker,
@@ -33,21 +25,11 @@ public static class GrpcObservable
         where TResponse : class =>
         Observable.Create<TResponse>(async (observer, ct) =>
         {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
             try
             {
-                using var call = invoker.AsyncServerStreamingCall(
-                    method,
-                    host: null,
-                    options: new CallOptions(cancellationToken: linked.Token),
-                    request);
-
-                while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
-                {
-                    observer.OnNext(call.ResponseStream.Current);
-                }
-
-                observer.OnCompleted();
+                await GrpcProtocol
+                    .ReadServerStreamAsync(invoker, method, request, observer.OnNext, observer.OnCompleted, cancellationToken, ct)
+                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -77,7 +59,7 @@ public static class GrpcObservable
             var writeCompleted = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             using var subscription = requests.Subscribe(
-                (Action<TRequest>)(item => _ = WriteRequestAsync(call.RequestStream, item, linked.Token)),
+                (Action<TRequest>)(item => _ = GrpcProtocol.WriteRequestAsync(call.RequestStream, item, linked.Token)),
                 (Action<Exception>)(ex => writeCompleted.TrySetException(ex)),
                 (Action<Result>)(_ => writeCompleted.TrySetResult(true)));
 
@@ -104,7 +86,7 @@ public static class GrpcObservable
             var writeCompleted = new TaskCompletionSource<bool>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             using var subscription = requests.Subscribe(
-                (Action<TRequest>)(item => _ = WriteRequestAsync(call.RequestStream, item, linked.Token)),
+                (Action<TRequest>)(item => _ = GrpcProtocol.WriteRequestAsync(call.RequestStream, item, linked.Token)),
                 (Action<Exception>)(ex => writeCompleted.TrySetException(ex)),
                 (Action<Result>)(_ => writeCompleted.TrySetResult(true)));
 
@@ -129,16 +111,4 @@ public static class GrpcObservable
                 observer.OnErrorResume(ex);
             }
         });
-
-    static async Task WriteRequestAsync<TRequest>(
-        IClientStreamWriter<TRequest> stream,
-        TRequest item,
-        CancellationToken cancellationToken)
-    {
-#if NETSTANDARD2_0
-        await stream.WriteAsync(item).ConfigureAwait(false);
-#else
-        await stream.WriteAsync(item, cancellationToken).ConfigureAwait(false);
-#endif
-    }
 }

--- a/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
+++ b/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
@@ -1,6 +1,7 @@
 using Grpc.Core;
 
 namespace Observables.Grpc;
+
 internal static class GrpcProtocol
 {
     internal static async Task<TResponse> UnaryAsync<TRequest, TResponse>(

--- a/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
+++ b/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
@@ -1,8 +1,6 @@
 using Grpc.Core;
 
 namespace Observables.Grpc;
-
-/// <summary>Feature protocol bridge for gRPC (unary / server stream / request write).</summary>
 internal static class GrpcProtocol
 {
     internal static async Task<TResponse> UnaryAsync<TRequest, TResponse>(

--- a/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
+++ b/Observables.Grpc/Observables.Grpc/GrpcProtocol.cs
@@ -1,0 +1,63 @@
+using Grpc.Core;
+
+namespace Observables.Grpc;
+
+/// <summary>Feature protocol bridge for gRPC (unary / server stream / request write).</summary>
+internal static class GrpcProtocol
+{
+    internal static async Task<TResponse> UnaryAsync<TRequest, TResponse>(
+        CallInvoker invoker,
+        Method<TRequest, TResponse> method,
+        TRequest request,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+        where TRequest : class
+        where TResponse : class
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        var call = invoker.AsyncUnaryCall(
+            method,
+            host: null,
+            options: new CallOptions(cancellationToken: linked.Token),
+            request);
+        return await call.ResponseAsync.ConfigureAwait(false);
+    }
+
+    internal static async Task ReadServerStreamAsync<TRequest, TResponse>(
+        CallInvoker invoker,
+        Method<TRequest, TResponse> method,
+        TRequest request,
+        Action<TResponse> onNext,
+        Action onCompleted,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+        where TRequest : class
+        where TResponse : class
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        using var call = invoker.AsyncServerStreamingCall(
+            method,
+            host: null,
+            options: new CallOptions(cancellationToken: linked.Token),
+            request);
+
+        while (await call.ResponseStream.MoveNext(linked.Token).ConfigureAwait(false))
+        {
+            onNext(call.ResponseStream.Current);
+        }
+
+        onCompleted();
+    }
+
+    internal static async Task WriteRequestAsync<TRequest>(
+        IClientStreamWriter<TRequest> stream,
+        TRequest item,
+        CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0
+        await stream.WriteAsync(item).ConfigureAwait(false);
+#else
+        await stream.WriteAsync(item, cancellationToken).ConfigureAwait(false);
+#endif
+    }
+}


### PR DESCRIPTION
## Summary

Internal `GrpcProtocol` owns unary, server-stream read loop, and WriteRequestAsync. Client/duplex stay in adapters (Observable vs IObservable and write/read ordering).

## Related Issue

Closes #256

## Solution module

- [x] Grpc

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] Grpc.Tests 2, Reactive.Tests 5, R3 generator 6, Reactive generator 4 (net8)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
