### PR TITLE
Concentrate Postgres LISTEN/NOTIFY behind thin adapters

### DIFF
--- a/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
+++ b/Observables.Postgres/Observables.Postgres.Reactive/SystemReactivePostgresAdapter.cs
@@ -1,80 +1,32 @@
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
-using System.Text.RegularExpressions;
 using Npgsql;
+using Observables.Postgres;
 
 namespace Observables.Postgres.Reactive;
 
 /// <summary>Bridges Npgsql LISTEN/NOTIFY to <see cref="IObservable{T}"/>.</summary>
 public static class SystemReactivePostgresAdapter
 {
-    static readonly Regex ChannelNameRegex = new(
-        @"^[A-Za-z_][A-Za-z0-9_]*$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
-    static readonly TimeSpan ListenWaitSlice = TimeSpan.FromMilliseconds(250);
-
     /// <summary>
     /// Hot stream: <c>LISTEN</c> on <paramref name="channel"/> and emit notification payloads until disposed.
     /// Runs a WaitAsync loop on <paramref name="connection"/> for the
     /// subscription lifetime. Use a dedicated non-pooled connection; do not share it with concurrent commands.
     /// </summary>
-    public static IObservable<string> FromListen(NpgsqlConnection connection, string channel)
-    {
-        if (connection is null)
+    public static IObservable<string> FromListen(NpgsqlConnection connection, string channel) =>
+        Observable.Create<string>(async (observer, ct) =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.Create<string>(async (observer, ct) =>
-        {
-            void Handler(object sender, NpgsqlNotificationEventArgs args)
-            {
-                if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                {
-                    observer.OnNext(args.Payload ?? string.Empty);
-                }
-            }
-
-            connection.Notification += Handler;
-            Exception? error = null;
-            try
-            {
-                await using (var listen = new NpgsqlCommand(
-                    "LISTEN " + QuoteIdent(channel) + ";",
-                    connection))
-                {
-                    await listen.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                }
-
-                await WaitForNotificationsAsync(connection, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception ex)
-            {
-                error = ex;
-            }
-            finally
-            {
-                connection.Notification -= Handler;
-                await UnlistenBestEffortAsync(connection, channel).ConfigureAwait(false);
-            }
-
-            if (error is not null)
-            {
-                observer.OnError(error);
-            }
-            else if (!ct.IsCancellationRequested)
-            {
-                observer.OnCompleted();
-            }
+            await PostgresProtocol
+                .ListenAsync(
+                    connection,
+                    channel,
+                    observer.OnNext,
+                    observer.OnCompleted,
+                    observer.OnError,
+                    completeOnCancel: false,
+                    ct)
+                .ConfigureAwait(false);
         });
-    }
 
     /// <summary>
     /// Hot stream: <c>LISTEN</c> on <paramref name="channel"/> and deserialize notification payloads to
@@ -82,86 +34,30 @@ public static class SystemReactivePostgresAdapter
     /// </summary>
     [RequiresUnreferencedCode(PostgresTrimAnnotations.JsonPayload)]
     [RequiresDynamicCode(PostgresTrimAnnotations.JsonPayload)]
-    public static IObservable<T> FromListen<T>(NpgsqlConnection connection, string channel)
-    {
-        if (connection is null)
+    public static IObservable<T> FromListen<T>(NpgsqlConnection connection, string channel) =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.Create<T>(async (observer, ct) =>
-        {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            var hasError = false;
-            Exception? error = null;
-
-            void Handler(object sender, NpgsqlNotificationEventArgs args)
-            {
-                if (!string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                {
-                    return;
-                }
-
-                try
-                {
-                    observer.OnNext(PostgresPayload.Deserialize<T>(args.Payload));
-                }
-                catch (Exception ex)
-                {
-                    hasError = true;
-                    observer.OnError(ex);
-                    try
+            await PostgresProtocol
+                .ListenAsync(
+                    connection,
+                    channel,
+                    payload =>
                     {
-                        cts.Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                    }
-                }
-            }
-
-            connection.Notification += Handler;
-            try
-            {
-                await using (var listen = new NpgsqlCommand(
-                    "LISTEN " + QuoteIdent(channel) + ";",
-                    connection))
-                {
-                    await listen.ExecuteNonQueryAsync(cts.Token).ConfigureAwait(false);
-                }
-
-                await WaitForNotificationsAsync(connection, cts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception ex)
-            {
-                error = ex;
-            }
-            finally
-            {
-                connection.Notification -= Handler;
-                await UnlistenBestEffortAsync(connection, channel).ConfigureAwait(false);
-            }
-
-            if (hasError)
-            {
-                return;
-            }
-
-            if (error is not null)
-            {
-                observer.OnError(error);
-            }
-            else if (!ct.IsCancellationRequested)
-            {
-                observer.OnCompleted();
-            }
+                        try
+                        {
+                            observer.OnNext(PostgresPayload.Deserialize<T>(payload));
+                        }
+                        catch (Exception ex)
+                        {
+                            observer.OnError(ex);
+                        }
+                    },
+                    observer.OnCompleted,
+                    observer.OnError,
+                    completeOnCancel: false,
+                    ct)
+                .ConfigureAwait(false);
         });
-    }
 
     /// <summary>Cold stream: send <c>NOTIFY</c> with an empty payload when subscribed.</summary>
     public static IObservable<System.Reactive.Unit> FromNotify(
@@ -175,32 +71,12 @@ public static class SystemReactivePostgresAdapter
         NpgsqlConnection connection,
         string channel,
         string? payload,
-        CancellationToken cancellationToken = default)
-    {
-        if (connection is null)
+        CancellationToken cancellationToken = default) =>
+        Observable.FromAsync(async ct =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await using var command = new NpgsqlCommand(
-                "SELECT pg_notify(@channel, @payload);",
-                connection)
-            {
-                Parameters =
-                {
-                    new("channel", channel),
-                    new("payload", payload ?? string.Empty),
-                },
-            };
-            await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
+            await PostgresProtocol.NotifyAsync(connection, channel, payload, cancellationToken, ct).ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
-    }
 
     /// <summary>Cold stream: serialize <paramref name="payload"/> and send <c>NOTIFY</c> when subscribed.</summary>
     [RequiresUnreferencedCode(PostgresTrimAnnotations.JsonPayload)]
@@ -209,85 +85,12 @@ public static class SystemReactivePostgresAdapter
         NpgsqlConnection connection,
         string channel,
         T payload,
-        CancellationToken cancellationToken = default)
-    {
-        if (connection is null)
+        CancellationToken cancellationToken = default) =>
+        Observable.FromAsync(async ct =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var text = PostgresPayload.SerializeToText(payload);
-            await using var command = new NpgsqlCommand(
-                "SELECT pg_notify(@channel, @payload);",
-                connection)
-            {
-                Parameters =
-                {
-                    new("channel", channel),
-                    new("payload", text),
-                },
-            };
-            await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
+            await PostgresProtocol
+                .NotifySerializedAsync(connection, channel, payload, cancellationToken, ct)
+                .ConfigureAwait(false);
             return System.Reactive.Unit.Default;
         });
-    }
-
-    static async Task WaitForNotificationsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            await connection.WaitAsync(ListenWaitSlice, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    static async Task UnlistenBestEffortAsync(NpgsqlConnection connection, string channel)
-    {
-        for (var attempt = 0; attempt < 20; attempt++)
-        {
-            try
-            {
-                if ((connection.State & ConnectionState.Open) == 0)
-                {
-                    return;
-                }
-
-                await using var unlisten = new NpgsqlCommand(
-                    "UNLISTEN " + QuoteIdent(channel) + ";",
-                    connection);
-                await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                return;
-            }
-            catch (NpgsqlOperationInProgressException)
-            {
-                await Task.Delay(25, CancellationToken.None).ConfigureAwait(false);
-            }
-            catch
-            {
-                return;
-            }
-        }
-    }
-
-    static void ValidateChannelName(string channel)
-    {
-        if (string.IsNullOrWhiteSpace(channel))
-        {
-            throw new ArgumentException("PostgreSQL channel name must be non-empty.", nameof(channel));
-        }
-
-        if (channel.Length > 63 || !ChannelNameRegex.IsMatch(channel))
-        {
-            throw new ArgumentException(
-                "PostgreSQL channel name must be at most 63 characters and match [A-Za-z_][A-Za-z0-9_]*.",
-                nameof(channel));
-        }
-    }
-
-    static string QuoteIdent(string channel) =>
-        "\"" + channel.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
 }

--- a/Observables.Postgres/Observables.Postgres/PostgresObservable.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresObservable.cs
@@ -1,6 +1,4 @@
-using System.Data;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Npgsql;
 using R3;
 
@@ -9,79 +7,25 @@ namespace Observables.Postgres;
 /// <summary>Bridges Npgsql LISTEN/NOTIFY to R3 <see cref="Observable{T}"/>.</summary>
 public static class PostgresObservable
 {
-    static readonly Regex ChannelNameRegex = new(
-        @"^[A-Za-z_][A-Za-z0-9_]*$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
     /// <summary>
     /// Hot stream: <c>LISTEN</c> on <paramref name="channel"/> and emit notification payloads until disposed.
     /// Runs a WaitAsync loop on <paramref name="connection"/> for the
     /// subscription lifetime. Use a dedicated non-pooled connection; do not share it with concurrent commands.
     /// </summary>
-    public static Observable<string> FromListen(NpgsqlConnection connection, string channel)
-    {
-        if (connection is null)
+    public static Observable<string> FromListen(NpgsqlConnection connection, string channel) =>
+        Observable.Create<string>(async (observer, ct) =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.Create<string>(async (observer, ct) =>
-        {
-            void Handler(object sender, NpgsqlNotificationEventArgs args)
-            {
-                if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                {
-                    observer.OnNext(args.Payload ?? string.Empty);
-                }
-            }
-
-            connection.Notification += Handler;
-            try
-            {
-                await using (var listen = new NpgsqlCommand(
-                    "LISTEN " + QuoteIdent(channel) + ";",
-                    connection))
-                {
-                    await listen.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                }
-
-                while (!ct.IsCancellationRequested)
-                {
-                    await connection.WaitAsync(ct).ConfigureAwait(false);
-                }
-
-                observer.OnCompleted();
-            }
-            catch (OperationCanceledException)
-            {
-                observer.OnCompleted();
-            }
-            catch (Exception ex)
-            {
-                observer.OnErrorResume(ex);
-            }
-            finally
-            {
-                connection.Notification -= Handler;
-                try
-                {
-                    if (connection.State == ConnectionState.Open)
-                    {
-                        await using var unlisten = new NpgsqlCommand(
-                            "UNLISTEN " + QuoteIdent(channel) + ";",
-                            connection);
-                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-                catch
-                {
-                    // Best-effort cleanup when the connection is already broken.
-                }
-            }
+            await PostgresProtocol
+                .ListenAsync(
+                    connection,
+                    channel,
+                    observer.OnNext,
+                    observer.OnCompleted,
+                    observer.OnErrorResume,
+                    completeOnCancel: true,
+                    ct)
+                .ConfigureAwait(false);
         });
-    }
 
     /// <summary>
     /// Hot stream: <c>LISTEN</c> on <paramref name="channel"/> and deserialize notification payloads to
@@ -89,79 +33,30 @@ public static class PostgresObservable
     /// </summary>
     [RequiresUnreferencedCode(PostgresTrimAnnotations.JsonPayload)]
     [RequiresDynamicCode(PostgresTrimAnnotations.JsonPayload)]
-    public static Observable<T> FromListen<T>(NpgsqlConnection connection, string channel)
-    {
-        if (connection is null)
+    public static Observable<T> FromListen<T>(NpgsqlConnection connection, string channel) =>
+        Observable.Create<T>(async (observer, ct) =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.Create<T>(async (observer, ct) =>
-        {
-            void Handler(object sender, NpgsqlNotificationEventArgs args)
-            {
-                if (!string.Equals(args.Channel, channel, StringComparison.Ordinal))
-                {
-                    return;
-                }
-
-                try
-                {
-                    observer.OnNext(PostgresPayload.Deserialize<T>(args.Payload));
-                }
-                catch (Exception ex)
-                {
-                    observer.OnErrorResume(ex);
-                }
-            }
-
-            connection.Notification += Handler;
-            try
-            {
-                await using (var listen = new NpgsqlCommand(
-                    "LISTEN " + QuoteIdent(channel) + ";",
-                    connection))
-                {
-                    await listen.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
-                }
-
-                while (!ct.IsCancellationRequested)
-                {
-                    await connection.WaitAsync(ct).ConfigureAwait(false);
-                }
-
-                observer.OnCompleted();
-            }
-            catch (OperationCanceledException)
-            {
-                observer.OnCompleted();
-            }
-            catch (Exception ex)
-            {
-                observer.OnErrorResume(ex);
-            }
-            finally
-            {
-                connection.Notification -= Handler;
-                try
-                {
-                    if (connection.State == ConnectionState.Open)
+            await PostgresProtocol
+                .ListenAsync(
+                    connection,
+                    channel,
+                    payload =>
                     {
-                        await using var unlisten = new NpgsqlCommand(
-                            "UNLISTEN " + QuoteIdent(channel) + ";",
-                            connection);
-                        await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-                catch
-                {
-                    // Best-effort cleanup when the connection is already broken.
-                }
-            }
+                        try
+                        {
+                            observer.OnNext(PostgresPayload.Deserialize<T>(payload));
+                        }
+                        catch (Exception ex)
+                        {
+                            observer.OnErrorResume(ex);
+                        }
+                    },
+                    observer.OnCompleted,
+                    observer.OnErrorResume,
+                    completeOnCancel: true,
+                    ct)
+                .ConfigureAwait(false);
         });
-    }
 
     /// <summary>Cold stream: send <c>NOTIFY</c> with an empty payload when subscribed.</summary>
     public static Observable<Unit> FromNotify(
@@ -175,32 +70,12 @@ public static class PostgresObservable
         NpgsqlConnection connection,
         string channel,
         string? payload,
-        CancellationToken cancellationToken = default)
-    {
-        if (connection is null)
+        CancellationToken cancellationToken = default) =>
+        Observable.FromAsync(async ct =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            await using var command = new NpgsqlCommand(
-                "SELECT pg_notify(@channel, @payload);",
-                connection)
-            {
-                Parameters =
-                {
-                    new("channel", channel),
-                    new("payload", payload ?? string.Empty),
-                },
-            };
-            await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
+            await PostgresProtocol.NotifyAsync(connection, channel, payload, cancellationToken, ct).ConfigureAwait(false);
             return Unit.Default;
         });
-    }
 
     /// <summary>Cold stream: serialize <paramref name="payload"/> and send <c>NOTIFY</c> when subscribed.</summary>
     [RequiresUnreferencedCode(PostgresTrimAnnotations.JsonPayload)]
@@ -209,49 +84,12 @@ public static class PostgresObservable
         NpgsqlConnection connection,
         string channel,
         T payload,
-        CancellationToken cancellationToken = default)
-    {
-        if (connection is null)
+        CancellationToken cancellationToken = default) =>
+        Observable.FromAsync(async ct =>
         {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        ValidateChannelName(channel);
-
-        return Observable.FromAsync(async ct =>
-        {
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ct);
-            var text = PostgresPayload.SerializeToText(payload);
-            await using var command = new NpgsqlCommand(
-                "SELECT pg_notify(@channel, @payload);",
-                connection)
-            {
-                Parameters =
-                {
-                    new("channel", channel),
-                    new("payload", text),
-                },
-            };
-            await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
+            await PostgresProtocol
+                .NotifySerializedAsync(connection, channel, payload, cancellationToken, ct)
+                .ConfigureAwait(false);
             return Unit.Default;
         });
-    }
-
-    static void ValidateChannelName(string channel)
-    {
-        if (string.IsNullOrWhiteSpace(channel))
-        {
-            throw new ArgumentException("PostgreSQL channel name must be non-empty.", nameof(channel));
-        }
-
-        if (channel.Length > 63 || !ChannelNameRegex.IsMatch(channel))
-        {
-            throw new ArgumentException(
-                "PostgreSQL channel name must be at most 63 characters and match [A-Za-z_][A-Za-z0-9_]*.",
-                nameof(channel));
-        }
-    }
-
-    static string QuoteIdent(string channel) =>
-        "\"" + channel.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
 }

--- a/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
@@ -1,0 +1,163 @@
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Npgsql;
+
+namespace Observables.Postgres;
+
+/// <summary>Feature protocol bridge for PostgreSQL LISTEN/NOTIFY.</summary>
+internal static class PostgresProtocol
+{
+    static readonly Regex ChannelNameRegex = new(
+        @"^[A-Za-z_][A-Za-z0-9_]*$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    static readonly TimeSpan ListenWaitSlice = TimeSpan.FromMilliseconds(250);
+
+    internal static void ValidateChannelName(string channel)
+    {
+        if (string.IsNullOrWhiteSpace(channel))
+        {
+            throw new ArgumentException("PostgreSQL channel name must be non-empty.", nameof(channel));
+        }
+
+        if (channel.Length > 63 || !ChannelNameRegex.IsMatch(channel))
+        {
+            throw new ArgumentException(
+                "PostgreSQL channel name must be at most 63 characters and match [A-Za-z_][A-Za-z0-9_]*.",
+                nameof(channel));
+        }
+    }
+
+    internal static string QuoteIdent(string channel) =>
+        "\"" + channel.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+
+    internal static async Task ListenAsync(
+        NpgsqlConnection connection,
+        string channel,
+        Action<string> onPayload,
+        Action onCompleted,
+        Action<Exception> onError,
+        bool completeOnCancel,
+        CancellationToken cancellationToken)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        ValidateChannelName(channel);
+
+        void Handler(object sender, NpgsqlNotificationEventArgs args)
+        {
+            if (string.Equals(args.Channel, channel, StringComparison.Ordinal))
+            {
+                onPayload(args.Payload ?? string.Empty);
+            }
+        }
+
+        connection.Notification += Handler;
+        Exception? error = null;
+        try
+        {
+            await using (var listen = new NpgsqlCommand(
+                "LISTEN " + QuoteIdent(channel) + ";",
+                connection))
+            {
+                await listen.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await connection.WaitAsync(ListenWaitSlice, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            error = ex;
+        }
+        finally
+        {
+            connection.Notification -= Handler;
+            await UnlistenBestEffortAsync(connection, channel).ConfigureAwait(false);
+        }
+
+        if (error is not null)
+        {
+            onError(error);
+        }
+        else if (completeOnCancel || !cancellationToken.IsCancellationRequested)
+        {
+            onCompleted();
+        }
+    }
+
+    internal static async Task NotifyAsync(
+        NpgsqlConnection connection,
+        string channel,
+        string? payload,
+        CancellationToken userToken,
+        CancellationToken pumpToken)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        ValidateChannelName(channel);
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(userToken, pumpToken);
+        await using var command = new NpgsqlCommand(
+            "SELECT pg_notify(@channel, @payload);",
+            connection)
+        {
+            Parameters =
+            {
+                new("channel", channel),
+                new("payload", payload ?? string.Empty),
+            },
+        };
+        await command.ExecuteNonQueryAsync(linked.Token).ConfigureAwait(false);
+    }
+
+    [RequiresUnreferencedCode(PostgresTrimAnnotations.JsonPayload)]
+    [RequiresDynamicCode(PostgresTrimAnnotations.JsonPayload)]
+    internal static Task NotifySerializedAsync<T>(
+        NpgsqlConnection connection,
+        string channel,
+        T payload,
+        CancellationToken userToken,
+        CancellationToken pumpToken) =>
+        NotifyAsync(connection, channel, PostgresPayload.SerializeToText(payload), userToken, pumpToken);
+
+    static async Task UnlistenBestEffortAsync(NpgsqlConnection connection, string channel)
+    {
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            try
+            {
+                if ((connection.State & ConnectionState.Open) == 0)
+                {
+                    return;
+                }
+
+                await using var unlisten = new NpgsqlCommand(
+                    "UNLISTEN " + QuoteIdent(channel) + ";",
+                    connection);
+                await unlisten.ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
+                return;
+            }
+            catch (NpgsqlOperationInProgressException)
+            {
+                await Task.Delay(25, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                return;
+            }
+        }
+    }
+}

--- a/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
@@ -4,8 +4,6 @@ using System.Text.RegularExpressions;
 using Npgsql;
 
 namespace Observables.Postgres;
-
-/// <summary>Feature protocol bridge for PostgreSQL LISTEN/NOTIFY.</summary>
 internal static class PostgresProtocol
 {
     static readonly Regex ChannelNameRegex = new(

--- a/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
+++ b/Observables.Postgres/Observables.Postgres/PostgresProtocol.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Npgsql;
 
 namespace Observables.Postgres;
+
 internal static class PostgresProtocol
 {
     static readonly Regex ChannelNameRegex = new(


### PR DESCRIPTION
## Summary

Internal `PostgresProtocol` owns channel validation, LISTEN/Wait/UNLISTEN, and NOTIFY. R3 still completes on cancel; Reactive does not.

## Related Issue

Closes #257

## Solution module

- [x] Postgres (Observables.Postgres)

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] R3 generator 10, Reactive generator 5 (net8)
- [ ] E2E needs portable Postgres (`initdb` missing on this machine)

## Breaking changes

- [x] None

## Checklist

- [x] This PR touches **only one** solution module
- [x] Commit messages are in **English**
- [x] No version bumps
- [x] No documentation changes needed
